### PR TITLE
Correct CI script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ This Prosemirror plugin adds the ability to add element nodes to a document.
 
 `yarn start` builds the project locally, spins up a webserver, and watches for file changes.
 
-
 ## Testing
 
 - Run the integration tests via Cypress with `yarn test:integration`.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "webpack serve --open",
     "test:integration": "cypress open",
     "test:unit": "jest",
-    "ci": "yarn lint && yarn test:unit && webpack serve & (wait-on http://localhost:7890 && cypress run)",
+    "ci": "yarn lint && yarn test:unit && (webpack serve & (wait-on http://localhost:7890 && cypress run))",
     "postci": "kill $(lsof -t -i:7890)",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },


### PR DESCRIPTION
## What does this change?

At the moment, CI is hanging indefinitely when either linting or testing fails. IIUC, this is because (in `bash` at least) the & operator looks to have a higher associativity than &&, so if linting or tests fail, webpack serve is never called and we run wait-on in parallel, which will run indefinitely.

To test this, try running the following commands in your shell:

```bash
false && true && echo "This shouldn't appear" # no output
false && true & echo "This shouldn't appear" # echoes 'This shouldn't appear'
false && (true & echo "This shouldn't appear") # no output
```

## How to test

Introduce e.g. a linting mistake and run `yarn ci`. Does the script fail fast with an exit code of `1`?