### PR TITLE
add field creator functions to imageelements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 .cache
 .DS_Store
 .vscode
+.metals
 cypress/videos
 cypress/screenshots
 .metals

--- a/.metals/metals.lock.db
+++ b/.metals/metals.lock.db
@@ -1,6 +1,0 @@
-#FileLock
-#Thu Jul 08 09:49:44 BST 2021
-hostName=localhost
-id=17a758b0407b7070ce8882977c80562f71a310241ab
-method=file
-server=localhost\:49752

--- a/.metals/metals.lock.db
+++ b/.metals/metals.lock.db
@@ -1,0 +1,6 @@
+#FileLock
+#Thu Jul 08 09:49:44 BST 2021
+hostName=localhost
+id=17a758b0407b7070ce8882977c80562f71a310241ab
+method=file
+server=localhost\:49752

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -1,4 +1,3 @@
-import type { EditorView } from "prosemirror-view";
 import {
   addElement,
   assertDocHtml,

--- a/src/editorial-source-components/CustomDropdown.tsx
+++ b/src/editorial-source-components/CustomDropdown.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import { space } from "@guardian/src-foundations";
 import { Option, Select } from "@guardian/src-select";
-import type { Option as OptionValue } from "../plugin/types/Element";
+import type { Option as OptionValue } from "../plugin/fieldViews/DropdownFieldView";
 import { inputBorder } from "./inputBorder";
 import { labelStyles } from "./Label";
 

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -9,12 +9,14 @@ import type {
 } from "../../plugin/types/Element";
 import { FieldView, getFieldViewTestId } from "../../renderers/react/FieldView";
 import { useCustomFieldViewState } from "../../renderers/react/useCustomFieldViewState";
-import type { imageProps, SetMedia } from "./imageElement";
+import type { createImageFields, SetMedia } from "./imageElement";
 
 type Props = {
-  fields: FieldNameToValueMap<ReturnType<typeof imageProps>>;
+  fields: FieldNameToValueMap<ReturnType<typeof createImageFields>>;
   errors: Record<string, string[]>;
-  fieldViewSpecMap: FieldNameToFieldViewSpec<ReturnType<typeof imageProps>>;
+  fieldViewSpecMap: FieldNameToFieldViewSpec<
+    ReturnType<typeof createImageFields>
+  >;
 };
 
 export const ImageElementTestId = "ImageElement";

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { CustomDropdown } from "../../editorial-source-components/CustomDropdown";
 import { Label } from "../../editorial-source-components/Label";
+import type { Option } from "../../plugin/fieldViews/DropdownFieldView";
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
 import type {
   CustomFieldViewSpec,
   FieldNameToFieldViewSpec,
-  Option,
 } from "../../plugin/types/Element";
 import { FieldView, getFieldViewTestId } from "../../renderers/react/FieldView";
 import { useCustomFieldViewState } from "../../renderers/react/useCustomFieldViewState";

--- a/src/elements/image/imageElement.tsx
+++ b/src/elements/image/imageElement.tsx
@@ -1,7 +1,10 @@
-import { exampleSetup } from "prosemirror-example-setup";
-import type { Schema } from "prosemirror-model";
 import React from "react";
-import type { CustomField, Option } from "../../plugin/types/Element";
+import { createCheckBox } from "../../plugin/fieldViews/CheckboxFieldView";
+import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
+import type { Option } from "../../plugin/fieldViews/DropdownFieldView";
+import { createDropDownField } from "../../plugin/fieldViews/DropdownFieldView";
+import { createRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
+import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { ImageElementForm } from "./ImageElementForm";
 
@@ -11,61 +14,47 @@ export type SetMedia = (
   assets: string[]
 ) => void;
 
-const createPlugins = (schema: Schema) => exampleSetup({ schema });
+type ImageField = {
+  mediaId?: string | undefined;
+  mediaApiUri?: string | undefined;
+  assets: string[];
+};
+
+type ImageProps = {
+  onSelectImage: (setMedia: SetMedia) => void;
+  onCropImage: (mediaId: string, setMedia: SetMedia) => void;
+};
 
 export const imageProps = (
   onSelectImage: (setSrc: SetMedia) => void,
   onCropImage: (mediaId: string, setMedia: SetMedia) => void
 ) => {
   return {
-    caption: {
-      type: "richText",
-      createPlugins,
-    },
-    altText: {
-      type: "richText",
-      createPlugins,
-    },
-    src: {
-      type: "text",
-    },
-    mainImage: {
-      type: "custom",
-      defaultValue: { mediaId: undefined, mediaApiUri: undefined, assets: [] },
-      props: {
+    caption: createRichTextField(),
+    altText: createRichTextField(),
+    src: createTextField(),
+    mainImage: createCustomField<ImageField, ImageProps>(
+      { mediaId: undefined, mediaApiUri: undefined, assets: [] },
+      {
         onSelectImage,
         onCropImage,
-      },
-    } as CustomField<
-      { mediaId?: string; mediaApiUri?: string; assets: string[] },
-      {
-        onSelectImage: (setSrc: SetMedia) => void;
-        onCropImage: (mediaId: string, setSrc: SetMedia) => void;
       }
-    >,
-    useSrc: {
-      type: "checkbox",
-      defaultValue: { value: false },
-    },
-    optionDropdown: {
-      type: "dropdown",
-      options: [
+    ),
+    useSrc: createCheckBox(false),
+    optionDropdown: createDropDownField(
+      [
         { text: "Option 1", value: "opt1" },
         { text: "Option 2", value: "opt2" },
         { text: "Option 3", value: "opt3" },
       ],
-      defaultValue: "opt1",
-    },
-    customDropdown: {
-      type: "custom",
-      defaultValue: "opt1",
-      props: [
-        { text: "Option 1", value: "opt1" },
-        { text: "Option 2", value: "opt2" },
-        { text: "Option 3", value: "opt3" },
-      ],
-    } as CustomField<string, Array<Option<string>>>,
-  } as const;
+      "opt1"
+    ),
+    customDropdown: createCustomField<string, Array<Option<string>>>("opt1", [
+      { text: "Option 1", value: "opt1" },
+      { text: "Option 2", value: "opt2" },
+      { text: "Option 3", value: "opt3" },
+    ]),
+  };
 };
 
 export const createImageElement = <Name extends string>(

--- a/src/elements/image/imageElement.tsx
+++ b/src/elements/image/imageElement.tsx
@@ -3,7 +3,7 @@ import { createCheckBox } from "../../plugin/fieldViews/CheckboxFieldView";
 import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
 import type { Option } from "../../plugin/fieldViews/DropdownFieldView";
 import { createDropDownField } from "../../plugin/fieldViews/DropdownFieldView";
-import { createRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
+import { createDefaultRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { ImageElementForm } from "./ImageElementForm";
@@ -30,8 +30,8 @@ export const createImageFields = (
   onCropImage: (mediaId: string, setMedia: SetMedia) => void
 ) => {
   return {
-    caption: createRichTextField(),
-    altText: createRichTextField(),
+    caption: createDefaultRichTextField(),
+    altText: createDefaultRichTextField(),
     src: createTextField(),
     mainImage: createCustomField<ImageField, ImageProps>(
       { mediaId: undefined, mediaApiUri: undefined, assets: [] },

--- a/src/elements/image/imageElement.tsx
+++ b/src/elements/image/imageElement.tsx
@@ -25,7 +25,7 @@ type ImageProps = {
   onCropImage: (mediaId: string, setMedia: SetMedia) => void;
 };
 
-export const imageProps = (
+export const createImageFields = (
   onSelectImage: (setSrc: SetMedia) => void,
   onCropImage: (mediaId: string, setMedia: SetMedia) => void
 ) => {
@@ -64,7 +64,7 @@ export const createImageElement = <Name extends string>(
 ) =>
   createReactElementSpec(
     name,
-    imageProps(onSelect, onCrop),
+    createImageFields(onSelect, onCrop),
     (fields, errors, __, fieldViewSpecs) => {
       return (
         <ImageElementForm

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -1,10 +1,10 @@
 import { buildElementPlugin } from "../element";
+import type { CustomField } from "../fieldViews/CustomFieldView";
 import {
   createEditorWithElements,
   createNoopElement,
   trimHtml,
 } from "../helpers/test";
-import type { CustomField } from "../types/Element";
 
 describe("buildElementPlugin", () => {
   describe("Typesafety", () => {

--- a/src/plugin/__tests__/elementSpec.spec.ts
+++ b/src/plugin/__tests__/elementSpec.spec.ts
@@ -1,7 +1,7 @@
 import { buildElementPlugin } from "../element";
 import { createElementSpec } from "../elementSpec";
+import type { CustomField } from "../fieldViews/CustomFieldView";
 import { createNoopElement } from "../helpers/test";
-import type { CustomField } from "../types/Element";
 
 describe("mount", () => {
   describe("fieldView typesafety", () => {

--- a/src/plugin/fieldViews/CheckboxFieldView.ts
+++ b/src/plugin/fieldViews/CheckboxFieldView.ts
@@ -3,9 +3,9 @@ import type { EditorView } from "prosemirror-view";
 import { AttributeFieldView } from "./AttributeFieldView";
 import type { BaseFieldSpec } from "./FieldView";
 
-export type CheckboxFields = { value: boolean };
+export type CheckboxValue = { value: boolean };
 
-export interface CheckboxField extends BaseFieldSpec<CheckboxFields> {
+export interface CheckboxField extends BaseFieldSpec<CheckboxValue> {
   type: typeof CheckboxFieldView.fieldName;
 }
 
@@ -14,7 +14,7 @@ export const createCheckBox = (defaultValue: boolean): CheckboxField => ({
   defaultValue: { value: defaultValue },
 });
 
-export class CheckboxFieldView extends AttributeFieldView<CheckboxFields> {
+export class CheckboxFieldView extends AttributeFieldView<CheckboxValue> {
   public static fieldName = "checkbox" as const;
   public static defaultValue = { value: false };
   private checkboxElement: HTMLInputElement | undefined = undefined;
@@ -28,16 +28,16 @@ export class CheckboxFieldView extends AttributeFieldView<CheckboxFields> {
     getPos: () => number,
     // The offset of this node relative to its parent FieldView.
     offset: number,
-    defaultFields: CheckboxFields
+    defaultFields: CheckboxValue
   ) {
     super(node, outerView, getPos, offset);
     this.createInnerView(node.attrs.fields || defaultFields);
   }
-  public getNodeValue(node: Node): CheckboxFields {
-    return node.attrs.fields as CheckboxFields;
+  public getNodeValue(node: Node): CheckboxValue {
+    return node.attrs.fields as CheckboxValue;
   }
 
-  protected createInnerView({ value }: CheckboxFields): void {
+  protected createInnerView({ value }: CheckboxValue): void {
     this.checkboxElement = document.createElement("input");
     this.checkboxElement.type = "checkbox";
     this.checkboxElement.checked = value;
@@ -48,7 +48,7 @@ export class CheckboxFieldView extends AttributeFieldView<CheckboxFields> {
     );
     this.fieldViewElement.appendChild(this.checkboxElement);
   }
-  protected updateInnerView({ value }: CheckboxFields): void {
+  protected updateInnerView({ value }: CheckboxValue): void {
     if (this.checkboxElement) {
       this.checkboxElement.checked = value;
     }

--- a/src/plugin/fieldViews/CheckboxFieldView.ts
+++ b/src/plugin/fieldViews/CheckboxFieldView.ts
@@ -1,8 +1,18 @@
 import type { Node } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
 import { AttributeFieldView } from "./AttributeFieldView";
+import type { BaseFieldSpec } from "./FieldView";
 
 export type CheckboxFields = { value: boolean };
+
+export interface CheckboxField extends BaseFieldSpec<CheckboxFields> {
+  type: typeof CheckboxFieldView.fieldName;
+}
+
+export const createCheckBox = (defaultValue: boolean): CheckboxField => ({
+  type: CheckboxFieldView.fieldName,
+  defaultValue: { value: defaultValue },
+});
 
 export class CheckboxFieldView extends AttributeFieldView<CheckboxFields> {
   public static fieldName = "checkbox" as const;

--- a/src/plugin/fieldViews/CustomFieldView.ts
+++ b/src/plugin/fieldViews/CustomFieldView.ts
@@ -30,12 +30,13 @@ type Subscriber<Fields extends unknown> = (fields: Fields) => void;
  * state changes. In this way, consuming code can manage state and UI changes itself,
  * perhaps in its own renderer format.
  */
-export class CustomFieldView<Fields = unknown> implements FieldView<Fields> {
+export class CustomFieldView<CustomFieldValue = unknown>
+  implements FieldView<CustomFieldValue> {
   public static fieldName = "custom" as const;
   public static fieldType = FieldType.ATTRIBUTES;
   public static defaultValue = undefined;
 
-  private subscribers: Array<Subscriber<Fields>> = [];
+  private subscribers: Array<Subscriber<CustomFieldValue>> = [];
 
   constructor(
     // The node that this FieldView is responsible for rendering.
@@ -48,24 +49,24 @@ export class CustomFieldView<Fields = unknown> implements FieldView<Fields> {
     protected offset: number
   ) {}
 
-  public getNodeValue(node: Node): Fields {
-    return node.attrs.fields as Fields;
+  public getNodeValue(node: Node): CustomFieldValue {
+    return node.attrs.fields as CustomFieldValue;
   }
 
-  public getNodeFromValue(fields: Fields): Node {
+  public getNodeFromValue(fields: CustomFieldValue): Node {
     return this.node.type.create({ fields });
   }
 
   /**
    * @returns A function that can be called to update the node fields.
    */
-  public subscribe(subscriber: Subscriber<Fields>) {
+  public subscribe(subscriber: Subscriber<CustomFieldValue>) {
     this.subscribers.push(subscriber);
-    subscriber(this.node.attrs.fields as Fields);
-    return (fields: Fields) => this.updateOuterEditor(fields);
+    subscriber(this.node.attrs.fields as CustomFieldValue);
+    return (fields: CustomFieldValue) => this.updateOuterEditor(fields);
   }
 
-  public unsubscribe(subscriber: Subscriber<Fields>) {
+  public unsubscribe(subscriber: Subscriber<CustomFieldValue>) {
     const subscriberIndex = this.subscribers.indexOf(subscriber);
     if (subscriberIndex === -1) {
       console.error(
@@ -83,7 +84,7 @@ export class CustomFieldView<Fields = unknown> implements FieldView<Fields> {
 
     this.offset = elementOffset;
 
-    this.updateSubscribers(node.attrs.fields as Fields);
+    this.updateSubscribers(node.attrs.fields as CustomFieldValue);
 
     return true;
   }
@@ -92,7 +93,7 @@ export class CustomFieldView<Fields = unknown> implements FieldView<Fields> {
     this.subscribers = [];
   }
 
-  private updateSubscribers(fields: Fields) {
+  private updateSubscribers(fields: CustomFieldValue) {
     this.subscribers.forEach((subscriber) => {
       subscriber(fields);
     });
@@ -101,7 +102,7 @@ export class CustomFieldView<Fields = unknown> implements FieldView<Fields> {
   /**
    * Update the outer editor with a new field state.
    */
-  protected updateOuterEditor(fields: Fields) {
+  protected updateOuterEditor(fields: CustomFieldValue) {
     const outerTr = this.outerView.state.tr;
     // When we insert content, we must offset to account for a few things:
     //  - getPos() returns the position directly before the parent node (+1)

--- a/src/plugin/fieldViews/CustomFieldView.ts
+++ b/src/plugin/fieldViews/CustomFieldView.ts
@@ -1,7 +1,23 @@
 import type { Node } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
-import type { FieldView } from "./FieldView";
+import type { BaseFieldSpec, FieldView } from "./FieldView";
 import { FieldType } from "./FieldView";
+
+export interface CustomField<Data = unknown, Props = unknown>
+  extends BaseFieldSpec<Data> {
+  type: typeof CustomFieldView.fieldName;
+  defaultValue: Data;
+  props: Props;
+}
+
+export const createCustomField = <Data, Props>(
+  defaultValue: Data,
+  props: Props
+): CustomField<Data, Props> => ({
+  type: "custom" as const,
+  defaultValue,
+  props,
+});
 
 type Subscriber<Fields extends unknown> = (fields: Fields) => void;
 

--- a/src/plugin/fieldViews/DropdownFieldView.ts
+++ b/src/plugin/fieldViews/DropdownFieldView.ts
@@ -3,18 +3,18 @@ import type { EditorView } from "prosemirror-view";
 import { AttributeFieldView } from "./AttributeFieldView";
 import type { BaseFieldSpec } from "./FieldView";
 
-export type Option = { text: string; value: string };
-type Options = readonly Option[];
+export type Option<Data> = { text: string; value: Data };
+type Options<Data> = ReadonlyArray<Option<Data>>;
 
-export interface DropdownField extends BaseFieldSpec<string | undefined> {
+export interface DropdownField<Data = unknown> extends BaseFieldSpec<Data> {
   type: typeof DropdownFieldView.fieldName;
-  options: Options;
+  options: ReadonlyArray<Option<Data>>;
 }
 
-export const createDropDownField = (
-  options: Options,
-  defaultValue: string
-): DropdownField => ({
+export const createDropDownField = <Data>(
+  options: Options<Data>,
+  defaultValue: Data
+): DropdownField<Data> => ({
   type: DropdownFieldView.fieldName,
   options,
   defaultValue,
@@ -22,7 +22,9 @@ export const createDropDownField = (
 
 export type DropdownFields = string;
 
-export class DropdownFieldView extends AttributeFieldView<string | undefined> {
+export class DropdownFieldView<
+  Data = unknown
+> extends AttributeFieldView<Data> {
   private dropdownElement: HTMLSelectElement | undefined = undefined;
   public static fieldName = "dropdown" as const;
   public static defaultValue = undefined;
@@ -36,14 +38,14 @@ export class DropdownFieldView extends AttributeFieldView<string | undefined> {
     getPos: () => number,
     // The offset of this node relative to its parent FieldView.
     offset: number,
-    defaultFields: string | undefined,
-    private options: readonly Option[]
+    defaultFields: Data,
+    private options: ReadonlyArray<Option<Data>>
   ) {
     super(node, outerView, getPos, offset);
     this.createInnerView(node.attrs.fields || defaultFields);
   }
 
-  protected createInnerView(chosenOption: string): void {
+  protected createInnerView(chosenOption: Data): void {
     this.dropdownElement = document.createElement("select");
 
     // Add a child option for each option in the array
@@ -65,7 +67,7 @@ export class DropdownFieldView extends AttributeFieldView<string | undefined> {
     this.fieldViewElement.appendChild(this.dropdownElement);
   }
 
-  protected updateInnerView(chosenOption: string): void {
+  protected updateInnerView(chosenOption: Data): void {
     if (this.dropdownElement) {
       const domOptions = Array.from(this.dropdownElement.options);
       domOptions.forEach(
@@ -76,8 +78,8 @@ export class DropdownFieldView extends AttributeFieldView<string | undefined> {
   }
 
   private optionToDOMnode(
-    option: Option,
-    chosenOption: string
+    option: Option<Data>,
+    chosenOption: Data
   ): HTMLOptionElement {
     const domOption = document.createElement("option");
     domOption.setAttribute("value", JSON.stringify(option.value));

--- a/src/plugin/fieldViews/DropdownFieldView.ts
+++ b/src/plugin/fieldViews/DropdownFieldView.ts
@@ -1,13 +1,28 @@
 import type { Node } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
-import type { Option } from "../types/Element";
 import { AttributeFieldView } from "./AttributeFieldView";
+import type { BaseFieldSpec } from "./FieldView";
+
+export type Option = { text: string; value: string };
+type Options = readonly Option[];
+
+export interface DropdownField extends BaseFieldSpec<string | undefined> {
+  type: typeof DropdownFieldView.fieldName;
+  options: Options;
+}
+
+export const createDropDownField = (
+  options: Options,
+  defaultValue: string
+): DropdownField => ({
+  type: DropdownFieldView.fieldName,
+  options,
+  defaultValue,
+});
 
 export type DropdownFields = string;
 
-export class DropdownFieldView<
-  Data = unknown
-> extends AttributeFieldView<Data> {
+export class DropdownFieldView extends AttributeFieldView<string | undefined> {
   private dropdownElement: HTMLSelectElement | undefined = undefined;
   public static fieldName = "dropdown" as const;
   public static defaultValue = undefined;
@@ -21,14 +36,14 @@ export class DropdownFieldView<
     getPos: () => number,
     // The offset of this node relative to its parent FieldView.
     offset: number,
-    defaultFields: Data,
-    private options: ReadonlyArray<Option<Data>>
+    defaultFields: string | undefined,
+    private options: readonly Option[]
   ) {
     super(node, outerView, getPos, offset);
     this.createInnerView(node.attrs.fields || defaultFields);
   }
 
-  protected createInnerView(chosenOption: Data): void {
+  protected createInnerView(chosenOption: string): void {
     this.dropdownElement = document.createElement("select");
 
     // Add a child option for each option in the array
@@ -50,7 +65,7 @@ export class DropdownFieldView<
     this.fieldViewElement.appendChild(this.dropdownElement);
   }
 
-  protected updateInnerView(chosenOption: Data): void {
+  protected updateInnerView(chosenOption: string): void {
     if (this.dropdownElement) {
       const domOptions = Array.from(this.dropdownElement.options);
       domOptions.forEach(
@@ -61,8 +76,8 @@ export class DropdownFieldView<
   }
 
   private optionToDOMnode(
-    option: Option<Data>,
-    chosenOption: Data
+    option: Option,
+    chosenOption: string
   ): HTMLOptionElement {
     const domOption = document.createElement("option");
     domOption.setAttribute("value", JSON.stringify(option.value));

--- a/src/plugin/fieldViews/FieldView.ts
+++ b/src/plugin/fieldViews/FieldView.ts
@@ -1,6 +1,15 @@
 import type { Node } from "prosemirror-model";
 import type { Decoration, DecorationSet } from "prosemirror-view";
 
+/**
+ * The specification for an element field, to be modelled as a Node in Prosemirror.
+ */
+export interface BaseFieldSpec<DefaultValue extends unknown> {
+  // The data type of the field.
+  type: string;
+  defaultValue?: DefaultValue;
+}
+
 export enum FieldType {
   // Uses node attributes to store field data.
   ATTRIBUTES = "ATTRIBUTES",

--- a/src/plugin/fieldViews/RichTextFieldView.ts
+++ b/src/plugin/fieldViews/RichTextFieldView.ts
@@ -1,9 +1,28 @@
+import { exampleSetup } from "prosemirror-example-setup";
 import { redo, undo } from "prosemirror-history";
 import { keymap } from "prosemirror-keymap";
-import type { Node } from "prosemirror-model";
+import type { Node, NodeSpec, Schema } from "prosemirror-model";
 import type { Plugin } from "prosemirror-state";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
+import type { BaseFieldSpec } from "./FieldView";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
+
+export interface RichTextField
+  extends BaseFieldSpec<string>,
+    Partial<Pick<NodeSpec, "toDOM" | "parseDOM" | "content">> {
+  type: typeof RichTextFieldView.fieldName;
+  createPlugins?: (schema: Schema) => Plugin[];
+}
+
+export const createRichTextField = (
+  createPlugins?: (schema: Schema) => Plugin[]
+): RichTextField => ({
+  type: RichTextFieldView.fieldName,
+  createPlugins: createPlugins,
+});
+
+export const createDefaultRichTextField = (): RichTextField =>
+  createRichTextField((schema) => exampleSetup({ schema }));
 
 export class RichTextFieldView extends ProseMirrorFieldView {
   public static fieldName = "richText" as const;

--- a/src/plugin/fieldViews/TextFieldView.ts
+++ b/src/plugin/fieldViews/TextFieldView.ts
@@ -2,7 +2,16 @@ import { redo, undo } from "prosemirror-history";
 import { keymap } from "prosemirror-keymap";
 import type { Node } from "prosemirror-model";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
+import type { BaseFieldSpec } from "./FieldView";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
+
+export interface TextField extends BaseFieldSpec<string> {
+  type: typeof TextFieldView.fieldName;
+}
+
+export const createTextField = (): TextField => ({
+  type: TextFieldView.fieldName,
+});
 
 export class TextFieldView extends ProseMirrorFieldView {
   public static fieldName = "text" as const;

--- a/src/plugin/fieldViews/helpers.ts
+++ b/src/plugin/fieldViews/helpers.ts
@@ -1,6 +1,7 @@
-import type { CustomField, FieldSpec } from "../types/Element";
+import type { FieldSpec } from "../types/Element";
 import { CheckboxFieldView } from "./CheckboxFieldView";
 import type { CheckboxFields } from "./CheckboxFieldView";
+import type { CustomField } from "./CustomFieldView";
 import { CustomFieldView } from "./CustomFieldView";
 import type { DropdownFields } from "./DropdownFieldView";
 import { DropdownFieldView } from "./DropdownFieldView";

--- a/src/plugin/fieldViews/helpers.ts
+++ b/src/plugin/fieldViews/helpers.ts
@@ -1,6 +1,6 @@
 import type { FieldSpec } from "../types/Element";
 import { CheckboxFieldView } from "./CheckboxFieldView";
-import type { CheckboxFields } from "./CheckboxFieldView";
+import type { CheckboxValue } from "./CheckboxFieldView";
 import type { CustomField } from "./CustomFieldView";
 import { CustomFieldView } from "./CustomFieldView";
 import type { DropdownFields } from "./DropdownFieldView";
@@ -35,7 +35,7 @@ export type FieldTypeToValueMap<
 > = {
   [TextFieldView.fieldName]: string;
   [RichTextFieldView.fieldName]: string;
-  [CheckboxFieldView.fieldName]: CheckboxFields;
+  [CheckboxFieldView.fieldName]: CheckboxValue;
   [DropdownFieldView.fieldName]: DropdownFields;
   [CustomFieldView.fieldName]: FSpec[Name] extends CustomField<infer Data>
     ? Data

--- a/src/plugin/types/Element.ts
+++ b/src/plugin/types/Element.ts
@@ -1,56 +1,26 @@
 import type { NodeSpec, Schema } from "prosemirror-model";
-import type { Plugin } from "prosemirror-state";
-import type { CheckboxFieldView } from "../fieldViews/CheckboxFieldView";
-import type { CustomFieldView } from "../fieldViews/CustomFieldView";
-import type { DropdownFieldView } from "../fieldViews/DropdownFieldView";
+import type {
+  CheckboxField,
+  CheckboxFieldView,
+} from "../fieldViews/CheckboxFieldView";
+import type {
+  CustomField,
+  CustomFieldView,
+} from "../fieldViews/CustomFieldView";
+import type {
+  DropdownField,
+  DropdownFieldView,
+} from "../fieldViews/DropdownFieldView";
 import type {
   FieldNameToValueMap,
   FieldTypeToViewMap,
 } from "../fieldViews/helpers";
-import type { RichTextFieldView } from "../fieldViews/RichTextFieldView";
-import type { TextFieldView } from "../fieldViews/TextFieldView";
+import type {
+  RichTextField,
+  RichTextFieldView,
+} from "../fieldViews/RichTextFieldView";
+import type { TextField, TextFieldView } from "../fieldViews/TextFieldView";
 import type { CommandCreator } from "./Commands";
-
-/**
- * The specification for an element field, to be modelled as a Node in Prosemirror.
- */
-interface BaseFieldSpec<DefaultValue extends unknown> {
-  // The data type of the field.
-  type: string;
-  defaultValue?: DefaultValue;
-}
-
-interface CheckboxField extends BaseFieldSpec<{ value: boolean }> {
-  type: typeof CheckboxFieldView.fieldName;
-}
-
-export type Option<Value> = {
-  text: string;
-  value: Value;
-};
-
-interface DropdownField<Data = unknown> extends BaseFieldSpec<Data> {
-  type: typeof DropdownFieldView.fieldName;
-  options: ReadonlyArray<Option<Data>>;
-}
-
-interface RichTextField
-  extends BaseFieldSpec<string>,
-    Partial<Pick<NodeSpec, "toDOM" | "parseDOM" | "content">> {
-  type: typeof RichTextFieldView.fieldName;
-  createPlugins?: (schema: Schema) => Plugin[];
-}
-
-interface TextField extends BaseFieldSpec<string> {
-  type: typeof TextFieldView.fieldName;
-}
-
-export interface CustomField<Data = unknown, Props = unknown>
-  extends BaseFieldSpec<Data> {
-  type: typeof CustomFieldView.fieldName;
-  defaultValue: Data;
-  props: Props;
-}
 
 export type Field =
   | TextField


### PR DESCRIPTION
## What does this change?
When creating elements at the moment we have to declare fields manually with object literals. This can mean that field declaration can be unnecessarily verbose and sometimes require type cast.

```ts 
mainImage: {
      type: "custom",
      defaultValue: { mediaId: undefined, mediaApiUri: undefined, assets: [] },
      props: {
        onSelectImage,
        onCropImage,
      },
    } as CustomField<
      { mediaId?: string; mediaApiUri?: string; assets: string[] },
      {
        onSelectImage: (setSrc: SetMedia) => void;
        onCropImage: (mediaId: string, setSrc: SetMedia) => void;
      }
    >
```
 This PR introduces `creator` functions for each field type; this enables a more concise way of declaring fields:
```ts
mainImage: createCustomField<ImageField, ImageProps>(
      { mediaId: undefined, mediaApiUri: undefined, assets: [] },
      {
        onSelectImage,
        onCropImage,
      }
    )
```

## How to test
All the current test should pass. 
Take a look at the new field creators, does it make it easier read and or work with?

## Dev notes
We decided to move the field types into their fieldView class files. This puts most field related code in the same place.