### PR TITLE
fix: Fix Firefox styling problem

### DIFF
--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -68,7 +68,7 @@ const Button = styled("button")`
   font-size: 16px;
   line-height: 1;
   padding: ${space[1]}px;
-  min-width: 32px;
+  width: 32px;
   transition: background-color 0.1s;
   :focus {
     ${focusHalo}


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This styles the sidebar in the element to be an appropriate size in Firefox.

#### Before: 
![image](https://user-images.githubusercontent.com/34686302/127299384-a000c69a-ce64-4efe-a9f7-a8f3ace43be2.png)

#### After:
![image](https://user-images.githubusercontent.com/34686302/127296448-b5fbf26d-5db5-41a6-a631-bd301416fca9.png)

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run `yarn start` and visit https://prosemirror-elements.local.dev-gutools.co.uk/

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [X] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [X] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [X] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
