### PR TITLE
chore: Consistent type parameters for FieldViews

### DIFF
--- a/src/plugin/fieldViews/AttributeFieldView.ts
+++ b/src/plugin/fieldViews/AttributeFieldView.ts
@@ -6,8 +6,8 @@ import { FieldType } from "./FieldView";
 /**
  * A FieldView representing a node that contains fields that are updated atomically.
  */
-export abstract class AttributeFieldView<Fields extends unknown>
-  implements FieldView<Fields> {
+export abstract class AttributeFieldView<Value extends unknown>
+  implements FieldView<Value> {
   public static fieldName: string;
   public static fieldType = FieldType.ATTRIBUTES;
   // The parent DOM element for this view. Public
@@ -28,19 +28,19 @@ export abstract class AttributeFieldView<Fields extends unknown>
     this.nodeType = node.type;
   }
 
-  public getNodeValue(node: Node): Fields {
-    return node.attrs.fields as Fields;
+  public getNodeValue(node: Node): Value {
+    return node.attrs.fields as Value;
   }
 
-  public getNodeFromValue(fields: Fields): Node {
+  public getNodeFromValue(fields: Value): Node {
     return this.nodeType.create({ fields });
   }
 
   // Classes extending AttributeFieldView should call e.g. this.createInnerView(node.attrs.fields || defaultFields)
   // in their constructor
-  protected abstract createInnerView(fields: Fields): void;
+  protected abstract createInnerView(fields: Value): void;
 
-  protected abstract updateInnerView(fields: Fields): void;
+  protected abstract updateInnerView(fields: Value): void;
 
   public onUpdate(node: Node, elementOffset: number) {
     if (node.type !== this.nodeType) {
@@ -48,12 +48,12 @@ export abstract class AttributeFieldView<Fields extends unknown>
     }
 
     this.offset = elementOffset;
-    this.updateInnerView(node.attrs.fields as Fields);
+    this.updateInnerView(node.attrs.fields as Value);
 
     return true;
   }
 
-  public update(value: Fields) {
+  public update(value: Value) {
     this.updateOuterEditor(value);
   }
 
@@ -64,7 +64,7 @@ export abstract class AttributeFieldView<Fields extends unknown>
   /**
    * Update the outer editor with a new field state.
    */
-  protected updateOuterEditor(fields: Fields) {
+  protected updateOuterEditor(fields: Value) {
     const outerTr = this.outerView.state.tr;
     // When we insert content, we must offset to account for a few things:
     //  - getPos() returns the position directly before the parent node (+1)

--- a/src/plugin/fieldViews/CustomFieldView.ts
+++ b/src/plugin/fieldViews/CustomFieldView.ts
@@ -30,13 +30,12 @@ type Subscriber<Fields extends unknown> = (fields: Fields) => void;
  * state changes. In this way, consuming code can manage state and UI changes itself,
  * perhaps in its own renderer format.
  */
-export class CustomFieldView<CustomFieldValue = unknown>
-  implements FieldView<CustomFieldValue> {
+export class CustomFieldView<Value = unknown> implements FieldView<Value> {
   public static fieldName = "custom" as const;
   public static fieldType = FieldType.ATTRIBUTES;
   public static defaultValue = undefined;
 
-  private subscribers: Array<Subscriber<CustomFieldValue>> = [];
+  private subscribers: Array<Subscriber<Value>> = [];
 
   constructor(
     // The node that this FieldView is responsible for rendering.
@@ -49,24 +48,24 @@ export class CustomFieldView<CustomFieldValue = unknown>
     protected offset: number
   ) {}
 
-  public getNodeValue(node: Node): CustomFieldValue {
-    return node.attrs.fields as CustomFieldValue;
+  public getNodeValue(node: Node): Value {
+    return node.attrs.fields as Value;
   }
 
-  public getNodeFromValue(fields: CustomFieldValue): Node {
+  public getNodeFromValue(fields: Value): Node {
     return this.node.type.create({ fields });
   }
 
   /**
    * @returns A function that can be called to update the node fields.
    */
-  public subscribe(subscriber: Subscriber<CustomFieldValue>) {
+  public subscribe(subscriber: Subscriber<Value>) {
     this.subscribers.push(subscriber);
-    subscriber(this.node.attrs.fields as CustomFieldValue);
-    return (fields: CustomFieldValue) => this.updateOuterEditor(fields);
+    subscriber(this.node.attrs.fields as Value);
+    return (fields: Value) => this.updateOuterEditor(fields);
   }
 
-  public unsubscribe(subscriber: Subscriber<CustomFieldValue>) {
+  public unsubscribe(subscriber: Subscriber<Value>) {
     const subscriberIndex = this.subscribers.indexOf(subscriber);
     if (subscriberIndex === -1) {
       console.error(
@@ -84,12 +83,12 @@ export class CustomFieldView<CustomFieldValue = unknown>
 
     this.offset = elementOffset;
 
-    this.updateSubscribers(node.attrs.fields as CustomFieldValue);
+    this.updateSubscribers(node.attrs.fields as Value);
 
     return true;
   }
 
-  public update(value: CustomFieldValue) {
+  public update(value: Value) {
     this.updateOuterEditor(value);
   }
 
@@ -97,7 +96,7 @@ export class CustomFieldView<CustomFieldValue = unknown>
     this.subscribers = [];
   }
 
-  private updateSubscribers(fields: CustomFieldValue) {
+  private updateSubscribers(fields: Value) {
     this.subscribers.forEach((subscriber) => {
       subscriber(fields);
     });
@@ -106,7 +105,7 @@ export class CustomFieldView<CustomFieldValue = unknown>
   /**
    * Update the outer editor with a new field state.
    */
-  protected updateOuterEditor(fields: CustomFieldValue) {
+  protected updateOuterEditor(fields: Value) {
     const outerTr = this.outerView.state.tr;
     // When we insert content, we must offset to account for a few things:
     //  - getPos() returns the position directly before the parent node (+1)


### PR DESCRIPTION
## What does this change?

A quick PR to make the type parameter names for FieldViews more consistent (`Fields`|`CustomFieldValue`|`Value` -> `Value`).

## How to test

Did I catch 'em all?