### PR TITLE
docs: Adds vision document

### DIFF
--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,59 @@
+# Challenges
+
+1. Nesting arbitrary content within ProseMirror 
+2. Seamlessly Integrating nested ProseMirror rich-text fields with the parent instance
+3. Providing a way to create any possible custom nested element
+4. Abstracting ProseMirror core functionality and  offering a simple interface
+
+# Vision
+
+The goal of the ProseMirror-Elements plugin is to provide a logical extension to ProseMirror's core functionality that makes modeling arbitrary nested content simple. It should be easy to understand, easy to implement and agnostic about the elements that use it.
+
+## Easy to understand
+
+Creating new elements with the plugin should require minimal understanding of the ProseMirror ecosystem and the plugin itself. It should abstract the complexity of adding nested content and provide developers with a clear intuitive interface.
+
+The plugin should provide an API that’s minimal and idiomatic, with opinionated defaults for common operations, and powerful escape hatches when consumers need something that strays off that path.
+
+#### KPIs
+
+- Consistent interface that's intuitive to understand
+- Succinct API that provides a powerful set of controls
+- Documentation that explains any areas that are unclear
+- Test environment allowing developers to quickly play around with the plugin
+
+
+## Easy to implement
+
+Adding the plugin to a new or existing project should be seamless and quickly show results. Once users have set the plugin up, they should be able to easily develop and add new elements.
+
+#### KPIs
+
+- Possible to implement into a ProseMirror instance quickly
+- Creating new elements can be 
+- Support different requirements
+
+## Agnostic
+
+The plugin should have no opinion about the elements that use it. Any complexity necessary to implement an element should be possible without increasing the surface area of the API.
+
+#### KPIs
+
+- Plugin should have no stake in implemented elements
+
+## Collaborative Editing
+
+The plugin should present no barrier to collaborative editing. Parent instances which implement collaborative editing should provide nested content with similar functionality in all relevant fields.
+
+#### KPIs
+
+- Collaborative editing should be easy to implement
+
+## Accessibility 
+
+While the plugin is agnostic about the elements that use it, it should be easy to create elements that meet our [accessibility standards](https://docs.google.com/document/d/1mCPo4U3U57IC869AKWiEylpGjyRnT5NVYlL8gOkCEOk/edit). 
+
+#### KPIs
+
+- Is it easy to implement new elements that meet our accessibility standard?
+

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,58 +1,59 @@
-# Challenges
+## Challenges
 
-1. Nesting arbitrary content within ProseMirror 
+1. Nesting arbitrary collections of content within ProseMirror
 2. Seamlessly integrating nested ProseMirror rich-text fields with the parent instance
-3. Providing a way to create any possible custom nested element
-4. Abstracting ProseMirror core functionality and  offering a simple interface
+3. Abstracting ProseMirror core functionality and offering a simple interface
 
-# Vision
+## Vision
 
 The goal of the ProseMirror-Elements plugin is to provide a logical extension to ProseMirror's core functionality that makes modeling arbitrary nested content simple. It should be easy to understand, easy to implement and agnostic about the elements that use it.
 
-## Easy to understand
+## Goals
+
+### Easy to use
 
 Creating new elements with the plugin should require minimal understanding of the ProseMirror ecosystem and the plugin itself. It should abstract the complexity of adding nested content and provide developers with a clear intuitive interface.
 
-The plugin should provide an API that’s minimal and idiomatic, with opinionated defaults for common operations, and powerful escape hatches when consumers need something that strays off that path.
+The plugin should provide an API that’s minimal and consistent, with opinionated defaults for common operations, and powerful escape hatches when consumers need something that strays off that path. The documentation should be comprehensive. We should consider a sandbox environment that lets users experiment with field declarations.
 
 #### KPIs
 
-- Consistent interface that's intuitive to understand
-- Succinct API that provides a powerful set of controls
-- Documentation that explains any areas that are unclear
-- Test environment allowing developers to quickly play around with the plugin
+- Few issues raised against this library to explain core functionality
+- The time between beginning to use the library and creating useful elements is minimal
+- The surface area of the API should be as small as possible for the feature set
 
+### Flexible
 
-## Easy to implement
-
-Adding the plugin to a new or existing project should be seamless and quickly show results. Once users have set the plugin up, they should be able to easily develop and add new elements.
+It should be possible for users to express complex data and UI requirements with `prosemirror-elements`.
 
 #### KPIs
 
-- Possible to implement into a ProseMirror instance quickly
-- Creating new elements can be done by people unfamiliar to ProseMirror
-- Elements with varying requirements and complexity can be implemented using the plugin
+- Feedback from consumers that the plugin has met their data and UI needs
 
-## Agnostic
+### Agnostic
 
-The plugin should have no opinion about the elements that use it. Any complexity necessary to implement an element should be possible without increasing the surface area of the API.
+The plugin should have no opinion about the elements that use it, or how they are displayed. Any complexity necessary to implement an element should be possible without increasing the surface area of the API.
 
 #### KPIs
 
-- Plugin should have no stake in implemented elements
+- Few requests to expand API
+- Possible to use arbitrary UI frameworks
 
-## Collaborative Editing
+### Seamless integration with Prosemirror
 
-The plugin should present no barrier to collaborative editing. Parent instances which implement collaborative editing should provide nested content with similar functionality in all relevant fields.
+Fields modelled in prosemirror-elements should integrate as seamlessly with Prosemirror as possible. Content should be modelled in a way which matches the Prosemirror schema as closely as possible. Marks and decorations from the parent editor should be available in fields that model text. 
+
+The plugin should present no barrier to collaborative editing. Parent instances which implement collaborative editing should be able to provide nested content with similar functionality in all relevant fields.
 
 #### KPIs
 
-- Collaborative editing should be easy to implement
+- Any functionality which depends on marks or decorations, should 'just work'
+- The structure of an element should be easily understandable by inspecting the document content, perhaps with the Prosemirror developer tools
 
-## Accessibility 
+### Accessibility 
 
 While the plugin is agnostic about the elements that use it, it should be easy to create elements that meet our [accessibility standards](https://docs.google.com/document/d/1mCPo4U3U57IC869AKWiEylpGjyRnT5NVYlL8gOkCEOk/edit). 
 
 #### KPIs
 
-- Is it easy to implement new elements that meet our accessibility standard?
+- The elements that are made from this library can be easily made accessible

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,7 +1,7 @@
 # Challenges
 
 1. Nesting arbitrary content within ProseMirror 
-2. Seamlessly Integrating nested ProseMirror rich-text fields with the parent instance
+2. Seamlessly integrating nested ProseMirror rich-text fields with the parent instance
 3. Providing a way to create any possible custom nested element
 4. Abstracting ProseMirror core functionality and  offering a simple interface
 
@@ -30,8 +30,8 @@ Adding the plugin to a new or existing project should be seamless and quickly sh
 #### KPIs
 
 - Possible to implement into a ProseMirror instance quickly
-- Creating new elements can be 
-- Support different requirements
+- Creating new elements can be done by people unfamiliar to ProseMirror
+- Elements with varying requirements and complexity can be implemented using the plugin
 
 ## Agnostic
 
@@ -56,4 +56,3 @@ While the plugin is agnostic about the elements that use it, it should be easy t
 #### KPIs
 
 - Is it easy to implement new elements that meet our accessibility standard?
-


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR adds an initial version of our ProseMirror-Elements vision document. It provides a clear set of challenges, ambition and guiding principals which can be used to help orient the direction of the project.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
When key decisions need to be made, we can refer to this document to see how the different options compare to our guiding principals. It should also provide a clear definition of the problem we are aiming to solve and why.
