### PR TITLE
Rerender decorations in rich text field when they change, even if the document hasn't

### DIFF
--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -1,4 +1,8 @@
-import { trimHtml } from "../../src/plugin/helpers/test";
+import type { EditorView } from "prosemirror-view";
+import {
+  ChangeTestDecoStringAction,
+  trimHtml,
+} from "../../src/plugin/helpers/test";
 import { elementWrapperTestId } from "../../src/renderers/react/ElementWrapper";
 import { getFieldViewTestId } from "../../src/renderers/react/FieldView";
 
@@ -62,6 +66,15 @@ export const assertDocHtml = (expectedHtml: string) =>
     }).docToHtml();
     expect(trimHtml(expectedHtml)).to.equal(actualHtml);
   });
+
+export const changeTestDecoString = (newTestString: string) => {
+  cy.window().then((win) => {
+    const view = ((win as unknown) as { view: EditorView }).view;
+    view.dispatch(
+      view.state.tr.setMeta(ChangeTestDecoStringAction, newTestString)
+    );
+  });
+};
 
 export const getSerialisedHtml = ({
   altTextValue = "<p></p>",

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -1,6 +1,8 @@
+import type { EditorView } from "prosemirror-view";
 import {
   addElement,
   assertDocHtml,
+  changeTestDecoString,
   getElementField,
   getElementMenuButton,
   getElementRichTextField,
@@ -58,6 +60,19 @@ describe("ImageElement", () => {
           getElementRichTextField(field)
             .find(".TestDecoration")
             .should("have.text", "deco");
+        });
+
+        it(`${field} – should render new decorations, even if the document state has not changed`, () => {
+          addElement();
+          const newDecoString = "decoChanged";
+          const text = `${field} deco ${newDecoString}`;
+
+          typeIntoElementField(field, text);
+          changeTestDecoString(newDecoString);
+
+          getElementRichTextField(field)
+            .find(".TestDecoration")
+            .should("have.text", newDecoString);
         });
 
         rteFieldStyles.forEach((style) => {

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -63,8 +63,9 @@ describe("ImageElement", () => {
 
         it(`${field} – should render new decorations, even if the document state has not changed`, () => {
           addElement();
+          const oldDecoString = "deco";
           const newDecoString = "decoChanged";
-          const text = `${field} deco ${newDecoString}`;
+          const text = `${field} ${oldDecoString} ${newDecoString}`;
 
           typeIntoElementField(field, text);
           changeTestDecoString(newDecoString);
@@ -72,6 +73,12 @@ describe("ImageElement", () => {
           getElementRichTextField(field)
             .find(".TestDecoration")
             .should("have.text", newDecoString);
+
+          changeTestDecoString(oldDecoString);
+
+          getElementRichTextField(field)
+            .find(".TestDecoration")
+            .should("have.text", oldDecoString);
         });
 
         rteFieldStyles.forEach((style) => {

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -1,4 +1,3 @@
-import type { EditorView } from "prosemirror-view";
 import {
   addElement,
   assertDocHtml,

--- a/src/plugin/helpers/test.ts
+++ b/src/plugin/helpers/test.ts
@@ -3,25 +3,41 @@ import { exampleSetup } from "prosemirror-example-setup";
 import type { NodeSpec } from "prosemirror-model";
 import { Schema } from "prosemirror-model";
 import { schema as basicSchema } from "prosemirror-schema-basic";
-import { EditorState, Plugin } from "prosemirror-state";
+import { EditorState, Plugin, PluginKey } from "prosemirror-state";
 import { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import { buildElementPlugin } from "../element";
 import { createElementSpec } from "../elementSpec";
 import type { ElementSpec, FieldSpec } from "../types/Element";
 import { createParsers } from "./prosemirror";
 
-export const testDecorationPlugin = new Plugin({
+const initialPhrase = "deco";
+const key = new PluginKey<string>("TEST_DECO_PLUGIN");
+export const ChangeTestDecoStringAction = "CHANGE_TEST_DECO_STRING";
+
+export const testDecorationPlugin = new Plugin<string>({
+  key,
+  state: {
+    init() {
+      return initialPhrase;
+    },
+    apply(tr, oldTestString) {
+      const maybeNewTestString = tr.getMeta(ChangeTestDecoStringAction) as
+        | string
+        | undefined;
+      return maybeNewTestString ?? oldTestString;
+    },
+  },
   props: {
     decorations: (state) => {
-      const decorateThisPhrase = "deco";
+      const testString = key.getState(state) ?? initialPhrase;
       const ranges = [] as Array<[number, number]>;
       state.doc.descendants((node, offset) => {
         if (node.isLeaf && node.textContent) {
-          const indexOfDeco = node.textContent.indexOf(decorateThisPhrase);
+          const indexOfDeco = node.textContent.indexOf(testString);
           if (indexOfDeco !== -1) {
             ranges.push([
               indexOfDeco + offset,
-              indexOfDeco + offset + decorateThisPhrase.length,
+              indexOfDeco + offset + testString.length,
             ]);
           }
         }


### PR DESCRIPTION
## What does this change?

Previous to this PR, if the decorations in a rich text field changed but the node content remained the same, the field would not update its decorations.

This is a problem for an upcoming PR that displays user carets in a collaborative editing context – the carets are represented as decorations, and nested fields do not update the position of these carets until their documents change.

## Dev notes

Because `Decoration`s and `DecorationSet`s are immutable, we can compare incoming decorations to the current decorations to see if they've changed, and flag. We can then ensure that if the document itself haven't changed but the decorations have, we dispatch a no-op transaction that forces the editor to rerender decorations, but leaves the document untouched.

## How to test

I've added an action to our `testDecorationPlugin` to test this, that modifies the decorations applied to content in a field. With that, I've added an integration test to prove that when decorations change, the nested field changes. Does this test convincingly cover this case?