### PR TITLE
chore: add semantic release

### DIFF
--- a/.github/workflows/node-js.yml
+++ b/.github/workflows/node-js.yml
@@ -16,3 +16,18 @@ jobs:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - run: yarn install
       - run: yarn ci
+      - run: yarn build
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v2
+        with:
+          branches: |
+            [
+              'main',
+              {
+                name: 'beta',
+                prerelease: true
+              }
+            ]
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,16 @@
+
+name: 'Lint PR'
+on:
+    pull_request:
+        types:
+            - opened
+            - edited
+            - synchronize
+
+jobs:
+    main:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: amannn/action-semantic-pull-request@v3.4.0
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ Modelling non-text content in Prosemirror can be tricky. `prosemirror-elements` 
   - You'll need to be running the application via `yarn start` simultaneously for the tests to work – make sure the server is responding on http://localhost:7890 before running the tests.
   - For reasons we're not yet able to determine, Cypress won't run your tests immediately when you select them in the GUI. Hit the 'refresh' button and they should run normally.
 
+## Releasing
+
+This repository uses [semantic-release](https://github.com/semantic-release/semantic-release) to publish new versions of this package when PRs are merged to `main`, and prelease versions when code is pushed to `beta`.
+
+Version numbers are determined by the commit history of main, and so to trigger a release you'll need to use the [commitizen](https://github.com/commitizen-tools/commitizen) format when naming pull requests. Then, when the PR is merged via a merge commit, the name of that commit (which corresponds to the name of the PR) will trigger a release.
+
+For example, merging a PR named:
+
+- `fix: this one weird bug` to `main` will trigger a release with a patch version bump
+- `feat: an exciting new thing` to `beta` will trigger a release with a `beta` suffix and a minor version bump
+
+
 ## Troubleshooting when developing this library
 
 ### Problems with `yarn link`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/prosemirror-elements",
-  "version": "0.1.0",
+  "version": "set-by-semantic-release",
   "type": "module",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## What does this change?

Adds [semantic-release](https://github.com/semantic-release/semantic-release) via a workflow and [github action](https://github.com/marketplace/actions/action-for-semantic-release). This means automated, semantically versioned releases with nicely formatted release histories – see [prosemirror-typerighter](https://github.com/guardian/prosemirror-typerighter/releases) for an example of a release history generated with this approach.

In order for semantic release to determine the correct version number, the project requires pull request names to be compliant with the [commitizen](https://github.com/commitizen-tools/commitizen) format: for example, `fix: a bug that was squashed` or `feat: an exciting new thing`.

This PR includes a github action that will validate the name of the PR in CI to ensure it's correctly formatted.

Comments on this approach really welcome.

## How to test

Does the github action run the correct code, and pass without errors?

Does the readme accurately reflect the new process? Is there anything we should add/remove?