### PR TITLE
feat: Only show focus when the user is keyboard navigating, not clicking

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -1,3 +1,4 @@
+import { FocusStyleManager } from "@guardian/src-foundations/utils";
 import type OrderedMap from "orderedmap";
 import { collab } from "prosemirror-collab";
 import { exampleSetup } from "prosemirror-example-setup";
@@ -17,6 +18,10 @@ import { testDecorationPlugin } from "../src/plugin/helpers/test";
 import { CollabServer, EditorConnection } from "./collab/CollabServer";
 import { createSelectionCollabPlugin } from "./collab/SelectionPlugin";
 import { onCropImage, onSelectImage } from "./helpers";
+
+// Only show focus when the user is keyboard navigating, not when
+// they click a text field.
+FocusStyleManager.onlyShowFocusOnTabs();
 
 const {
   plugin: elementPlugin,

--- a/src/editorial-source-components/editor.ts
+++ b/src/editorial-source-components/editor.ts
@@ -1,4 +1,5 @@
 import { css } from "@emotion/react";
+import { background } from "@guardian/src-foundations";
 import { focusHalo } from "@guardian/src-foundations/accessibility";
 import { body } from "@guardian/src-foundations/typography";
 import { inputBorder } from "./inputBorder";
@@ -6,10 +7,13 @@ import { inputBorder } from "./inputBorder";
 export const editor = css`
   ${body.small()}
   .ProseMirror {
-    background-color: #fff;
+    background-color: ${background.primary};
     ${inputBorder}
-  }
-  .ProseMirror-focused {
-    ${focusHalo}
+    &:active {
+      border: 1px solid ${background.inputChecked};
+    }
+    &:focus {
+      ${focusHalo}
+    }
   }
 `;


### PR DESCRIPTION
## What does this change?
This PR makes some small changes to focus style, so that the wide focus ring only shows to users who are keyboard navigating, *not* selecting fields with the mouse.

This is accomplished by adding the Source `FocusStyleManager`, and running `FocusStyleManager.onlyShowFocusOnTabs();`. this only needs to be done once per application - and may also need to be done in applications using our Source-styled Elements.

#### Via mouse:
![2021-07-27 10 27 05](https://user-images.githubusercontent.com/34686302/127130909-e885361a-f3b8-42ef-a3f5-2477c1b9907f.gif)

#### Via keyboard:
![2021-07-27 10 27 44](https://user-images.githubusercontent.com/34686302/127130935-f8adb3ba-bb99-45b9-8533-53b6e05863a7.gif)

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run `yarn start` locally and use the `Element`.

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [X] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [X] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [X] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
