### PR TITLE
feat: Add `createFlatRichTextField` field creator

### DIFF
--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -110,6 +110,16 @@ describe("ImageElement", () => {
         );
       });
 
+      it(`restrictedTextField – creates br tags, not new paragraphs`, () => {
+        addImageElement();
+        typeIntoElementField("restrictedTextField", "Example {Enter}text");
+        assertDocHtml(
+          getSerialisedHtml({
+            restrictedTextValue: "Example <br>text",
+          })
+        );
+      });
+
       it("should serialise content as HTML within the appropriate nodes in the document", () => {
         addImageElement();
         typeIntoElementField("caption", "Caption text");

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -2,7 +2,7 @@ import { FocusStyleManager } from "@guardian/src-foundations/utils";
 import type OrderedMap from "orderedmap";
 import { collab } from "prosemirror-collab";
 import { exampleSetup } from "prosemirror-example-setup";
-import type { Node, NodeSpec } from "prosemirror-model";
+import type { DOMOutputSpec, Node, NodeSpec } from "prosemirror-model";
 import { Schema } from "prosemirror-model";
 import { schema as basicSchema } from "prosemirror-schema-basic";
 import { EditorState } from "prosemirror-state";
@@ -51,8 +51,20 @@ const {
   pullquoteElement,
 });
 
+const restrictedParagraph = {
+  content: "text*",
+  marks: "em",
+  group: "block",
+  parseDOM: [{ tag: "restricted-p" }],
+  toDOM() {
+    return ["restricted-p", 0] as DOMOutputSpec;
+  },
+};
+
 const schema = new Schema({
-  nodes: (basicSchema.spec.nodes as OrderedMap<NodeSpec>).append(nodeSpec),
+  nodes: (basicSchema.spec.nodes as OrderedMap<NodeSpec>)
+    .append(nodeSpec)
+    .append({ restrictedParagraph }),
   marks: basicSchema.spec.marks,
 });
 

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -6,7 +6,7 @@ import type { Option } from "../../plugin/fieldViews/DropdownFieldView";
 import { createDropDownField } from "../../plugin/fieldViews/DropdownFieldView";
 import {
   createDefaultRichTextField,
-  createRichTextField,
+  createFlatRichTextField,
 } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import {
@@ -41,10 +41,9 @@ export const createImageFields = (
 ) => {
   return {
     caption: createDefaultRichTextField(),
-    restrictedTextField: createRichTextField({
+    restrictedTextField: createFlatRichTextField({
       createPlugins: (schema) => exampleSetup({ schema }),
       nodeSpec: {
-        content: "(text|hard_break)*",
         marks: "em",
       },
     }),

--- a/src/plugin/fieldViews/RichTextFieldView.ts
+++ b/src/plugin/fieldViews/RichTextFieldView.ts
@@ -59,7 +59,7 @@ export const createFlatRichTextField = ({
       };
 
       const plugin = keymap(keymapping);
-      return (createPlugins?.(schema) ?? []).concat(plugin);
+      return [plugin, ...(createPlugins?.(schema) ?? [])];
     },
     nodeSpec: {
       ...nodeSpec,

--- a/src/plugin/fieldViews/TextFieldView.ts
+++ b/src/plugin/fieldViews/TextFieldView.ts
@@ -73,6 +73,7 @@ export class TextFieldView extends ProseMirrorFieldView {
           };
       keymapping["Enter"] = newLineCommand;
     }
+
     super(
       node,
       outerView,


### PR DESCRIPTION
## What does this change?

Adds a `createFlatRichTextField` field creator. (It's not a great name, eh. Can we think of a better one? `createNoParaRichTextField`?)

It creates a rich text field that doesn't use paragraphs – instead, it produces flat text, with `br` tags for line breaks.

To do this, the field adds two pieces of configuration –
- adds a keymapping from `Enter` that adds a `br` tag
- specifies the content for the node to be `(text|hard_break)*`

The user is free to add plugins or alter other parts of the `NodeSpec` themselves.

## How to test

This effectively duplicates the testable functionality of #75 in a helper function. I've added a test to check that the enter key works.

Try the field out in the demo element. Does it work as expected? Does the output match what we describe above?
