### PR TITLE
feat: Expand rich text options to accommodate a modified NodeSpec 

### DIFF
--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -99,6 +99,7 @@ export const getSerialisedHtml = ({
   codeValue = "",
   useSrcValue = "false",
   optionValue = "opt1",
+  restrictedTextValue = "",
   customDropdownValue = "opt1",
   mainImageValue = {
     assets: "[]",
@@ -112,6 +113,7 @@ export const getSerialisedHtml = ({
   codeValue?: string;
   useSrcValue?: string;
   optionValue?: string;
+  restrictedTextValue?: string;
   customDropdownValue?: string;
   mainImageValue?: {
     assets: string;
@@ -134,6 +136,7 @@ export const getSerialisedHtml = ({
     <element-imageelement-customdropdown class="ProsemirrorElement__imageElement-customDropdown" fields="&quot;${customDropdownValue}&quot;"></element-imageelement-customdropdown>
     <element-imageelement-mainimage class="ProsemirrorElement__imageElement-mainImage" fields="{${mainImageFields}}"></element-imageelement-mainimage>
     <element-imageelement-optiondropdown class="ProsemirrorElement__imageElement-optionDropdown" fields="&quot;${optionValue}&quot;"></element-imageelement-optiondropdown>
+    <element-imageelement-restrictedtextfield class="ProsemirrorElement__imageElement-restrictedTextField">${restrictedTextValue}</element-imageelement-restrictedtextfield>
     <element-imageelement-src class="ProsemirrorElement__imageElement-src">${srcValue}</element-imageelement-src>
     <element-imageelement-usesrc class="ProsemirrorElement__imageElement-useSrc" fields="{&quot;value&quot;:${useSrcValue}}"></element-imageelement-usesrc>
   </imageelement><p>First paragraph</p><p>Second paragraph</p>`);

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -88,6 +88,28 @@ describe("ImageElement", () => {
         });
       });
 
+      it(`restrictedTextField – can toggle italic style of an input in an element`, () => {
+        addImageElement();
+        getElementMenuButton("restrictedTextField", "Toggle emphasis").click();
+        typeIntoElementField("restrictedTextField", "Example text");
+        getElementRichTextField("restrictedTextField")
+          .find("em")
+          .should("have.text", "Example text");
+      });
+
+      it(`restrictedTextField – can't toggle strong style of an input in an element`, () => {
+        addImageElement();
+        getElementMenuButton(
+          "restrictedTextField",
+          "Toggle strong style"
+        ).click();
+        typeIntoElementField("restrictedTextField", "Example text");
+        getElementRichTextField("restrictedTextField").should(
+          "not.contain.html",
+          "<strong>"
+        );
+      });
+
       it("should serialise content as HTML within the appropriate nodes in the document", () => {
         addImageElement();
         typeIntoElementField("caption", "Caption text");

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -2,7 +2,7 @@ import { FocusStyleManager } from "@guardian/src-foundations/utils";
 import type OrderedMap from "orderedmap";
 import { collab } from "prosemirror-collab";
 import { exampleSetup } from "prosemirror-example-setup";
-import type { DOMOutputSpec, Node, NodeSpec } from "prosemirror-model";
+import type { Node, NodeSpec } from "prosemirror-model";
 import { Schema } from "prosemirror-model";
 import { schema as basicSchema } from "prosemirror-schema-basic";
 import { EditorState } from "prosemirror-state";
@@ -51,20 +51,8 @@ const {
   pullquoteElement,
 });
 
-const restrictedParagraph = {
-  content: "text*",
-  marks: "em",
-  group: "block",
-  parseDOM: [{ tag: "restricted-p" }],
-  toDOM() {
-    return ["restricted-p", 0] as DOMOutputSpec;
-  },
-};
-
 const schema = new Schema({
-  nodes: (basicSchema.spec.nodes as OrderedMap<NodeSpec>)
-    .append(nodeSpec)
-    .append({ restrictedParagraph }),
+  nodes: (basicSchema.spec.nodes as OrderedMap<NodeSpec>).append(nodeSpec),
   marks: basicSchema.spec.marks,
 });
 

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -2,7 +2,7 @@ import { FocusStyleManager } from "@guardian/src-foundations/utils";
 import type OrderedMap from "orderedmap";
 import { collab } from "prosemirror-collab";
 import { exampleSetup } from "prosemirror-example-setup";
-import type { Node, NodeSpec } from "prosemirror-model";
+import type { DOMOutputSpec, Node, NodeSpec } from "prosemirror-model";
 import { Schema } from "prosemirror-model";
 import { schema as basicSchema } from "prosemirror-schema-basic";
 import { EditorState } from "prosemirror-state";
@@ -51,8 +51,20 @@ const {
   pullquoteElement,
 });
 
+const restrictedParagraph = {
+  content: "text*",
+  marks: "em",
+  group: "block",
+  parseDOM: [{ tag: "restricted-p" }],
+  toDOM() {
+    return ["restricted-p", 0] as DOMOutputSpec;
+  },
+};
+
 const schema = new Schema({
-  nodes: (basicSchema.spec.nodes as OrderedMap<NodeSpec>).append(nodeSpec),
+  nodes: (basicSchema.spec.nodes as OrderedMap<NodeSpec>)
+    .append(nodeSpec)
+    .append({ restrictedParagraph }),
   marks: basicSchema.spec.marks,
 });
 

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -1,9 +1,13 @@
+import { exampleSetup } from "prosemirror-example-setup";
 import React from "react";
 import { createCheckBox } from "../../plugin/fieldViews/CheckboxFieldView";
 import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
 import type { Option } from "../../plugin/fieldViews/DropdownFieldView";
 import { createDropDownField } from "../../plugin/fieldViews/DropdownFieldView";
-import { createDefaultRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
+import {
+  createDefaultRichTextField,
+  createRichTextField,
+} from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import {
   createValidator,
@@ -37,6 +41,13 @@ export const createImageFields = (
 ) => {
   return {
     caption: createDefaultRichTextField(),
+    restrictedTextField: createRichTextField({
+      createPlugins: (schema) => exampleSetup({ schema }),
+      nodeSpec: {
+        content: "(text|hard_break)*",
+        marks: "em",
+      },
+    }),
     altText: createTextField({ isMultiline: true, rows: 2 }),
     src: createTextField(),
     code: createTextField({ isMultiline: true, rows: 4 }, true),

--- a/src/elements/demo-image/DemoImageElementForm.tsx
+++ b/src/elements/demo-image/DemoImageElementForm.tsx
@@ -44,6 +44,11 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
     >
       Programmatically update alt text
     </button>
+    <Field
+      fieldViewSpec={fieldViewSpecs.restrictedTextField}
+      label="Restricted Text Field"
+      errors={errors.restrictedTextField}
+    />
     <Field label="Src" fieldViewSpec={fieldViewSpecs.src} errors={errors.src} />
     <Field
       label="Code"

--- a/src/plugin/__tests__/elementSpec.spec.ts
+++ b/src/plugin/__tests__/elementSpec.spec.ts
@@ -125,9 +125,11 @@ describe("mount", () => {
           const fieldSpec = {
             field1: {
               type: "richText" as const,
-              content: "text",
-              toDOM: () => "element-testelement1-field1",
-              parseDOM: [{ tag: "header" }],
+              nodeSpec: {
+                content: "text",
+                toDOM: () => "element-testelement1-field1",
+                parseDOM: [{ tag: "header" }],
+              },
             },
           };
 
@@ -137,9 +139,9 @@ describe("mount", () => {
           expect(
             nodeSpec.get(getNodeNameFromField("field1", "testElement1"))
           ).toEqual({
-            content: fieldSpec.field1.content,
-            toDOM: fieldSpec.field1.toDOM,
-            parseDOM: fieldSpec.field1.parseDOM,
+            content: fieldSpec.field1.nodeSpec.content,
+            toDOM: fieldSpec.field1.nodeSpec.toDOM,
+            parseDOM: fieldSpec.field1.nodeSpec.parseDOM,
           });
         });
       });

--- a/src/plugin/fieldViews/RichTextFieldView.ts
+++ b/src/plugin/fieldViews/RichTextFieldView.ts
@@ -7,22 +7,28 @@ import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import type { BaseFieldSpec } from "./FieldView";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
 
-export interface RichTextField
-  extends BaseFieldSpec<string>,
-    Partial<Pick<NodeSpec, "toDOM" | "parseDOM" | "content">> {
+export interface RichTextField extends BaseFieldSpec<string> {
   type: typeof RichTextFieldView.fieldName;
   createPlugins?: (schema: Schema) => Plugin[];
+  nodeSpec?: Partial<NodeSpec>;
 }
 
-export const createRichTextField = (
-  createPlugins?: (schema: Schema) => Plugin[]
-): RichTextField => ({
+type RichTextOptions = {
+  createPlugins?: (schema: Schema) => Plugin[];
+  nodeSpec?: Partial<NodeSpec>;
+};
+
+export const createRichTextField = ({
+  createPlugins,
+  nodeSpec,
+}: RichTextOptions): RichTextField => ({
   type: RichTextFieldView.fieldName,
-  createPlugins: createPlugins,
+  createPlugins,
+  nodeSpec,
 });
 
 export const createDefaultRichTextField = (): RichTextField =>
-  createRichTextField((schema) => exampleSetup({ schema }));
+  createRichTextField({ createPlugins: (schema) => exampleSetup({ schema }) });
 
 export class RichTextFieldView extends ProseMirrorFieldView {
   public static fieldName = "richText" as const;

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -86,18 +86,21 @@ export const getNodeSpecForField = (
           code: field.isCode,
         },
       };
-    case "richText":
+    case "richText": {
+      const nodeSpec = field.nodeSpec ?? {};
       return {
         [getNodeNameFromField(fieldName, elementName)]: {
-          content: field.content ?? "paragraph+",
+          ...nodeSpec,
+          content: nodeSpec.content ?? "paragraph+",
           toDOM:
-            field.toDOM ??
+            nodeSpec.toDOM ??
             getDefaultToDOMForContentNode(elementName, fieldName),
-          parseDOM: field.parseDOM ?? [
+          parseDOM: nodeSpec.parseDOM ?? [
             { tag: getTagForNode(elementName, fieldName) },
           ],
         },
       };
+    }
     case "checkbox":
       return {
         [getNodeNameFromField(fieldName, elementName)]: {


### PR DESCRIPTION
_> co-authored-by: @rhystmills_ 

## What does this change?

Expands the options for rich text options to accommodate a modified `NodeSpec`. This can be useful when e.g. restricting marks, or specifying different kinds of content.

The `createRichTextField` field creator signature has been modified to allow these options to be passed.

We think there's room for a new field creator, alongside `createDefaultRichTextField`, to create a field that does not include paragraphs – perhaps `createFlatRichTextField`. This would reduce some repetition when declaring fields – for example, all of our captions across different elements are likely to use these defaults.

This would also need to include a binding for the `enter` key that inserts a hard_break (as with the multiline text input)  – but that can be added in a separate PR.

## How to test

- The automated tests should pass.
-  Have a play with the 'restricted text'. It should only permit italic marks, and only shift+enter should work (to insert line breaks).