### PR TITLE
Fix incorrect fields in AttributeFieldView passed on update

### DIFF
--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -120,6 +120,21 @@ describe("ImageElement", () => {
         getElementField("useSrc").find("input").click();
         assertDocHtml(getSerialisedHtml({ useSrcValue: "false" }));
       });
+
+      it(`should track the field offset, and update correctly after fields above have changed`, () => {
+        addElement();
+
+        getElementField("useSrc").find("input").click();
+        typeIntoElementField("altText", "Example text");
+        getElementField("useSrc").find("input").click();
+
+        assertDocHtml(
+          getSerialisedHtml({
+            altTextValue: "<p>Example text</p>",
+            useSrcValue: "false",
+          })
+        );
+      });
     });
 
     describe("Custom element – image src", () => {

--- a/src/fieldViews/AttributeFieldView.ts
+++ b/src/fieldViews/AttributeFieldView.ts
@@ -1,4 +1,4 @@
-import type { Node } from "prosemirror-model";
+import type { Node, NodeType } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
 import type { FieldView } from "./FieldView";
 import { FieldType } from "./FieldView";
@@ -13,10 +13,11 @@ export abstract class AttributeFieldView<Fields extends unknown>
   // The parent DOM element for this view. Public
   // so it can be mounted by consuming elements.
   public fieldViewElement = document.createElement("div");
+  private nodeType: NodeType;
 
   constructor(
     // The node that this FieldView is responsible for rendering.
-    private node: Node,
+    node: Node,
     // The outer editor instance. Updated from within this class when the inner state changes.
     private outerView: EditorView,
     // Returns the current position of the parent FieldView in the document.
@@ -25,6 +26,7 @@ export abstract class AttributeFieldView<Fields extends unknown>
     private offset: number,
     defaultFields: Fields
   ) {
+    this.nodeType = node.type;
     this.createInnerView(node.attrs.fields || defaultFields);
   }
 
@@ -33,7 +35,7 @@ export abstract class AttributeFieldView<Fields extends unknown>
   }
 
   public getNodeFromValue(fields: Fields): Node {
-    return this.node.type.create({ fields });
+    return this.nodeType.create({ fields });
   }
 
   protected abstract createInnerView(fields: Fields): void;
@@ -41,7 +43,7 @@ export abstract class AttributeFieldView<Fields extends unknown>
   protected abstract updateInnerView(fields: Fields): void;
 
   public update(node: Node, elementOffset: number) {
-    if (node.type !== this.node.type) {
+    if (node.type !== this.nodeType) {
       return false;
     }
 

--- a/src/fieldViews/AttributeFieldView.ts
+++ b/src/fieldViews/AttributeFieldView.ts
@@ -41,13 +41,12 @@ export abstract class AttributeFieldView<Fields extends unknown>
   protected abstract updateInnerView(fields: Fields): void;
 
   public update(node: Node, elementOffset: number) {
-    if (!node.sameMarkup(this.node)) {
+    if (node.attrs.type !== this.node.attrs.type) {
       return false;
     }
 
     this.offset = elementOffset;
-
-    this.updateInnerView(node.attrs as Fields);
+    this.updateInnerView(node.attrs.fields as Fields);
 
     return true;
   }

--- a/src/fieldViews/AttributeFieldView.ts
+++ b/src/fieldViews/AttributeFieldView.ts
@@ -41,7 +41,7 @@ export abstract class AttributeFieldView<Fields extends unknown>
   protected abstract updateInnerView(fields: Fields): void;
 
   public update(node: Node, elementOffset: number) {
-    if (node.attrs.type !== this.node.attrs.type) {
+    if (node.type !== this.node.type) {
       return false;
     }
 

--- a/src/fieldViews/__tests__/AttributeFieldView.spec.ts
+++ b/src/fieldViews/__tests__/AttributeFieldView.spec.ts
@@ -1,0 +1,77 @@
+import type { Node } from "prosemirror-model";
+import { Schema } from "prosemirror-model";
+import { schema } from "prosemirror-schema-basic";
+import { createEditorWithElements } from "../../__tests__/helpers";
+import { getNodeSpecForProp } from "../../nodeSpec";
+import { AttributeFieldView } from "../AttributeFieldView";
+
+const createInnerView = jest.fn();
+const updateInnerView = jest.fn();
+
+type TestAttributeFields = { value: boolean };
+
+class TestAttributeFieldView extends AttributeFieldView<TestAttributeFields> {
+  public static propName = "checkbox" as const;
+  public static defaultValue = "default";
+
+  public getNodeValue(node: Node): TestAttributeFields {
+    return node.attrs.fields as TestAttributeFields;
+  }
+
+  protected createInnerView(fields: TestAttributeFields) {
+    createInnerView(fields);
+  }
+
+  protected updateInnerView(fields: TestAttributeFields) {
+    updateInnerView(fields);
+  }
+}
+
+const testSchema = new Schema({
+  nodes: {
+    doc: schema.nodes.doc,
+    text: schema.nodes.text,
+    ...getNodeSpecForProp("doc", "testField", {
+      type: "checkbox",
+      defaultValue: { value: false },
+    }),
+  },
+});
+
+describe("AttributeFieldView", () => {
+  beforeEach(() => {
+    createInnerView.mockReset();
+    updateInnerView.mockReset();
+  });
+
+  it("will pass the correct value to its inheritors on createInnerView", () => {
+    const { view } = createEditorWithElements([]);
+    const node = testSchema.nodes.testField.create({
+      type: "checkbox",
+      fields: { value: true },
+    });
+    new TestAttributeFieldView(node, view, () => 0, 0, { value: false });
+
+    expect(createInnerView.mock.calls[0]).toEqual([{ value: true }]);
+  });
+
+  it("will pass the correct value to its inheritors on updateInnerView", () => {
+    const { view } = createEditorWithElements([]);
+    const node = testSchema.nodes.testField.create({
+      type: "checkbox",
+      fields: { value: false },
+    });
+
+    const fieldView = new TestAttributeFieldView(node, view, () => 0, 0, {
+      value: false,
+    });
+
+    const newNode = testSchema.nodes.testField.create({
+      fields: { value: true },
+    });
+
+    fieldView.update(newNode, 0);
+
+    expect(updateInnerView.mock.calls[0]).toEqual([{ value: true }]);
+  });
+});

--- a/src/fieldViews/__tests__/AttributeFieldView.spec.ts
+++ b/src/fieldViews/__tests__/AttributeFieldView.spec.ts
@@ -5,8 +5,8 @@ import { createEditorWithElements } from "../../__tests__/helpers";
 import { getNodeSpecForProp } from "../../nodeSpec";
 import { AttributeFieldView } from "../AttributeFieldView";
 
-const createInnerView = jest.fn();
-const updateInnerView = jest.fn();
+const createInnerViewSpy = jest.fn();
+const updateInnerViewSpy = jest.fn();
 
 type TestAttributeFields = { value: boolean };
 
@@ -19,11 +19,11 @@ class TestAttributeFieldView extends AttributeFieldView<TestAttributeFields> {
   }
 
   protected createInnerView(fields: TestAttributeFields) {
-    createInnerView(fields);
+    createInnerViewSpy(fields);
   }
 
   protected updateInnerView(fields: TestAttributeFields) {
-    updateInnerView(fields);
+    updateInnerViewSpy(fields);
   }
 }
 
@@ -40,8 +40,8 @@ const testSchema = new Schema({
 
 describe("AttributeFieldView", () => {
   beforeEach(() => {
-    createInnerView.mockReset();
-    updateInnerView.mockReset();
+    createInnerViewSpy.mockReset();
+    updateInnerViewSpy.mockReset();
   });
 
   it("should pass the correct value to its inheritors on createInnerView", () => {
@@ -52,7 +52,7 @@ describe("AttributeFieldView", () => {
     });
     new TestAttributeFieldView(node, view, () => 0, 0, { value: false });
 
-    expect(createInnerView.mock.calls[0]).toEqual([{ value: true }]);
+    expect(createInnerViewSpy.mock.calls[0]).toEqual([{ value: true }]);
   });
 
   it("should pass the correct value to its inheritors on updateInnerView", () => {
@@ -72,6 +72,6 @@ describe("AttributeFieldView", () => {
 
     fieldView.update(newNode, 0);
 
-    expect(updateInnerView.mock.calls[0]).toEqual([{ value: true }]);
+    expect(updateInnerViewSpy.mock.calls[0]).toEqual([{ value: true }]);
   });
 });

--- a/src/fieldViews/__tests__/AttributeFieldView.spec.ts
+++ b/src/fieldViews/__tests__/AttributeFieldView.spec.ts
@@ -1,4 +1,4 @@
-import type { Node } from "prosemirror-model";
+import type { Node, NodeSpec } from "prosemirror-model";
 import { Schema } from "prosemirror-model";
 import { schema } from "prosemirror-schema-basic";
 import { createEditorWithElements } from "../../__tests__/helpers";
@@ -31,10 +31,10 @@ const testSchema = new Schema({
   nodes: {
     doc: schema.nodes.doc,
     text: schema.nodes.text,
-    ...getNodeSpecForProp("doc", "testField", {
+    ...(getNodeSpecForProp("doc", "testField", {
       type: "checkbox",
       defaultValue: { value: false },
-    }),
+    }) as { testField: NodeSpec }),
   },
 });
 
@@ -44,7 +44,7 @@ describe("AttributeFieldView", () => {
     updateInnerView.mockReset();
   });
 
-  it("will pass the correct value to its inheritors on createInnerView", () => {
+  it("should pass the correct value to its inheritors on createInnerView", () => {
     const { view } = createEditorWithElements([]);
     const node = testSchema.nodes.testField.create({
       type: "checkbox",
@@ -55,7 +55,7 @@ describe("AttributeFieldView", () => {
     expect(createInnerView.mock.calls[0]).toEqual([{ value: true }]);
   });
 
-  it("will pass the correct value to its inheritors on updateInnerView", () => {
+  it("should pass the correct value to its inheritors on updateInnerView", () => {
     const { view } = createEditorWithElements([]);
     const node = testSchema.nodes.testField.create({
       type: "checkbox",

--- a/src/nodeSpec.ts
+++ b/src/nodeSpec.ts
@@ -61,7 +61,7 @@ const getNodeSpecForElement = (
   },
 });
 
-const getNodeSpecForProp = (
+export const getNodeSpecForProp = (
   elementName: string,
   propName: string,
   prop: Field


### PR DESCRIPTION
## What does this change?

Fixes a problem with incorrect fields being passed to inheritors of `AttributeFieldView` – a straightforward problem papered over by the loose typing of the attributes in Prosemirror's `Node` type.

This also uncovered another problem, where `sameMarkup` was inappropriately being used to figure out whether we should accept updates. This isn't right – this check includes a [deep comparison of attributes](https://github.com/ProseMirror/prosemirror-model/blob/eef20c8c6dbf841b1d70859df5d59c21b5108a4f/src/node.js#L131), which aren't relevant for an identity check in this case, and will always produce an incorrect result once field attributes are updated.

## How to test

The automated tests (unit and integration) should pass, and cover the cases discussed above.
