### PR TITLE
feat: spruce validation UI

### DIFF
--- a/src/editorial-source-components/Error.tsx
+++ b/src/editorial-source-components/Error.tsx
@@ -1,0 +1,18 @@
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+import { space, text } from "@guardian/src-foundations";
+import { textSans } from "@guardian/src-foundations/typography";
+
+export const errorStyles = css`
+  ${textSans.small({ lineHeight: "loose" })}
+  font-family: "Guardian Agate Sans";
+  margin-top: ${space[2]}px;
+  margin-bottom: ${space[2]}px;
+  display: block;
+  margin-left: auto;
+  color: ${text.error};
+`;
+
+export const Error = styled.div`
+  ${errorStyles}
+`;

--- a/src/editorial-source-components/Field.tsx
+++ b/src/editorial-source-components/Field.tsx
@@ -1,0 +1,20 @@
+import type {
+  FieldViewSpec,
+  NonCustomFieldViews,
+} from "../plugin/types/Element";
+import { FieldView } from "../renderers/react/FieldView";
+import { InputGroup } from "./InputGroup";
+import { InputHeading } from "./InputHeading";
+
+type Props = {
+  fieldViewSpec: FieldViewSpec<NonCustomFieldViews>;
+  errors: string[];
+  label: string;
+};
+
+export const Field = ({ fieldViewSpec, errors, label }: Props) => (
+  <InputGroup>
+    <InputHeading label={label} errors={errors} />
+    <FieldView fieldViewSpec={fieldViewSpec} hasErrors={!!errors.length} />
+  </InputGroup>
+);

--- a/src/editorial-source-components/InputGroup.tsx
+++ b/src/editorial-source-components/InputGroup.tsx
@@ -1,0 +1,7 @@
+import styled from "@emotion/styled";
+import { space } from "@guardian/src-foundations";
+
+export const InputGroup = styled.div`
+  margin-top: ${space[2]}px;
+  margin-bottom: ${space[2]}px;
+`;

--- a/src/editorial-source-components/InputHeading.tsx
+++ b/src/editorial-source-components/InputHeading.tsx
@@ -1,0 +1,22 @@
+import styled from "@emotion/styled";
+import { Error } from "./Error";
+import { Label } from "./Label";
+
+const InputHeadingContainer = styled.div`
+  display: flex;
+`;
+
+const Errors = ({ errors }: { errors: string[] }) =>
+  !errors.length ? null : <Error>{errors.join(", ")}</Error>;
+
+type Props = {
+  label: string;
+  errors: string[];
+};
+
+export const InputHeading = ({ label, errors }: Props) => (
+  <InputHeadingContainer>
+    <Label>{label}</Label>
+    <Errors errors={errors} />
+  </InputHeadingContainer>
+);

--- a/src/editorial-source-components/editor.ts
+++ b/src/editorial-source-components/editor.ts
@@ -1,14 +1,15 @@
-import { css } from "@emotion/react";
-import { background } from "@guardian/src-foundations";
+import styled from "@emotion/styled";
+import { background, border } from "@guardian/src-foundations";
 import { focusHalo } from "@guardian/src-foundations/accessibility";
 import { body } from "@guardian/src-foundations/typography";
 import { inputBorder } from "./inputBorder";
 
-export const editor = css`
+export const Editor = styled.div<{ hasErrors: boolean }>`
   ${body.small()}
   .ProseMirror {
     background-color: ${background.primary};
     ${inputBorder}
+    ${({ hasErrors }) => !!hasErrors && `border-color: ${border.error};`}
     &:active {
       border: 1px solid ${background.inputChecked};
     }

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -73,7 +73,7 @@ export const createImageElement = (
         <ImageElementForm
           fields={fields}
           errors={errors}
-          fieldViewSpecMap={fieldViewSpecs}
+          fieldViewSpecs={fieldViewSpecs}
         />
       );
     },

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -6,7 +6,7 @@ import { createDropDownField } from "../../plugin/fieldViews/DropdownFieldView";
 import { createDefaultRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import {
-  buildValidator,
+  createValidator,
   htmlMaxLength,
   htmlRequired,
 } from "../../plugin/helpers/validation";
@@ -77,7 +77,7 @@ export const createImageElement = (
         />
       );
     },
-    buildValidator({
+    createValidator({
       altText: [htmlMaxLength(100), htmlRequired()],
       caption: [htmlRequired()],
     }),

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -5,6 +5,7 @@ import type { Option } from "../../plugin/fieldViews/DropdownFieldView";
 import { createDropDownField } from "../../plugin/fieldViews/DropdownFieldView";
 import { createDefaultRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
+import { buildValidator, maxLength, required } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { ImageElementForm } from "./DemoImageElementForm";
 
@@ -57,6 +58,11 @@ export const createImageFields = (
   };
 };
 
+const validator = buildValidator({
+  altText: [maxLength(1), required()],
+  caption: [required()],
+});
+
 export const createImageElement = (
   onSelect: (setSrc: SetMedia) => void,
   onCrop: (mediaId: string, setSrc: SetMedia) => void
@@ -72,11 +78,7 @@ export const createImageElement = (
         />
       );
     },
-    ({ altText }) => {
-      const el = document.createElement("div");
-      el.innerHTML = altText;
-      return el.innerText ? null : { altText: ["Alt tag must be set"] };
-    },
+    validator,
     {
       caption: "",
       useSrc: { value: true },

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -5,7 +5,11 @@ import type { Option } from "../../plugin/fieldViews/DropdownFieldView";
 import { createDropDownField } from "../../plugin/fieldViews/DropdownFieldView";
 import { createDefaultRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
-import { buildValidator, maxLength, required } from "../../plugin/helpers/validation";
+import {
+  buildValidator,
+  htmlMaxLength,
+  htmlRequired,
+} from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { ImageElementForm } from "./DemoImageElementForm";
 
@@ -58,11 +62,6 @@ export const createImageFields = (
   };
 };
 
-const validator = buildValidator({
-  altText: [maxLength(1), required()],
-  caption: [required()],
-});
-
 export const createImageElement = (
   onSelect: (setSrc: SetMedia) => void,
   onCrop: (mediaId: string, setSrc: SetMedia) => void
@@ -78,7 +77,10 @@ export const createImageElement = (
         />
       );
     },
-    validator,
+    buildValidator({
+      altText: [htmlMaxLength(100), htmlRequired()],
+      caption: [htmlRequired()],
+    }),
     {
       caption: "",
       useSrc: { value: true },

--- a/src/elements/demo-image/DemoImageElementForm.tsx
+++ b/src/elements/demo-image/DemoImageElementForm.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { CustomDropdown } from "../../editorial-source-components/CustomDropdown";
+import { Field } from "../../editorial-source-components/Field";
 import { Label } from "../../editorial-source-components/Label";
 import type { Option } from "../../plugin/fieldViews/DropdownFieldView";
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
@@ -7,14 +8,14 @@ import type {
   CustomFieldViewSpec,
   FieldNameToFieldViewSpec,
 } from "../../plugin/types/Element";
-import { FieldView, getFieldViewTestId } from "../../renderers/react/FieldView";
+import { getFieldViewTestId } from "../../renderers/react/FieldView";
 import { useCustomFieldViewState } from "../../renderers/react/useCustomFieldViewState";
 import type { createImageFields, SetMedia } from "./DemoImageElement";
 
 type Props = {
   fields: FieldNameToValueMap<ReturnType<typeof createImageFields>>;
   errors: Record<string, string[]>;
-  fieldViewSpecMap: FieldNameToFieldViewSpec<
+  fieldViewSpecs: FieldNameToFieldViewSpec<
     ReturnType<typeof createImageFields>
   >;
 };
@@ -24,14 +25,30 @@ export const ImageElementTestId = "ImageElement";
 export const ImageElementForm: React.FunctionComponent<Props> = ({
   fields,
   errors,
-  fieldViewSpecMap: fieldViewSpecs,
+  fieldViewSpecs,
 }) => (
   <div data-cy={ImageElementTestId}>
-    <FieldView fieldViewSpec={fieldViewSpecs.caption} />
-    <FieldView fieldViewSpec={fieldViewSpecs.altText} />
-    <FieldView fieldViewSpec={fieldViewSpecs.src} />
-    <FieldView fieldViewSpec={fieldViewSpecs.useSrc} />
-    <FieldView fieldViewSpec={fieldViewSpecs.optionDropdown} />
+    <Field
+      label="Caption"
+      fieldViewSpec={fieldViewSpecs.caption}
+      errors={errors.caption}
+    />
+    <Field
+      label="Alt text"
+      fieldViewSpec={fieldViewSpecs.altText}
+      errors={errors.altText}
+    />
+    <Field label="Src" fieldViewSpec={fieldViewSpecs.src} errors={errors.src} />
+    <Field
+      label="Use image source?"
+      fieldViewSpec={fieldViewSpecs.useSrc}
+      errors={errors.useSrc}
+    />
+    <Field
+      label="Options"
+      fieldViewSpec={fieldViewSpecs.optionDropdown}
+      errors={errors.optionDropdown}
+    />
     <ImageView fieldViewSpec={fieldViewSpecs.mainImage} />
     <CustomDropdownView fieldViewSpec={fieldViewSpecs.customDropdown} />
     <hr />

--- a/src/plugin/fieldViews/helpers.ts
+++ b/src/plugin/fieldViews/helpers.ts
@@ -52,6 +52,6 @@ export type FieldTypeToValueMap<
  *
  * `{ altText: string }, { isVisible: { value: boolean }}`
  */
-export type FieldNameToValueMap<FSpec extends FieldSpec<string>> = {
+export type FieldNameToValueMap<FSpec extends FieldSpec<keyof FSpec>> = {
   [Name in keyof FSpec]: FieldTypeToValueMap<FSpec, Name>[FSpec[Name]["type"]];
 };

--- a/src/plugin/helpers/validation.spec.ts
+++ b/src/plugin/helpers/validation.spec.ts
@@ -1,0 +1,35 @@
+import { buildValidator, maxLength, required } from "./validation";
+
+describe("Validation helpers", () => {
+  describe("buildValidator", () => {
+    it("should receive a validation map, and return the results of validators", () => {
+      const validator = buildValidator({
+        field1: [maxLength(5)],
+        field2: [maxLength(5)],
+      });
+      const result = validator({
+        field1: "OK!",
+        field2: "Not OK!",
+      });
+
+      expect(result).toEqual({
+        field1: [],
+        field2: ["Too long: 7/5"],
+      });
+    });
+
+    it("should receive a validation map, and return the results of multiple validators per field", () => {
+      const validator = buildValidator({
+        field1: [required(), maxLength(5)],
+      });
+
+      const result = validator({
+        field1: "",
+      });
+
+      expect(result).toEqual({
+        field1: ["Required"],
+      });
+    });
+  });
+});

--- a/src/plugin/helpers/validation.spec.ts
+++ b/src/plugin/helpers/validation.spec.ts
@@ -1,9 +1,9 @@
-import { buildValidator, maxLength, required } from "./validation";
+import { createValidator, maxLength, required } from "./validation";
 
 describe("Validation helpers", () => {
   describe("buildValidator", () => {
     it("should receive a validation map, and return the results of validators", () => {
-      const validator = buildValidator({
+      const validator = createValidator({
         field1: [maxLength(5)],
         field2: [maxLength(5)],
       });
@@ -19,7 +19,7 @@ describe("Validation helpers", () => {
     });
 
     it("should receive a validation map, and return the results of multiple validators per field", () => {
-      const validator = buildValidator({
+      const validator = createValidator({
         field1: [required(), maxLength(5)],
       });
 

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -3,7 +3,7 @@ import type { FieldSpec } from "../types/Element";
 
 type Validator = (fieldValue: unknown) => string[];
 
-export const buildValidator = (
+export const createValidator = (
   fieldValidationMap: Record<string, Validator[]>
 ) => <FSpec extends FieldSpec<string>>(
   fieldValues: FieldNameToValueMap<FSpec>

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -1,0 +1,46 @@
+import type { FieldNameToValueMap } from "../fieldViews/helpers";
+import type { FieldSpec } from "../types/Element";
+
+type Validator = (fieldValue: string) => string[];
+
+export const buildValidator = (
+  fieldValidationMap: Record<string, Validator[]>
+) => <FSpec extends FieldSpec<string>>(
+  fieldValues: FieldNameToValueMap<FSpec>
+): Record<string, string[]> => {
+  const errors: Record<string, string[]> = {};
+
+  for (const fieldName in fieldValidationMap) {
+    const validators = fieldValidationMap[fieldName];
+    const value = fieldValues[fieldName];
+    // We've got a field name, and a list of validators
+    // Let's append any errors these validators produce to the errors object
+    const fieldErrors = validators.flatMap((validator) => validator(value));
+    errors[fieldName] = fieldErrors;
+  }
+  return errors;
+};
+
+export const maxLength = (maxLength: number): Validator => (value) => {
+  const el = document.createElement("div");
+  el.innerHTML = value;
+  if (el.innerText.length > maxLength) {
+    return [`Too long: ${el.innerText.length}/${maxLength}`];
+  }
+  return [];
+};
+
+export const required = (): Validator => (value) => {
+  const el = document.createElement("div");
+  el.innerHTML = value;
+  if (!el.innerText.length) {
+    return ["Required"];
+  }
+  return [];
+};
+
+// What happens when we're dealing with different element types, for example, RichText vs Text
+// need a different treatment for their data types. Can we pass in the Field declaration to have
+// them do the right thing, contextually.
+
+// We've got a typeerror! Can we fix it?

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -1,7 +1,7 @@
 import type { FieldNameToValueMap } from "../fieldViews/helpers";
 import type { FieldSpec } from "../types/Element";
 
-type Validator = (fieldValue: string) => string[];
+type Validator = (fieldValue: unknown) => string[];
 
 export const buildValidator = (
   fieldValidationMap: Record<string, Validator[]>
@@ -13,15 +13,16 @@ export const buildValidator = (
   for (const fieldName in fieldValidationMap) {
     const validators = fieldValidationMap[fieldName];
     const value = fieldValues[fieldName];
-    // We've got a field name, and a list of validators
-    // Let's append any errors these validators produce to the errors object
     const fieldErrors = validators.flatMap((validator) => validator(value));
     errors[fieldName] = fieldErrors;
   }
   return errors;
 };
 
-export const maxLength = (maxLength: number): Validator => (value) => {
+export const htmlMaxLength = (maxLength: number): Validator => (value) => {
+  if (typeof value !== "string") {
+    throw new Error(`[htmlMaxLength]: value is not of type string`);
+  }
   const el = document.createElement("div");
   el.innerHTML = value;
   if (el.innerText.length > maxLength) {
@@ -30,7 +31,20 @@ export const maxLength = (maxLength: number): Validator => (value) => {
   return [];
 };
 
-export const required = (): Validator => (value) => {
+export const maxLength = (maxLength: number): Validator => (value) => {
+  if (typeof value !== "string") {
+    throw new Error(`[maxLength]: value is not of type string`);
+  }
+  if (value.length > maxLength) {
+    return [`Too long: ${value.length}/${maxLength}`];
+  }
+  return [];
+};
+
+export const htmlRequired = (): Validator => (value) => {
+  if (typeof value !== "string") {
+    throw new Error(`[maxLength]: value is not of type string`);
+  }
   const el = document.createElement("div");
   el.innerHTML = value;
   if (!el.innerText.length) {
@@ -39,8 +53,12 @@ export const required = (): Validator => (value) => {
   return [];
 };
 
-// What happens when we're dealing with different element types, for example, RichText vs Text
-// need a different treatment for their data types. Can we pass in the Field declaration to have
-// them do the right thing, contextually.
-
-// We've got a typeerror! Can we fix it?
+export const required = (): Validator => (value) => {
+  if (typeof value !== "string") {
+    throw new Error(`[maxLength]: value is not of type string`);
+  }
+  if (!value.length) {
+    return ["Required"];
+  }
+  return [];
+};

--- a/src/plugin/types/Element.ts
+++ b/src/plugin/types/Element.ts
@@ -42,6 +42,12 @@ export type FieldViews =
   | CustomFieldView
   | DropdownFieldView;
 
+export type NonCustomFieldViews =
+  | TextFieldView
+  | RichTextFieldView
+  | CheckboxFieldView
+  | DropdownFieldView;
+
 export type FieldViewSpec<FieldView extends FieldViews> = {
   fieldView: FieldView;
   fieldSpec: Field;

--- a/src/renderers/react/ElementProvider.tsx
+++ b/src/renderers/react/ElementProvider.tsx
@@ -99,7 +99,7 @@ export class ElementProvider<FSpec extends FieldSpec<string>> extends Component<
       this.props.validate(this.state.fieldValues)
     );
     return (
-      <ElementWrapper name="Image" {...this.state.commands}>
+      <ElementWrapper {...this.state.commands}>
         {this.props.consumer(
           this.state.fieldValues,
           errors,

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -3,7 +3,6 @@ import styled from "@emotion/styled";
 import { space } from "@guardian/src-foundations";
 import { focusHalo } from "@guardian/src-foundations/accessibility";
 import { neutral } from "@guardian/src-foundations/palette";
-import { textSans } from "@guardian/src-foundations/typography";
 import {
   SvgArrowDownStraight,
   SvgArrowUpStraight,
@@ -16,16 +15,6 @@ import type { CommandCreator } from "../../plugin/types/Commands";
 
 const Container = styled("div")`
   margin: ${space[3]}px 0;
-`;
-
-const Header = styled("div")`
-  border-bottom: 1px solid ${neutral[86]};
-  padding-left: ${space[3]}px;
-  margin-top: ${space[3]}px;
-`;
-
-const Title = styled("h2")`
-  ${textSans.large({ fontWeight: "bold" })}
 `;
 
 const Body = styled("div")`
@@ -46,7 +35,8 @@ const Panel = styled("div")`
   background: ${neutral[97]};
   flex-grow: 1;
   overflow: hidden;
-  padding: ${space[3]}px;
+  padding-left: ${space[3]}px;
+  padding-right: ${space[3]}px;
 `;
 
 const Actions = styled("div")`
@@ -102,7 +92,6 @@ const Button = styled("button")`
 `;
 
 type Props = {
-  name: string;
   children?: ReactElement;
 } & ReturnType<CommandCreator>;
 
@@ -114,7 +103,6 @@ export const moveDownTestId = "ElementWrapper__moveDown";
 export const removeTestId = "ElementWrapper__remove";
 
 export const ElementWrapper: React.FunctionComponent<Props> = ({
-  name,
   moveUp,
   moveDown,
   moveTop,
@@ -124,12 +112,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
 }) => (
   <Container data-cy={elementWrapperTestId}>
     <Body>
-      <Panel>
-        <Header>
-          <Title>{name}</Title>
-        </Header>
-        {children}
-      </Panel>
+      <Panel>{children}</Panel>
       <Actions className="actions">
         <Button
           data-cy={moveTopTestId}

--- a/src/renderers/react/FieldView.tsx
+++ b/src/renderers/react/FieldView.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import { editor } from "../../editorial-source-components/editor";
-import { Label } from "../../editorial-source-components/Label";
+import { Editor } from "../../editorial-source-components/Editor";
 import type { CheckboxFieldView } from "../../plugin/fieldViews/CheckboxFieldView";
 import type { DropdownFieldView } from "../../plugin/fieldViews/DropdownFieldView";
 import type { RichTextFieldView } from "../../plugin/fieldViews/RichTextFieldView";
@@ -11,12 +10,14 @@ type Props = {
   fieldViewSpec: FieldViewSpec<
     TextFieldView | RichTextFieldView | CheckboxFieldView | DropdownFieldView
   >;
+  hasErrors?: boolean;
 };
 
 export const getFieldViewTestId = (name: string) => `FieldView-${name}`;
 
 export const FieldView: React.FunctionComponent<Props> = ({
   fieldViewSpec,
+  hasErrors = false,
 }) => {
   const editorRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -27,9 +28,10 @@ export const FieldView: React.FunctionComponent<Props> = ({
   }, []);
 
   return (
-    <div data-cy={getFieldViewTestId(fieldViewSpec.name)}>
-      <Label>{fieldViewSpec.name}</Label>
-      <div css={editor} ref={editorRef}></div>
-    </div>
+    <Editor
+      hasErrors={hasErrors}
+      data-cy={getFieldViewTestId(fieldViewSpec.name)}
+      ref={editorRef}
+    ></Editor>
   );
 };


### PR DESCRIPTION
## What does this change?

Gives us some common components to express error messages in the UI.

I haven't altered our custom components, as I'm aware that there may be changes needed downstream, but hopefully the `Field` component contains a template to work from.

Before:

<img width="816" alt="Screenshot 2021-08-04 at 17 45 54" src="https://user-images.githubusercontent.com/7767575/128221262-9cdda0bd-f424-483f-8c69-92f5695cd4d3.png">

After (note more readable labels, validation message and highlighting, consistent margins):

<img width="816" alt="Screenshot 2021-08-04 at 17 47 05" src="https://user-images.githubusercontent.com/7767575/128221372-0a046cc1-998c-4484-a500-6f035a796f64.png">

## How to test

Do the changes look OK? Do the components look reusable for other elements?

## Accessibility

- [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398) – this wasn't easy, are there ways to make error-reporting clearer to screen readers?
- [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f) – **interesting, can we express 'error-ness' another way here?**
