### PR TITLE
feat: Add API to programmatically update fields

### DIFF
--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -1,3 +1,4 @@
+import { UpdateAltTextButtonId } from "../../src/elements/demo-image/DemoImageElementForm";
 import {
   addElement,
   assertDocHtml,
@@ -6,6 +7,7 @@ import {
   getElementMenuButton,
   getElementRichTextField,
   getSerialisedHtml,
+  selectDataCy,
   typeIntoElementField,
   visitRoot,
 } from "../helpers/editor";
@@ -213,6 +215,17 @@ describe("ImageElement", () => {
         addElement();
         getElementField("customDropdown").find("select").select("opt2");
         assertDocHtml(getSerialisedHtml({ customDropdownValue: "opt2" }));
+      });
+    });
+
+    describe("Programmatically update fields", () => {
+      it("should revert the alt text to 'Default alt text' when the button is clicked", () => {
+        addElement();
+        cy.get(`button${selectDataCy(UpdateAltTextButtonId)}`).click();
+        getElementRichTextField("altText").should(
+          "have.text",
+          "Default alt text"
+        );
       });
     });
   });

--- a/demo/helpers.ts
+++ b/demo/helpers.ts
@@ -6,6 +6,9 @@ export const onGridMessage = (setMedia: SetMedia, modal: HTMLElement) => ({
   data: {
     image: {
       data: {
+        metadata: {
+          description: string;
+        };
         id: string;
       };
     };
@@ -23,7 +26,8 @@ export const onGridMessage = (setMedia: SetMedia, modal: HTMLElement) => ({
   setMedia(
     data.image.data.id,
     data.crop.data.specification.uri,
-    data.crop.data.assets.map((_) => _.secureUrl)
+    data.crop.data.assets.map((_) => _.secureUrl),
+    data.image.data.metadata.description
   );
 };
 

--- a/src/editorial-source-components/Field.tsx
+++ b/src/editorial-source-components/Field.tsx
@@ -1,18 +1,20 @@
-import type {
-  FieldViewSpec,
-  NonCustomFieldViews,
-} from "../plugin/types/Element";
+import type { FieldView as TFieldView } from "../plugin/fieldViews/FieldView";
+import type { FieldViewSpec } from "../plugin/types/Element";
 import { FieldView } from "../renderers/react/FieldView";
 import { InputGroup } from "./InputGroup";
 import { InputHeading } from "./InputHeading";
 
-type Props = {
-  fieldViewSpec: FieldViewSpec<NonCustomFieldViews>;
+type Props<F> = {
+  fieldViewSpec: F;
   errors: string[];
   label: string;
 };
 
-export const Field = ({ fieldViewSpec, errors, label }: Props) => (
+export const Field = <F extends FieldViewSpec<TFieldView<unknown>>>({
+  fieldViewSpec,
+  errors,
+  label,
+}: Props<F>) => (
   <InputGroup>
     <InputHeading label={label} errors={errors} />
     <FieldView fieldViewSpec={fieldViewSpec} hasErrors={!!errors.length} />

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -16,7 +16,8 @@ import { ImageElementForm } from "./DemoImageElementForm";
 export type SetMedia = (
   mediaId: string,
   mediaApiUri: string,
-  assets: string[]
+  assets: string[],
+  caption: string
 ) => void;
 
 type ImageField = {

--- a/src/elements/demo-image/DemoImageElementForm.tsx
+++ b/src/elements/demo-image/DemoImageElementForm.tsx
@@ -49,7 +49,13 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
       fieldViewSpec={fieldViewSpecs.optionDropdown}
       errors={errors.optionDropdown}
     />
-    <ImageView fieldViewSpec={fieldViewSpecs.mainImage} />
+    <ImageView
+      fieldViewSpec={fieldViewSpecs.mainImage}
+      onChange={(_, __, ___, description) => {
+        fieldViewSpecs.altText.update(description);
+        fieldViewSpecs.caption.update(description);
+      }}
+    />
     <CustomDropdownView fieldViewSpec={fieldViewSpecs.customDropdown} />
     <hr />
     <Label>Element errors</Label>
@@ -61,6 +67,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
 );
 
 type ImageViewProps = {
+  onChange: SetMedia;
   fieldViewSpec: CustomFieldViewSpec<
     {
       mediaId?: string;
@@ -74,15 +81,21 @@ type ImageViewProps = {
   >;
 };
 
-const ImageView = ({ fieldViewSpec }: ImageViewProps) => {
+const ImageView = ({ fieldViewSpec, onChange }: ImageViewProps) => {
   const [imageFields, setImageFieldsRef] = useCustomFieldViewState(
     fieldViewSpec
   );
 
-  const setMedia = (mediaId: string, mediaApiUri: string, assets: string[]) => {
+  const setMedia = (
+    mediaId: string,
+    mediaApiUri: string,
+    assets: string[],
+    description: string
+  ) => {
     if (setImageFieldsRef.current) {
       setImageFieldsRef.current({ mediaId, mediaApiUri, assets });
     }
+    onChange(mediaId, mediaApiUri, assets, description);
   };
 
   return (

--- a/src/elements/demo-image/DemoImageElementForm.tsx
+++ b/src/elements/demo-image/DemoImageElementForm.tsx
@@ -21,6 +21,7 @@ type Props = {
 };
 
 export const ImageElementTestId = "ImageElement";
+export const UpdateAltTextButtonId = "UpdateAltTextButton";
 
 export const ImageElementForm: React.FunctionComponent<Props> = ({
   fields,
@@ -38,8 +39,11 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
       fieldViewSpec={fieldViewSpecs.altText}
       errors={errors.altText}
     />
-    <button onClick={() => fieldViewSpecs.altText.update("")}>
-      Clear alt text
+    <button
+      data-cy={UpdateAltTextButtonId}
+      onClick={() => fieldViewSpecs.altText.update("Default alt text")}
+    >
+      Programmatically update alt text
     </button>
     <Field label="Src" fieldViewSpec={fieldViewSpecs.src} errors={errors.src} />
     <Field

--- a/src/elements/demo-image/DemoImageElementForm.tsx
+++ b/src/elements/demo-image/DemoImageElementForm.tsx
@@ -38,6 +38,9 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
       fieldViewSpec={fieldViewSpecs.altText}
       errors={errors.altText}
     />
+    <button onClick={() => fieldViewSpecs.altText.update("")}>
+      Clear alt text
+    </button>
     <Field label="Src" fieldViewSpec={fieldViewSpecs.src} errors={errors.src} />
     <Field
       label="Use image source?"

--- a/src/plugin/fieldViews/AttributeFieldView.ts
+++ b/src/plugin/fieldViews/AttributeFieldView.ts
@@ -42,7 +42,7 @@ export abstract class AttributeFieldView<Fields extends unknown>
 
   protected abstract updateInnerView(fields: Fields): void;
 
-  public update(node: Node, elementOffset: number) {
+  public onUpdate(node: Node, elementOffset: number) {
     if (node.type !== this.nodeType) {
       return false;
     }
@@ -51,6 +51,10 @@ export abstract class AttributeFieldView<Fields extends unknown>
     this.updateInnerView(node.attrs.fields as Fields);
 
     return true;
+  }
+
+  public update(value: Fields) {
+    this.updateOuterEditor(value);
   }
 
   public destroy() {

--- a/src/plugin/fieldViews/AttributeFieldView.ts
+++ b/src/plugin/fieldViews/AttributeFieldView.ts
@@ -6,8 +6,8 @@ import { FieldType } from "./FieldView";
 /**
  * A FieldView representing a node that contains fields that are updated atomically.
  */
-export abstract class AttributeFieldView<Fields extends unknown>
-  implements FieldView<Fields> {
+export abstract class AttributeFieldView<Value extends unknown>
+  implements FieldView<Value> {
   public static fieldName: string;
   public static fieldType = FieldType.ATTRIBUTES;
   // The parent DOM element for this view. Public
@@ -28,19 +28,19 @@ export abstract class AttributeFieldView<Fields extends unknown>
     this.nodeType = node.type;
   }
 
-  public getNodeValue(node: Node): Fields {
-    return node.attrs.fields as Fields;
+  public getNodeValue(node: Node): Value {
+    return node.attrs.fields as Value;
   }
 
-  public getNodeFromValue(fields: Fields): Node {
+  public getNodeFromValue(fields: Value): Node {
     return this.nodeType.create({ fields });
   }
 
   // Classes extending AttributeFieldView should call e.g. this.createInnerView(node.attrs.fields || defaultFields)
   // in their constructor
-  protected abstract createInnerView(fields: Fields): void;
+  protected abstract createInnerView(fields: Value): void;
 
-  protected abstract updateInnerView(fields: Fields): void;
+  protected abstract updateInnerView(fields: Value): void;
 
   public onUpdate(node: Node, elementOffset: number) {
     if (node.type !== this.nodeType) {
@@ -48,12 +48,12 @@ export abstract class AttributeFieldView<Fields extends unknown>
     }
 
     this.offset = elementOffset;
-    this.updateInnerView(node.attrs.fields as Fields);
+    this.updateInnerView(node.attrs.fields as Value);
 
     return true;
   }
 
-  public update(value: Fields) {
+  public update(value: Value) {
     this.updateOuterEditor(value);
   }
 
@@ -64,7 +64,7 @@ export abstract class AttributeFieldView<Fields extends unknown>
   /**
    * Update the outer editor with a new field state.
    */
-  protected updateOuterEditor(fields: Fields) {
+  protected updateOuterEditor(fields: Value) {
     const outerTr = this.outerView.state.tr;
     // When we insert content, we must offset to account for a few things:
     //  - getPos() returns the position directly before the parent node (+1)

--- a/src/plugin/fieldViews/CustomFieldView.ts
+++ b/src/plugin/fieldViews/CustomFieldView.ts
@@ -77,7 +77,7 @@ export class CustomFieldView<CustomFieldValue = unknown>
     this.subscribers.splice(subscriberIndex, 1);
   }
 
-  public update(node: Node, elementOffset: number) {
+  public onUpdate(node: Node, elementOffset: number) {
     if (node.type !== this.node.type) {
       return false;
     }
@@ -87,6 +87,10 @@ export class CustomFieldView<CustomFieldValue = unknown>
     this.updateSubscribers(node.attrs.fields as CustomFieldValue);
 
     return true;
+  }
+
+  public update(value: CustomFieldValue) {
+    this.updateOuterEditor(value);
   }
 
   public destroy() {

--- a/src/plugin/fieldViews/CustomFieldView.ts
+++ b/src/plugin/fieldViews/CustomFieldView.ts
@@ -30,13 +30,12 @@ type Subscriber<Fields extends unknown> = (fields: Fields) => void;
  * state changes. In this way, consuming code can manage state and UI changes itself,
  * perhaps in its own renderer format.
  */
-export class CustomFieldView<CustomFieldValue = unknown>
-  implements FieldView<CustomFieldValue> {
+export class CustomFieldView<Value = unknown> implements FieldView<Value> {
   public static fieldName = "custom" as const;
   public static fieldType = FieldType.ATTRIBUTES;
   public static defaultValue = undefined;
 
-  private subscribers: Array<Subscriber<CustomFieldValue>> = [];
+  private subscribers: Array<Subscriber<Value>> = [];
 
   constructor(
     // The node that this FieldView is responsible for rendering.
@@ -49,24 +48,24 @@ export class CustomFieldView<CustomFieldValue = unknown>
     protected offset: number
   ) {}
 
-  public getNodeValue(node: Node): CustomFieldValue {
-    return node.attrs.fields as CustomFieldValue;
+  public getNodeValue(node: Node): Value {
+    return node.attrs.fields as Value;
   }
 
-  public getNodeFromValue(fields: CustomFieldValue): Node {
+  public getNodeFromValue(fields: Value): Node {
     return this.node.type.create({ fields });
   }
 
   /**
    * @returns A function that can be called to update the node fields.
    */
-  public subscribe(subscriber: Subscriber<CustomFieldValue>) {
+  public subscribe(subscriber: Subscriber<Value>) {
     this.subscribers.push(subscriber);
-    subscriber(this.node.attrs.fields as CustomFieldValue);
-    return (fields: CustomFieldValue) => this.updateOuterEditor(fields);
+    subscriber(this.node.attrs.fields as Value);
+    return (fields: Value) => this.updateOuterEditor(fields);
   }
 
-  public unsubscribe(subscriber: Subscriber<CustomFieldValue>) {
+  public unsubscribe(subscriber: Subscriber<Value>) {
     const subscriberIndex = this.subscribers.indexOf(subscriber);
     if (subscriberIndex === -1) {
       console.error(
@@ -84,12 +83,12 @@ export class CustomFieldView<CustomFieldValue = unknown>
 
     this.offset = elementOffset;
 
-    this.updateSubscribers(node.attrs.fields as CustomFieldValue);
+    this.updateSubscribers(node.attrs.fields as Value);
 
     return true;
   }
 
-  public update(value: CustomFieldValue) {
+  public update(value: Value) {
     this.updateOuterEditor(value);
   }
 
@@ -97,7 +96,7 @@ export class CustomFieldView<CustomFieldValue = unknown>
     this.subscribers = [];
   }
 
-  private updateSubscribers(fields: CustomFieldValue) {
+  private updateSubscribers(fields: Value) {
     this.subscribers.forEach((subscriber) => {
       subscriber(fields);
     });
@@ -106,7 +105,7 @@ export class CustomFieldView<CustomFieldValue = unknown>
   /**
    * Update the outer editor with a new field state.
    */
-  protected updateOuterEditor(fields: CustomFieldValue) {
+  protected updateOuterEditor(fields: Value) {
     const outerTr = this.outerView.state.tr;
     // When we insert content, we must offset to account for a few things:
     //  - getPos() returns the position directly before the parent node (+1)

--- a/src/plugin/fieldViews/DropdownFieldView.ts
+++ b/src/plugin/fieldViews/DropdownFieldView.ts
@@ -6,15 +6,15 @@ import type { BaseFieldSpec } from "./FieldView";
 export type Option<Data> = { text: string; value: Data };
 type Options<Data> = ReadonlyArray<Option<Data>>;
 
-export interface DropdownField<Data = unknown> extends BaseFieldSpec<Data> {
+export interface DropdownField extends BaseFieldSpec<string> {
   type: typeof DropdownFieldView.fieldName;
-  options: ReadonlyArray<Option<Data>>;
+  options: ReadonlyArray<Option<string>>;
 }
 
-export const createDropDownField = <Data>(
-  options: Options<Data>,
-  defaultValue: Data
-): DropdownField<Data> => ({
+export const createDropDownField = (
+  options: Options<string>,
+  defaultValue: string
+): DropdownField => ({
   type: DropdownFieldView.fieldName,
   options,
   defaultValue,
@@ -22,12 +22,10 @@ export const createDropDownField = <Data>(
 
 export type DropdownFields = string;
 
-export class DropdownFieldView<
-  Data = unknown
-> extends AttributeFieldView<Data> {
+export class DropdownFieldView extends AttributeFieldView<string> {
   private dropdownElement: HTMLSelectElement | undefined = undefined;
   public static fieldName = "dropdown" as const;
-  public static defaultValue = undefined;
+  public static defaultValue = "";
 
   constructor(
     // The node that this FieldView is responsible for rendering.
@@ -38,14 +36,14 @@ export class DropdownFieldView<
     getPos: () => number,
     // The offset of this node relative to its parent FieldView.
     offset: number,
-    defaultFields: Data,
-    private options: ReadonlyArray<Option<Data>>
+    defaultFields: string,
+    private options: ReadonlyArray<Option<string>>
   ) {
     super(node, outerView, getPos, offset);
     this.createInnerView(node.attrs.fields || defaultFields);
   }
 
-  protected createInnerView(chosenOption: Data): void {
+  protected createInnerView(chosenOption: string): void {
     this.dropdownElement = document.createElement("select");
 
     // Add a child option for each option in the array
@@ -67,7 +65,7 @@ export class DropdownFieldView<
     this.fieldViewElement.appendChild(this.dropdownElement);
   }
 
-  protected updateInnerView(chosenOption: Data): void {
+  protected updateInnerView(chosenOption: string): void {
     if (this.dropdownElement) {
       const domOptions = Array.from(this.dropdownElement.options);
       domOptions.forEach(
@@ -78,8 +76,8 @@ export class DropdownFieldView<
   }
 
   private optionToDOMnode(
-    option: Option<Data>,
-    chosenOption: Data
+    option: Option<string>,
+    chosenOption: string
   ): HTMLOptionElement {
     const domOption = document.createElement("option");
     domOption.setAttribute("value", JSON.stringify(option.value));

--- a/src/plugin/fieldViews/FieldView.ts
+++ b/src/plugin/fieldViews/FieldView.ts
@@ -29,11 +29,16 @@ export abstract class FieldView<NodeValue> {
   /**
    * Called when the fieldView is updated.
    */
-  public abstract update(
+  public abstract onUpdate(
     node: Node,
     elementOffset: number,
     decorations: DecorationSet | Decoration[]
   ): boolean;
+
+  /**
+   * Programmatically update this fieldView with the given value.
+   */
+  public abstract update(value: NodeValue): void;
 
   /**
    * Called when the fieldView is destroyed.

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -51,7 +51,7 @@ export abstract class ProseMirrorFieldView implements FieldView<string> {
     // The ProseMirror node type name
     private readonly fieldName: string,
     // Plugins that the editor should use
-    plugins?: Plugin[]
+    private plugins?: Plugin[]
   ) {
     this.applyDecorationsFromOuterEditor(decorations);
     this.serialiser = DOMSerializer.fromSchema(node.type.schema);
@@ -73,7 +73,7 @@ export abstract class ProseMirrorFieldView implements FieldView<string> {
     return this.node.type.create({ type: this.fieldName }, content);
   }
 
-  public update(
+  public onUpdate(
     node: Node,
     elementOffset: number,
     decorations: DecorationSet | Decoration[]
@@ -85,6 +85,17 @@ export abstract class ProseMirrorFieldView implements FieldView<string> {
     this.updateInnerEditor(node, decorations, elementOffset);
 
     return true;
+  }
+
+  public update(value: string) {
+    if (!this.innerEditorView) {
+      return;
+    }
+
+    const node = this.getNodeFromValue(value);
+    const tr = this.innerEditorView.state.tr;
+    tr.replaceWith(0, this.innerEditorView.state.doc.content.size, node);
+    this.onInnerStateChange(tr);
   }
 
   public destroy() {

--- a/src/plugin/fieldViews/__tests__/AttributeFieldView.spec.ts
+++ b/src/plugin/fieldViews/__tests__/AttributeFieldView.spec.ts
@@ -57,7 +57,7 @@ describe("AttributeFieldView", () => {
       fields: { value: true },
     });
 
-    fieldView.update(newNode, 0);
+    fieldView.onUpdate(newNode, 0);
 
     expect(updateInnerViewSpy.mock.calls[0]).toEqual([{ value: true }]);
   });

--- a/src/plugin/fieldViews/helpers.ts
+++ b/src/plugin/fieldViews/helpers.ts
@@ -3,7 +3,6 @@ import { CheckboxFieldView } from "./CheckboxFieldView";
 import type { CheckboxValue } from "./CheckboxFieldView";
 import type { CustomField } from "./CustomFieldView";
 import { CustomFieldView } from "./CustomFieldView";
-import type { DropdownFields } from "./DropdownFieldView";
 import { DropdownFieldView } from "./DropdownFieldView";
 import { RichTextFieldView } from "./RichTextFieldView";
 import { TextFieldView } from "./TextFieldView";
@@ -36,7 +35,7 @@ export type FieldTypeToValueMap<
   [TextFieldView.fieldName]: string;
   [RichTextFieldView.fieldName]: string;
   [CheckboxFieldView.fieldName]: CheckboxValue;
-  [DropdownFieldView.fieldName]: DropdownFields;
+  [DropdownFieldView.fieldName]: string;
   [CustomFieldView.fieldName]: FSpec[Name] extends CustomField<infer Data>
     ? Data
     : never;

--- a/src/plugin/helpers/plugin.ts
+++ b/src/plugin/helpers/plugin.ts
@@ -47,7 +47,7 @@ export const getElementFieldViewFromType = (
         view,
         getPos,
         offset,
-        field.defaultValue ?? DropdownFieldView.defaultValue,
+        field.defaultValue ?? DropdownFieldView.defaultValue ?? "",
         field.options
       );
   }

--- a/src/plugin/helpers/plugin.ts
+++ b/src/plugin/helpers/plugin.ts
@@ -47,7 +47,7 @@ export const getElementFieldViewFromType = (
         view,
         getPos,
         offset,
-        field.defaultValue ?? DropdownFieldView.defaultValue ?? "",
+        field.defaultValue ?? DropdownFieldView.defaultValue,
         field.options
       );
   }

--- a/src/plugin/types/Element.ts
+++ b/src/plugin/types/Element.ts
@@ -11,6 +11,7 @@ import type {
   DropdownField,
   DropdownFieldView,
 } from "../fieldViews/DropdownFieldView";
+import type { FieldView } from "../fieldViews/FieldView";
 import type {
   FieldNameToValueMap,
   FieldTypeToViewMap,
@@ -45,20 +46,19 @@ export type FieldViews =
 export type NonCustomFieldViews =
   | TextFieldView
   | RichTextFieldView
-  | CheckboxFieldView
-  | DropdownFieldView;
+  | CheckboxFieldView;
 
-export type FieldViewSpec<FieldView extends FieldViews> = {
-  fieldView: FieldView;
+export interface FieldViewSpec<F> {
+  fieldView: F;
   fieldSpec: Field;
   name: string;
-};
+  update: (value: F extends FieldView<infer Value> ? Value : never) => void;
+}
 
-export type CustomFieldViewSpec<Data = unknown, Props = unknown> = {
-  fieldView: CustomFieldView<Data>;
+export interface CustomFieldViewSpec<Data = unknown, Props = unknown>
+  extends FieldViewSpec<CustomFieldView<Data>> {
   fieldSpec: CustomField<Data, Props>;
-  name: string;
-};
+}
 
 export type FieldNameToFieldViewSpec<FSpec extends FieldSpec<string>> = {
   [name in Extract<keyof FSpec, string>]: FSpec[name] extends CustomField<

--- a/src/renderers/react/FieldView.tsx
+++ b/src/renderers/react/FieldView.tsx
@@ -1,27 +1,22 @@
-import React, { useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { Editor } from "../../editorial-source-components/Editor";
-import type { CheckboxFieldView } from "../../plugin/fieldViews/CheckboxFieldView";
-import type { DropdownFieldView } from "../../plugin/fieldViews/DropdownFieldView";
-import type { RichTextFieldView } from "../../plugin/fieldViews/RichTextFieldView";
-import type { TextFieldView } from "../../plugin/fieldViews/TextFieldView";
+import type { FieldView as TFieldView } from "../../plugin/fieldViews/FieldView";
 import type { FieldViewSpec } from "../../plugin/types/Element";
 
-type Props = {
-  fieldViewSpec: FieldViewSpec<
-    TextFieldView | RichTextFieldView | CheckboxFieldView | DropdownFieldView
-  >;
+type Props<F extends FieldViewSpec<unknown>> = {
+  fieldViewSpec: F;
   hasErrors?: boolean;
 };
 
 export const getFieldViewTestId = (name: string) => `FieldView-${name}`;
 
-export const FieldView: React.FunctionComponent<Props> = ({
+export const FieldView = <F extends FieldViewSpec<TFieldView<unknown>>>({
   fieldViewSpec,
   hasErrors = false,
-}) => {
+}: Props<F>) => {
   const editorRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
-    if (!editorRef.current) {
+    if (!editorRef.current || !fieldViewSpec.fieldView.fieldViewElement) {
       return;
     }
     editorRef.current.appendChild(fieldViewSpec.fieldView.fieldViewElement);


### PR DESCRIPTION
_co-authored-by: @dskamiotis_ 

## What does this change?

Adds an function to allow us to programmatically update fields to the `FieldViewSpec` type:

```ts
<button
  data-cy={UpdateAltTextButtonId}
  onClick={() => fieldViewSpecs.altText.update("Default alt text")}
>
```

The function is typesafe, and should only allow us to pass values that match the type handled by the field.

See `DemoImageElement.tsx`, where it's used in the example above, and to programmatically update the `altText` and `caption` fields when we receive a new image.

## How to test

- The new integration test should pass, and you should be convinced it's testing a programmatic update.
- Add a new image to the demo image element. Does that operation also update the altText and caption fields with the description of that image?

## Dev notes

In order to keep our types as simple as possible, I've removed the type parameter from the `DropdownFieldView` fieldview – it meant we had to use conditional types in our `Field` component, which meant that writing the type signatures was more complex.

At the moment, we don't have an example of a dropdown field that doesn't have a `string` value – we actually don't use this component at all, preferring to model dropdowns via a `CustomFieldView` and a React component which uses Source. Me and @SHession have discussed this tradeoff before.

My current take is that this isn't worth maintaining or adding complexity for whilst there's not a use case for it, hence the removal, but if there's a strong argument for its continued inclusion we can definitely revisit this decision!