### PR TITLE
Refactor: remove the consumer argument from `createEmbedSpec`

### DIFF
--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -23,7 +23,6 @@ export const createNoopEmbed = <
   createEmbedSpec(
     name,
     fieldSpec,
-    () => () => null,
     () => null,
     () => null,
     {}

--- a/src/__tests__/mount.spec.ts
+++ b/src/__tests__/mount.spec.ts
@@ -13,8 +13,7 @@ describe("mount", () => {
       createEmbedSpec(
         "testEmbed",
         fieldSpec,
-        () => () => null,
-        (_, __, ___, fieldNodeViews) => {
+        (_, __, fieldNodeViews) => {
           // Prop1 is derived from the fieldSpec
           fieldNodeViews.prop1;
         },
@@ -32,8 +31,7 @@ describe("mount", () => {
       createEmbedSpec(
         "testEmbed",
         fieldSpec,
-        () => () => null,
-        (_, __, ___, fieldNodeViews) => {
+        (_, __, fieldNodeViews) => {
           // @ts-expect-error – prop1 is not available on this object,
           // as it is not defined in `fieldSpec` passed into `mount`
           fieldNodeViews.prop1;
@@ -44,8 +42,8 @@ describe("mount", () => {
     });
   });
 
-  describe("field typesafety", () => {
-    it("should provide typesafe fields to its consumer", () => {
+  describe("validator typesafety", () => {
+    it("should provide typesafe fields to its validator", () => {
       const fieldSpec = {
         prop1: {
           type: "richText",
@@ -58,14 +56,14 @@ describe("mount", () => {
       createEmbedSpec(
         "testEmbed",
         fieldSpec,
-        () => () => null,
+        () => () => undefined,
         (fields) => {
           // Prop1 is derived from the fieldSpec, and is a string b/c it's a richText field
           fields.prop1.toString();
           // Prop2 is a boolean b/c it's a checkbox field
           fields.prop2.value.valueOf();
+          return null;
         },
-        () => null,
         { prop1: "text" }
       );
     });
@@ -79,13 +77,13 @@ describe("mount", () => {
       createEmbedSpec(
         "testEmbed",
         fieldSpec,
-        () => () => null,
+        () => () => undefined,
         (fields) => {
           // @ts-expect-error – prop1 is not available on this object,
           // as it is not defined in `fieldSpec` passed into `mount`
           fields.doesNotExist;
+          return null;
         },
-        () => null,
         { notProp1: "text" }
       );
     });

--- a/src/embedSpec.ts
+++ b/src/embedSpec.ts
@@ -1,7 +1,6 @@
 import { getNodeSpecFromFieldSpec } from "./nodeSpec";
 import type { FieldNameToValueMap } from "./nodeViews/helpers";
 import type { TCommandCreator, TCommands } from "./types/Commands";
-import type { TConsumer } from "./types/Consumer";
 import type {
   EmbedSpec,
   FieldNameToNodeViewSpec,
@@ -32,8 +31,7 @@ export type Validator<FSpec extends FieldSpec<string>> = (
   fields: FieldNameToValueMap<FSpec>
 ) => null | Record<string, string[]>;
 
-export type TRenderer<RendererOutput, FSpec extends FieldSpec<string>> = (
-  consumer: TConsumer<RendererOutput, FSpec>,
+export type Renderer<FSpec extends FieldSpec<string>> = (
   validate: Validator<FSpec>,
   // The HTMLElement representing the node parent. The renderer can mount onto this node.
   dom: HTMLElement,
@@ -52,14 +50,12 @@ export type TRenderer<RendererOutput, FSpec extends FieldSpec<string>> = (
 ) => void;
 
 export const createEmbedSpec = <
-  RenderOutput,
   FSpec extends FieldSpec<string>,
   EmbedName extends string
 >(
   name: EmbedName,
   fieldSpec: FSpec,
-  render: TRenderer<RenderOutput, FSpec>,
-  consumer: TConsumer<RenderOutput, FSpec>,
+  render: Renderer<FSpec>,
   validate: Validator<FSpec>,
   defaultState: Partial<FieldNameToValueMap<FSpec>>
 ): EmbedSpec<FSpec, EmbedName> => ({
@@ -69,7 +65,6 @@ export const createEmbedSpec = <
   createUpdator: (dom, fields, updateState, fieldValues, commands) => {
     const updater = createUpdater<FSpec>();
     render(
-      consumer,
       validate,
       dom,
       fields,

--- a/src/renderers/react/EmbedProvider.tsx
+++ b/src/renderers/react/EmbedProvider.tsx
@@ -3,7 +3,7 @@ import React, { Component } from "react";
 import type { Validator } from "../../embedSpec";
 import type { FieldNameToValueMap } from "../../nodeViews/helpers";
 import type { TCommands } from "../../types/Commands";
-import type { TConsumer } from "../../types/Consumer";
+import type { Consumer } from "../../types/Consumer";
 import type { FieldNameToNodeViewSpec, FieldSpec } from "../../types/Embed";
 import type { TErrors } from "../../types/Errors";
 import { EmbedWrapper } from "./EmbedWrapper";
@@ -28,7 +28,7 @@ type IProps<FSpec extends FieldSpec<string>> = {
   fieldValues: FieldNameToValueMap<FSpec>;
   onStateChange: (fields: FieldNameToValueMap<FSpec>) => void;
   validate: Validator<FSpec>;
-  consumer: TConsumer<ReactElement, FSpec>;
+  consumer: Consumer<ReactElement, FSpec>;
   fields: FieldNameToNodeViewSpec<FSpec>;
 };
 

--- a/src/renderers/react/createReactEmbedSpec.tsx
+++ b/src/renderers/react/createReactEmbedSpec.tsx
@@ -2,9 +2,9 @@ import type { ReactElement } from "react";
 import React from "react";
 import { render } from "react-dom";
 import { createEmbedSpec } from "../../embedSpec";
-import type { TRenderer, Validator } from "../../embedSpec";
+import type { Renderer, Validator } from "../../embedSpec";
 import type { FieldNameToValueMap } from "../../nodeViews/helpers";
-import type { TConsumer } from "../../types/Consumer";
+import type { Consumer } from "../../types/Consumer";
 import type { FieldSpec } from "../../types/Embed";
 import { EmbedProvider } from "./EmbedProvider";
 
@@ -14,12 +14,11 @@ export const createReactEmbedSpec = <
 >(
   name: Name,
   fieldSpec: FSpec,
-  consumer: TConsumer<ReactElement, FSpec>,
+  consumer: Consumer<ReactElement, FSpec>,
   validate: Validator<FSpec>,
   defaultState: FieldNameToValueMap<FSpec>
 ) => {
-  const renderer: TRenderer<ReactElement, FSpec> = (
-    consumer,
+  const renderer: Renderer<FSpec> = (
     validate,
     dom,
     fields,
@@ -41,12 +40,5 @@ export const createReactEmbedSpec = <
       dom
     );
 
-  return createEmbedSpec(
-    name,
-    fieldSpec,
-    renderer,
-    consumer,
-    validate,
-    defaultState
-  );
+  return createEmbedSpec(name, fieldSpec, renderer, validate, defaultState);
 };

--- a/src/types/Consumer.ts
+++ b/src/types/Consumer.ts
@@ -2,7 +2,7 @@ import type { FieldNameToValueMap } from "../nodeViews/helpers";
 import type { FieldNameToNodeViewSpec, FieldSpec } from "./Embed";
 import type { TErrors } from "./Errors";
 
-export type TConsumer<ConsumerResult, FSpec extends FieldSpec<string>> = (
+export type Consumer<ConsumerResult, FSpec extends FieldSpec<string>> = (
   fieldValues: FieldNameToValueMap<FSpec>,
   errors: TErrors,
   updateFields: (fieldValues: FieldNameToValueMap<FSpec>) => void,


### PR DESCRIPTION
## What does this change?

Removes the consumer function that's passed through `createEmbedSpec`. It's not used by `createEmbedSpec`, and is necessarily already in scope in the consumer context – so we don't need it as an argument. This simplifies the signature of `createEmbedSpec`.

# How to test

This is a no-op – test should pass as before.
