### PR TITLE
Allow passing plugins into rich text editor fields

### DIFF
--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/src/elements/image/imageElement.tsx
+++ b/src/elements/image/imageElement.tsx
@@ -12,7 +12,7 @@ export type SetMedia = (
   assets: string[]
 ) => void;
 
-const examplePlugins: Plugin[] = exampleSetup({ schema, menuBar: false });
+const examplePlugins: Plugin[] = exampleSetup({ schema });
 
 export const imageProps = (
   onSelectImage: (setSrc: SetMedia) => void,

--- a/src/elements/image/imageElement.tsx
+++ b/src/elements/image/imageElement.tsx
@@ -1,9 +1,9 @@
-import React from "react";
-import { Plugin } from "prosemirror-state";
 import { exampleSetup } from "prosemirror-example-setup";
 import { schema } from "prosemirror-schema-basic";
-import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+import type { Plugin } from "prosemirror-state";
+import React from "react";
 import type { CustomField } from "../../plugin/types/Element";
+import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { ImageElementForm } from "./ImageElementForm";
 
 export type SetMedia = (

--- a/src/elements/image/imageElement.tsx
+++ b/src/elements/image/imageElement.tsx
@@ -1,6 +1,5 @@
 import { exampleSetup } from "prosemirror-example-setup";
-import { schema } from "prosemirror-schema-basic";
-import type { Plugin } from "prosemirror-state";
+import type { Schema } from "prosemirror-model";
 import React from "react";
 import type { CustomField } from "../../plugin/types/Element";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
@@ -12,7 +11,7 @@ export type SetMedia = (
   assets: string[]
 ) => void;
 
-const examplePlugins: Plugin[] = exampleSetup({ schema });
+const createPlugins = (schema: Schema) => exampleSetup({ schema });
 
 export const imageProps = (
   onSelectImage: (setSrc: SetMedia) => void,
@@ -21,11 +20,11 @@ export const imageProps = (
   return {
     caption: {
       type: "richText",
-      plugins: examplePlugins,
+      createPlugins,
     },
     altText: {
       type: "richText",
-      plugins: examplePlugins,
+      createPlugins,
     },
     src: {
       type: "text",

--- a/src/elements/image/imageElement.tsx
+++ b/src/elements/image/imageElement.tsx
@@ -1,6 +1,9 @@
 import React from "react";
-import type { CustomField } from "../../plugin/types/Element";
+import { Plugin } from "prosemirror-state";
+import { exampleSetup } from "prosemirror-example-setup";
+import { schema } from "prosemirror-schema-basic";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+import type { CustomField } from "../../plugin/types/Element";
 import { ImageElementForm } from "./ImageElementForm";
 
 export type SetMedia = (
@@ -9,6 +12,8 @@ export type SetMedia = (
   assets: string[]
 ) => void;
 
+const examplePlugins: Plugin[] = exampleSetup({ schema, menuBar: false });
+
 export const imageProps = (
   onSelectImage: (setSrc: SetMedia) => void,
   onCropImage: (mediaId: string, setMedia: SetMedia) => void
@@ -16,9 +21,11 @@ export const imageProps = (
   return {
     caption: {
       type: "richText",
+      plugins: examplePlugins,
     },
     altText: {
       type: "richText",
+      plugins: examplePlugins,
     },
     src: {
       type: "text",

--- a/src/plugin/fieldViews/RichTextFieldView.ts
+++ b/src/plugin/fieldViews/RichTextFieldView.ts
@@ -1,7 +1,7 @@
-import { exampleSetup } from "prosemirror-example-setup";
 import { redo, undo } from "prosemirror-history";
 import { keymap } from "prosemirror-keymap";
-import type { Node, Schema } from "prosemirror-model";
+import type { Node } from "prosemirror-model";
+import type { Plugin } from "prosemirror-state";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
 
@@ -18,7 +18,9 @@ export class RichTextFieldView extends ProseMirrorFieldView {
     // The offset of this node relative to its parent FieldView.
     offset: number,
     // The initial decorations for the FieldView.
-    decorations: DecorationSet | Decoration[]
+    decorations: DecorationSet | Decoration[],
+    // The plugins passed by the consumer into the FieldView, if any.
+    plugins: Plugin[]
   ) {
     super(
       node,
@@ -32,7 +34,7 @@ export class RichTextFieldView extends ProseMirrorFieldView {
           "Mod-z": () => undo(outerView.state, outerView.dispatch),
           "Mod-y": () => redo(outerView.state, outerView.dispatch),
         }),
-        ...exampleSetup({ schema: node.type.schema as Schema }),
+        ...plugins,
       ]
     );
   }

--- a/src/plugin/helpers/plugin.ts
+++ b/src/plugin/helpers/plugin.ts
@@ -29,7 +29,7 @@ export const getElementFieldViewFromType = (
         getPos,
         offset,
         innerDecos,
-        prop.plugins ?? []
+        field.plugins ?? []
       );
     case "checkbox":
       return new CheckboxFieldView(

--- a/src/plugin/helpers/plugin.ts
+++ b/src/plugin/helpers/plugin.ts
@@ -23,7 +23,14 @@ export const getElementFieldViewFromType = (
     case "text":
       return new TextFieldView(node, view, getPos, offset, innerDecos);
     case "richText":
-      return new RichTextFieldView(node, view, getPos, offset, innerDecos);
+      return new RichTextFieldView(
+        node,
+        view,
+        getPos,
+        offset,
+        innerDecos,
+        prop.plugins ?? []
+      );
     case "checkbox":
       return new CheckboxFieldView(
         node,

--- a/src/plugin/helpers/plugin.ts
+++ b/src/plugin/helpers/plugin.ts
@@ -29,7 +29,7 @@ export const getElementFieldViewFromType = (
         getPos,
         offset,
         innerDecos,
-        field.plugins ?? []
+        field.createPlugins ? field.createPlugins(node.type.schema) : []
       );
     case "checkbox":
       return new CheckboxFieldView(

--- a/src/plugin/types/Element.ts
+++ b/src/plugin/types/Element.ts
@@ -38,7 +38,7 @@ interface RichTextField
   extends BaseFieldSpec<string>,
     Partial<Pick<NodeSpec, "toDOM" | "parseDOM" | "content">> {
   type: typeof RichTextFieldView.fieldName;
-  plugins?: Plugin[];
+  createPlugins?: (schema: Schema) => Plugin[];
 }
 
 interface TextField extends BaseFieldSpec<string> {

--- a/src/plugin/types/Element.ts
+++ b/src/plugin/types/Element.ts
@@ -1,4 +1,5 @@
 import type { NodeSpec, Schema } from "prosemirror-model";
+import type { Plugin } from "prosemirror-state";
 import type { CheckboxFieldView } from "../fieldViews/CheckboxFieldView";
 import type { CustomFieldView } from "../fieldViews/CustomFieldView";
 import type { DropdownFieldView } from "../fieldViews/DropdownFieldView";
@@ -37,6 +38,7 @@ interface RichTextField
   extends BaseFieldSpec<string>,
     Partial<Pick<NodeSpec, "toDOM" | "parseDOM" | "content">> {
   type: typeof RichTextFieldView.fieldName;
+  plugins?: Plugin[];
 }
 
 interface TextField extends BaseFieldSpec<string> {


### PR DESCRIPTION
## What does this change?

Creates a property in a RichTextField field declaration, `plugins: Plugin[]`, to allow element to pass plugins into fields directly. This replaces the current approach, where we just add an `exampleSetup` plugin arbitrarily.

This will eventually allow consumers to pass plugins to elements to govern RTE behaviour – e.g. at the Guardian we may do this to supply custom RTE menu bars in Composer, amongst other things.

I've added an exampleSetup plugin but ~turned menu bars off to show that the field is now governing plugin behaviour~ left menu bars in, as our integration tests rely on them 😅 

## How to test

This is a no-op – the automated tests should pass.