### PR TITLE
Pass parent schema directly to children

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
       rules: {
         "@typescript-eslint/unbound-method": 0,
         "@typescript-eslint/explicit-module-boundary-types": 0,
+        "@typescript-eslint/no-unused-vars": 2
       },
     },
   ],

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -33,6 +33,15 @@ describe("ImageElement", () => {
           getElementRichTextField(field).should("have.text", text);
         });
 
+        it(`${field} – should create hard breaks on shift-enter`, () => {
+          addElement();
+          const text = `${field}{shift+enter}text`;
+          typeIntoElementField(field, text);
+          getElementRichTextField(field).should(($div) =>
+            expect($div.html()).to.equal(`<p>${field}<br>text</p>`)
+          );
+        });
+
         it(`${field} – should render decorations passed from the parent editor`, () => {
           addElement();
           const text = `${field} deco `;

--- a/src/fieldViews/ProseMirrorFieldView.ts
+++ b/src/fieldViews/ProseMirrorFieldView.ts
@@ -69,7 +69,7 @@ export abstract class ProseMirrorFieldView implements FieldView<string> {
     elementOffset: number,
     decorations: DecorationSet | Decoration[]
   ) {
-    if (node.type.name !== this.node.type.name) {
+    if (!node.hasMarkup(this.node.type)) {
       return false;
     }
 

--- a/src/fieldViews/ProseMirrorFieldView.ts
+++ b/src/fieldViews/ProseMirrorFieldView.ts
@@ -52,7 +52,7 @@ export abstract class ProseMirrorFieldView<LocalSchema extends Schema = Schema>
     this.applyDecorationsFromOuterEditor(decorations);
     this.serialiser = DOMSerializer.fromSchema(schema);
     this.parser = DOMParser.fromSchema(schema);
-    this.node = this.getInnerNodeFromOuter(node);
+    this.node = this.getInnerNodeFromOuter(schema, node);
     this.innerEditorView = this.createInnerEditorView(schema, plugins);
   }
 
@@ -114,7 +114,7 @@ export abstract class ProseMirrorFieldView<LocalSchema extends Schema = Schema>
   ) {
     this.applyDecorationsFromOuterEditor(decorations);
     this.offset = elementOffset;
-    this.node = this.getInnerNodeFromOuter(outerNode);
+    this.node = this.getInnerNodeFromOuter(this.node.type.schema, outerNode);
 
     if (!this.innerEditorView) {
       return;
@@ -257,10 +257,8 @@ export abstract class ProseMirrorFieldView<LocalSchema extends Schema = Schema>
    * Transform an incoming node from the outer editor into
    * a node that matches the schema of the inner editor.
    */
-  private getInnerNodeFromOuter(outerNode: Node) {
-    return this.parser.parse(
-      this.serialiser.serializeFragment(outerNode.content)
-    );
+  private getInnerNodeFromOuter(innerSchema: Schema, outerNode: Node) {
+    return innerSchema.nodeFromJSON(outerNode.toJSON());
   }
 
   /**

--- a/src/fieldViews/ProseMirrorFieldView.ts
+++ b/src/fieldViews/ProseMirrorFieldView.ts
@@ -1,14 +1,8 @@
 import type { Node, Schema } from "prosemirror-model";
-import { DOMParser, DOMSerializer, Slice } from "prosemirror-model";
+import { DOMParser, DOMSerializer } from "prosemirror-model";
 import type { Plugin, Transaction } from "prosemirror-state";
 import { EditorState } from "prosemirror-state";
-import { Step } from "prosemirror-transform";
-import {
-  Mapping,
-  ReplaceAroundStep,
-  ReplaceStep,
-  StepMap,
-} from "prosemirror-transform";
+import { Mapping, Step, StepMap } from "prosemirror-transform";
 import type { Decoration } from "prosemirror-view";
 import { DecorationSet, EditorView } from "prosemirror-view";
 import type { FieldView } from "./FieldView";
@@ -36,10 +30,6 @@ export abstract class ProseMirrorFieldView<LocalSchema extends Schema = Schema>
   private serialiser: DOMSerializer;
   // The parser for the Node.
   private parser: DOMParser;
-  // The serialiser for the outer editor.
-  private outerSerialiser: DOMSerializer;
-  // The parser for the outer editor.
-  private outerParser: DOMParser;
 
   constructor(
     // The node that this FieldView is responsible for rendering.
@@ -51,7 +41,7 @@ export abstract class ProseMirrorFieldView<LocalSchema extends Schema = Schema>
     // The offset of this node relative to its parent FieldView.
     private offset: number,
     // The schema that the internal editor should use.
-    private schema: LocalSchema,
+    schema: LocalSchema,
     // The initial decorations for the FieldView.
     decorations: DecorationSet | Decoration[],
     // The ProseMirror node type name
@@ -62,10 +52,6 @@ export abstract class ProseMirrorFieldView<LocalSchema extends Schema = Schema>
     this.applyDecorationsFromOuterEditor(decorations);
     this.serialiser = DOMSerializer.fromSchema(schema);
     this.parser = DOMParser.fromSchema(schema);
-    this.outerSerialiser = DOMSerializer.fromSchema(
-      this.outerView.state.schema
-    );
-    this.outerParser = DOMParser.fromSchema(this.outerView.state.schema);
     this.node = this.getInnerNodeFromOuter(node);
     this.innerEditorView = this.createInnerEditorView(schema, plugins);
   }
@@ -282,6 +268,6 @@ export abstract class ProseMirrorFieldView<LocalSchema extends Schema = Schema>
    * a node that matches the schema of the inner editor.
    */
   private applyOuterSliceToInnerStep(step: Step): Step {
-    return Step.fromJSON(this.outerView.state.schema, step.toJSON())
+    return Step.fromJSON(this.outerView.state.schema, step.toJSON());
   }
 }

--- a/src/fieldViews/ProseMirrorFieldView.ts
+++ b/src/fieldViews/ProseMirrorFieldView.ts
@@ -2,7 +2,7 @@ import type { Node, Schema } from "prosemirror-model";
 import { DOMParser, DOMSerializer, Slice } from "prosemirror-model";
 import type { Plugin, Transaction } from "prosemirror-state";
 import { EditorState } from "prosemirror-state";
-import type { Step } from "prosemirror-transform";
+import { Step } from "prosemirror-transform";
 import {
   Mapping,
   ReplaceAroundStep,
@@ -211,8 +211,7 @@ export abstract class ProseMirrorFieldView<LocalSchema extends Schema = Schema>
       for (let j = 0; j < steps.length; j++) {
         const mappedStep = steps[j].map(offsetMap);
         if (mappedStep) {
-          this.applyOuterSliceToInnerStep(mappedStep);
-          outerTr.step(mappedStep);
+          outerTr.step(this.applyOuterSliceToInnerStep(mappedStep));
         }
       }
     }
@@ -282,13 +281,7 @@ export abstract class ProseMirrorFieldView<LocalSchema extends Schema = Schema>
    * Transform an incoming node from the outer editor into
    * a node that matches the schema of the inner editor.
    */
-  private applyOuterSliceToInnerStep(step: Step) {
-    if (step instanceof ReplaceStep || step instanceof ReplaceAroundStep) {
-      const slice = (step as any).slice as Slice;
-      const content = this.outerParser.parseSlice(
-        this.outerSerialiser.serializeFragment(slice.content)
-      ).content;
-      (step as any).slice = new Slice(content, slice.openStart, slice.openEnd);
-    }
+  private applyOuterSliceToInnerStep(step: Step): Step {
+    return Step.fromJSON(this.outerView.state.schema, step.toJSON())
   }
 }

--- a/src/fieldViews/RichTextFieldView.ts
+++ b/src/fieldViews/RichTextFieldView.ts
@@ -1,29 +1,15 @@
-import type OrderedMap from "orderedmap";
 import { exampleSetup } from "prosemirror-example-setup";
 import { redo, undo } from "prosemirror-history";
 import { keymap } from "prosemirror-keymap";
-import { Schema } from "prosemirror-model";
-import type { Node, NodeSpec } from "prosemirror-model";
+import type { Node, Schema } from "prosemirror-model";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
-import { getNodeSpecForProp } from "../nodeSpec";
-import type { Field } from "../types/Element";
+import { addRootNodeToSchema } from "./helpers";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
-
-const addRootNodeToSchema = (schema: Schema, propName: string, field: Field) =>
-  new Schema({
-    nodes: (schema.spec.nodes as OrderedMap<NodeSpec>)
-      .append(getNodeSpecForProp("noop", propName, field))
-      .remove("doc"),
-    marks: schema.spec.marks,
-    topNode: propName,
-  });
 
 export class RichTextFieldView extends ProseMirrorFieldView {
   public static propName = "richText" as const;
 
   constructor(
-    // The field this FieldView represents.
-    field: Field,
     // The node that this FieldView is responsible for rendering.
     node: Node,
     // The outer editor instance. Updated from within this class when the inner state changes.
@@ -37,7 +23,7 @@ export class RichTextFieldView extends ProseMirrorFieldView {
     // The initial decorations for the FieldView.
     decorations: DecorationSet | Decoration[]
   ) {
-    const localSchema = addRootNodeToSchema(schema, node.type.name, field);
+    const localSchema = addRootNodeToSchema(schema, node.type.name);
     super(
       node,
       outerView,

--- a/src/fieldViews/RichTextFieldView.ts
+++ b/src/fieldViews/RichTextFieldView.ts
@@ -3,7 +3,6 @@ import { redo, undo } from "prosemirror-history";
 import { keymap } from "prosemirror-keymap";
 import type { Node, Schema } from "prosemirror-model";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
-import { addRootNodeToSchema } from "./helpers";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
 
 export class RichTextFieldView extends ProseMirrorFieldView {
@@ -18,18 +17,14 @@ export class RichTextFieldView extends ProseMirrorFieldView {
     getPos: () => number,
     // The offset of this node relative to its parent FieldView.
     offset: number,
-    // The schema that the internal editor should use.
-    schema: Schema,
     // The initial decorations for the FieldView.
     decorations: DecorationSet | Decoration[]
   ) {
-    const localSchema = addRootNodeToSchema(schema, node.type.name);
     super(
       node,
       outerView,
       getPos,
       offset,
-      localSchema,
       decorations,
       RichTextFieldView.propName,
       [
@@ -37,7 +32,7 @@ export class RichTextFieldView extends ProseMirrorFieldView {
           "Mod-z": () => undo(outerView.state, outerView.dispatch),
           "Mod-y": () => redo(outerView.state, outerView.dispatch),
         }),
-        ...exampleSetup({ schema: localSchema }),
+        ...exampleSetup({ schema: node.type.schema as Schema }),
       ]
     );
   }

--- a/src/fieldViews/TextFieldView.ts
+++ b/src/fieldViews/TextFieldView.ts
@@ -1,7 +1,6 @@
 import { redo, undo } from "prosemirror-history";
 import { keymap } from "prosemirror-keymap";
-import type { Node } from "prosemirror-model";
-import { Schema } from "prosemirror-model";
+import type { Node, Schema } from "prosemirror-model";
 import { nodes } from "prosemirror-schema-basic";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
@@ -18,25 +17,16 @@ export class TextFieldView extends ProseMirrorFieldView {
     getPos: () => number,
     // The offset of this node relative to its parent FieldView.
     offset: number,
+    schema: Schema,
     // The initial decorations for the FieldView.
     decorations: DecorationSet | Decoration[]
   ) {
-    const textSchema = new Schema({
-      nodes: {
-        doc: {
-          content: "text*",
-          marks: "",
-          toDOM: () => ["div", 0],
-        },
-        text: nodes.text,
-      },
-    });
     super(
       node,
       outerView,
       getPos,
       offset,
-      textSchema,
+      schema,
       decorations,
       TextFieldView.propName,
       [

--- a/src/fieldViews/TextFieldView.ts
+++ b/src/fieldViews/TextFieldView.ts
@@ -1,7 +1,6 @@
 import { redo, undo } from "prosemirror-history";
 import { keymap } from "prosemirror-keymap";
-import type { Node, Schema } from "prosemirror-model";
-import { nodes } from "prosemirror-schema-basic";
+import type { Node } from "prosemirror-model";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
 

--- a/src/fieldViews/TextFieldView.ts
+++ b/src/fieldViews/TextFieldView.ts
@@ -17,7 +17,6 @@ export class TextFieldView extends ProseMirrorFieldView {
     getPos: () => number,
     // The offset of this node relative to its parent FieldView.
     offset: number,
-    schema: Schema,
     // The initial decorations for the FieldView.
     decorations: DecorationSet | Decoration[]
   ) {
@@ -26,7 +25,6 @@ export class TextFieldView extends ProseMirrorFieldView {
       outerView,
       getPos,
       offset,
-      schema,
       decorations,
       TextFieldView.propName,
       [

--- a/src/fieldViews/helpers.ts
+++ b/src/fieldViews/helpers.ts
@@ -1,8 +1,4 @@
-import type OrderedMap from "orderedmap";
-import type { NodeSpec } from "prosemirror-model";
-import { Schema } from "prosemirror-model";
-import { getNodeSpecForProp } from "../nodeSpec";
-import type { CustomField, Field, FieldSpec } from "../types/Element";
+import type { CustomField, FieldSpec } from "../types/Element";
 import { CheckboxFieldView } from "./CheckboxFieldView";
 import type { CheckboxFields } from "./CheckboxFieldView";
 import { CustomFieldView } from "./CustomFieldView";

--- a/src/fieldViews/helpers.ts
+++ b/src/fieldViews/helpers.ts
@@ -1,4 +1,8 @@
-import type { CustomField, FieldSpec } from "../types/Element";
+import type OrderedMap from "orderedmap";
+import type { NodeSpec } from "prosemirror-model";
+import { Schema } from "prosemirror-model";
+import { getNodeSpecForProp } from "../nodeSpec";
+import type { CustomField, Field, FieldSpec } from "../types/Element";
 import { CheckboxFieldView } from "./CheckboxFieldView";
 import type { CheckboxFields } from "./CheckboxFieldView";
 import { CustomFieldView } from "./CustomFieldView";
@@ -54,3 +58,10 @@ export type FieldTypeToValueMap<
 export type FieldNameToValueMap<FSpec extends FieldSpec<string>> = {
   [Name in keyof FSpec]: FieldTypeToValueMap<FSpec, Name>[FSpec[Name]["type"]];
 };
+
+export const addRootNodeToSchema = (schema: Schema, propName: string) =>
+  new Schema({
+    nodes: schema.spec.nodes,
+    marks: schema.spec.marks,
+    topNode: propName,
+  });

--- a/src/fieldViews/helpers.ts
+++ b/src/fieldViews/helpers.ts
@@ -58,10 +58,3 @@ export type FieldTypeToValueMap<
 export type FieldNameToValueMap<FSpec extends FieldSpec<string>> = {
   [Name in keyof FSpec]: FieldTypeToValueMap<FSpec, Name>[FSpec[Name]["type"]];
 };
-
-export const addRootNodeToSchema = (schema: Schema, propName: string) =>
-  new Schema({
-    nodes: schema.spec.nodes,
-    marks: schema.spec.marks,
-    topNode: propName,
-  });

--- a/src/fieldViews/helpers.ts
+++ b/src/fieldViews/helpers.ts
@@ -1,7 +1,3 @@
-import type { Node, Schema } from "prosemirror-model";
-import { DOMParser, DOMSerializer, Slice } from "prosemirror-model";
-import type { Step } from "prosemirror-transform";
-import { ReplaceAroundStep, ReplaceStep } from "prosemirror-transform";
 import type { CustomField, FieldSpec } from "../types/Element";
 import { CheckboxFieldView } from "./CheckboxFieldView";
 import type { CheckboxFields } from "./CheckboxFieldView";

--- a/src/fieldViews/helpers.ts
+++ b/src/fieldViews/helpers.ts
@@ -1,3 +1,7 @@
+import type { Node, Schema } from "prosemirror-model";
+import { DOMParser, DOMSerializer, Slice } from "prosemirror-model";
+import type { Step } from "prosemirror-transform";
+import { ReplaceAroundStep, ReplaceStep } from "prosemirror-transform";
 import type { CustomField, FieldSpec } from "../types/Element";
 import { CheckboxFieldView } from "./CheckboxFieldView";
 import type { CheckboxFields } from "./CheckboxFieldView";

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,7 +1,6 @@
 import type { Node } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
 import { AllSelection } from "prosemirror-state";
-// import { canJoin } from 'prosemirror-transform';
 import type { EditorView } from "prosemirror-view";
 import { Decoration, DecorationSet } from "prosemirror-view";
 

--- a/src/pluginHelpers.ts
+++ b/src/pluginHelpers.ts
@@ -31,6 +31,7 @@ export const getElementFieldViewFromType = (
       return new TextFieldView(node, view, getPos, offset, innerDecos);
     case "richText":
       return new RichTextFieldView(
+        prop,
         node,
         view,
         getPos,

--- a/src/pluginHelpers.ts
+++ b/src/pluginHelpers.ts
@@ -1,6 +1,4 @@
 import type { Node } from "prosemirror-model";
-import { Schema } from "prosemirror-model";
-import { schema } from "prosemirror-schema-basic";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import { CheckboxFieldView } from "./fieldViews/CheckboxFieldView";
 import { CustomFieldView } from "./fieldViews/CustomFieldView";
@@ -8,11 +6,6 @@ import { DropdownFieldView } from "./fieldViews/DropdownFieldView";
 import { RichTextFieldView } from "./fieldViews/RichTextFieldView";
 import { TextFieldView } from "./fieldViews/TextFieldView";
 import type { Field } from "./types/Element";
-
-export const temporaryHardcodedSchema = new Schema({
-  nodes: schema.spec.nodes,
-  marks: schema.spec.marks,
-});
 
 type Options = {
   node: Node;
@@ -28,23 +21,9 @@ export const getElementFieldViewFromType = (
 ) => {
   switch (prop.type) {
     case "text":
-      return new TextFieldView(
-        node,
-        view,
-        getPos,
-        offset,
-        view.state.schema,
-        innerDecos
-      );
+      return new TextFieldView(node, view, getPos, offset, innerDecos);
     case "richText":
-      return new RichTextFieldView(
-        node,
-        view,
-        getPos,
-        offset,
-        view.state.schema,
-        innerDecos
-      );
+      return new RichTextFieldView(node, view, getPos, offset, innerDecos);
     case "checkbox":
       return new CheckboxFieldView(
         node,

--- a/src/pluginHelpers.ts
+++ b/src/pluginHelpers.ts
@@ -28,15 +28,21 @@ export const getElementFieldViewFromType = (
 ) => {
   switch (prop.type) {
     case "text":
-      return new TextFieldView(node, view, getPos, offset, innerDecos);
-    case "richText":
-      return new RichTextFieldView(
-        prop,
+      return new TextFieldView(
         node,
         view,
         getPos,
         offset,
-        temporaryHardcodedSchema,
+        view.state.schema,
+        innerDecos
+      );
+    case "richText":
+      return new RichTextFieldView(
+        node,
+        view,
+        getPos,
+        offset,
+        view.state.schema,
         innerDecos
       );
     case "checkbox":


### PR DESCRIPTION
## What does this change?

At the moment, for `ProsemirrorFieldView` instances, we swap nodes and transactions between inner and outer instances of Prosemirror editors transparently, but the editors have different schemas. This has worked by coincidence, so far.

I thought we'd need to translate between the inner and outer schemas on fieldView creation and update (outer -> inner) and when dispatching transactions on the outer editor (inner -> outer), but a discussion on the [Prosemirror forums](https://discuss.prosemirror.net/t/translating-nodes-and-transaction-steps-between-editors-with-different-schemas/3863) has clarified that this isn't necessary – the editor either doesn't seem to enforce the `topNode` specified in the schema, or assumes that the `topNode` is the node passed on initialisation.

So instead of creating a new schema for the child editor, we can pass the parent schema in directly, and everything works as expected. Yay!

## How to test

The integration tests should pass. I've added an integration test for a bug that was caused by our old approach – hard breaks didn't work!