### PR TITLE
feat: add validation helpers

### DIFF
--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -6,7 +6,7 @@ import { createDropDownField } from "../../plugin/fieldViews/DropdownFieldView";
 import { createDefaultRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import {
-  buildValidator,
+  createValidator,
   htmlMaxLength,
   htmlRequired,
 } from "../../plugin/helpers/validation";
@@ -77,7 +77,7 @@ export const createImageElement = (
         />
       );
     },
-    buildValidator({
+    createValidator({
       altText: [htmlMaxLength(100), htmlRequired()],
       caption: [htmlRequired()],
     }),

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -5,6 +5,7 @@ import type { Option } from "../../plugin/fieldViews/DropdownFieldView";
 import { createDropDownField } from "../../plugin/fieldViews/DropdownFieldView";
 import { createDefaultRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
+import { buildValidator, maxLength, required } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { ImageElementForm } from "./DemoImageElementForm";
 
@@ -57,6 +58,11 @@ export const createImageFields = (
   };
 };
 
+const validator = buildValidator({
+  altText: [maxLength(1), required()],
+  caption: [required()],
+});
+
 export const createImageElement = (
   onSelect: (setSrc: SetMedia) => void,
   onCrop: (mediaId: string, setSrc: SetMedia) => void
@@ -72,11 +78,7 @@ export const createImageElement = (
         />
       );
     },
-    ({ altText }) => {
-      const el = document.createElement("div");
-      el.innerHTML = altText;
-      return el.innerText ? null : { altText: ["Alt tag must be set"] };
-    },
+    validator,
     {
       caption: "",
       useSrc: { value: true },

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -5,7 +5,11 @@ import type { Option } from "../../plugin/fieldViews/DropdownFieldView";
 import { createDropDownField } from "../../plugin/fieldViews/DropdownFieldView";
 import { createDefaultRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
-import { buildValidator, maxLength, required } from "../../plugin/helpers/validation";
+import {
+  buildValidator,
+  htmlMaxLength,
+  htmlRequired,
+} from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { ImageElementForm } from "./DemoImageElementForm";
 
@@ -58,11 +62,6 @@ export const createImageFields = (
   };
 };
 
-const validator = buildValidator({
-  altText: [maxLength(1), required()],
-  caption: [required()],
-});
-
 export const createImageElement = (
   onSelect: (setSrc: SetMedia) => void,
   onCrop: (mediaId: string, setSrc: SetMedia) => void
@@ -78,7 +77,10 @@ export const createImageElement = (
         />
       );
     },
-    validator,
+    buildValidator({
+      altText: [htmlMaxLength(100), htmlRequired()],
+      caption: [htmlRequired()],
+    }),
     {
       caption: "",
       useSrc: { value: true },

--- a/src/plugin/helpers/validation.spec.ts
+++ b/src/plugin/helpers/validation.spec.ts
@@ -1,0 +1,35 @@
+import { buildValidator, maxLength, required } from "./validation";
+
+describe("Validation helpers", () => {
+  describe("buildValidator", () => {
+    it("should receive a validation map, and return the results of validators", () => {
+      const validator = buildValidator({
+        field1: [maxLength(5)],
+        field2: [maxLength(5)],
+      });
+      const result = validator({
+        field1: "OK!",
+        field2: "Not OK!",
+      });
+
+      expect(result).toEqual({
+        field1: [],
+        field2: ["Too long: 7/5"],
+      });
+    });
+
+    it("should receive a validation map, and return the results of multiple validators per field", () => {
+      const validator = buildValidator({
+        field1: [required(), maxLength(5)],
+      });
+
+      const result = validator({
+        field1: "",
+      });
+
+      expect(result).toEqual({
+        field1: ["Required"],
+      });
+    });
+  });
+});

--- a/src/plugin/helpers/validation.spec.ts
+++ b/src/plugin/helpers/validation.spec.ts
@@ -1,9 +1,9 @@
-import { buildValidator, maxLength, required } from "./validation";
+import { createValidator, maxLength, required } from "./validation";
 
 describe("Validation helpers", () => {
   describe("buildValidator", () => {
     it("should receive a validation map, and return the results of validators", () => {
-      const validator = buildValidator({
+      const validator = createValidator({
         field1: [maxLength(5)],
         field2: [maxLength(5)],
       });
@@ -19,7 +19,7 @@ describe("Validation helpers", () => {
     });
 
     it("should receive a validation map, and return the results of multiple validators per field", () => {
-      const validator = buildValidator({
+      const validator = createValidator({
         field1: [required(), maxLength(5)],
       });
 

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -3,7 +3,7 @@ import type { FieldSpec } from "../types/Element";
 
 type Validator = (fieldValue: unknown) => string[];
 
-export const buildValidator = (
+export const createValidator = (
   fieldValidationMap: Record<string, Validator[]>
 ) => <FSpec extends FieldSpec<string>>(
   fieldValues: FieldNameToValueMap<FSpec>

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -1,0 +1,46 @@
+import type { FieldNameToValueMap } from "../fieldViews/helpers";
+import type { FieldSpec } from "../types/Element";
+
+type Validator = (fieldValue: string) => string[];
+
+export const buildValidator = (
+  fieldValidationMap: Record<string, Validator[]>
+) => <FSpec extends FieldSpec<string>>(
+  fieldValues: FieldNameToValueMap<FSpec>
+): Record<string, string[]> => {
+  const errors: Record<string, string[]> = {};
+
+  for (const fieldName in fieldValidationMap) {
+    const validators = fieldValidationMap[fieldName];
+    const value = fieldValues[fieldName];
+    // We've got a field name, and a list of validators
+    // Let's append any errors these validators produce to the errors object
+    const fieldErrors = validators.flatMap((validator) => validator(value));
+    errors[fieldName] = fieldErrors;
+  }
+  return errors;
+};
+
+export const maxLength = (maxLength: number): Validator => (value) => {
+  const el = document.createElement("div");
+  el.innerHTML = value;
+  if (el.innerText.length > maxLength) {
+    return [`Too long: ${el.innerText.length}/${maxLength}`];
+  }
+  return [];
+};
+
+export const required = (): Validator => (value) => {
+  const el = document.createElement("div");
+  el.innerHTML = value;
+  if (!el.innerText.length) {
+    return ["Required"];
+  }
+  return [];
+};
+
+// What happens when we're dealing with different element types, for example, RichText vs Text
+// need a different treatment for their data types. Can we pass in the Field declaration to have
+// them do the right thing, contextually.
+
+// We've got a typeerror! Can we fix it?

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -1,7 +1,7 @@
 import type { FieldNameToValueMap } from "../fieldViews/helpers";
 import type { FieldSpec } from "../types/Element";
 
-type Validator = (fieldValue: string) => string[];
+type Validator = (fieldValue: unknown) => string[];
 
 export const buildValidator = (
   fieldValidationMap: Record<string, Validator[]>
@@ -13,15 +13,16 @@ export const buildValidator = (
   for (const fieldName in fieldValidationMap) {
     const validators = fieldValidationMap[fieldName];
     const value = fieldValues[fieldName];
-    // We've got a field name, and a list of validators
-    // Let's append any errors these validators produce to the errors object
     const fieldErrors = validators.flatMap((validator) => validator(value));
     errors[fieldName] = fieldErrors;
   }
   return errors;
 };
 
-export const maxLength = (maxLength: number): Validator => (value) => {
+export const htmlMaxLength = (maxLength: number): Validator => (value) => {
+  if (typeof value !== "string") {
+    throw new Error(`[htmlMaxLength]: value is not of type string`);
+  }
   const el = document.createElement("div");
   el.innerHTML = value;
   if (el.innerText.length > maxLength) {
@@ -30,7 +31,20 @@ export const maxLength = (maxLength: number): Validator => (value) => {
   return [];
 };
 
-export const required = (): Validator => (value) => {
+export const maxLength = (maxLength: number): Validator => (value) => {
+  if (typeof value !== "string") {
+    throw new Error(`[maxLength]: value is not of type string`);
+  }
+  if (value.length > maxLength) {
+    return [`Too long: ${value.length}/${maxLength}`];
+  }
+  return [];
+};
+
+export const htmlRequired = (): Validator => (value) => {
+  if (typeof value !== "string") {
+    throw new Error(`[maxLength]: value is not of type string`);
+  }
   const el = document.createElement("div");
   el.innerHTML = value;
   if (!el.innerText.length) {
@@ -39,8 +53,12 @@ export const required = (): Validator => (value) => {
   return [];
 };
 
-// What happens when we're dealing with different element types, for example, RichText vs Text
-// need a different treatment for their data types. Can we pass in the Field declaration to have
-// them do the right thing, contextually.
-
-// We've got a typeerror! Can we fix it?
+export const required = (): Validator => (value) => {
+  if (typeof value !== "string") {
+    throw new Error(`[maxLength]: value is not of type string`);
+  }
+  if (!value.length) {
+    return ["Required"];
+  }
+  return [];
+};


### PR DESCRIPTION
_co-authored-with: @dskamiotis, @rhystmills_  

## What does this change?

Adds a validation helper function that allows the user to compose validators against fields. This should make common validation tasks easier to express.

## How to test

- The unit tests should pass. The new unit tests should adequately demonstrate the helper's behaviour.
- The validation applied to the demo element should work as expected – take a look at the `DemoImageElement` declaration, and compare it to the runtime behaviour.

## How can we measure success?

We have an easier time expressing validation with new elements.
