### PR TITLE
fix: Remove element defaults

### DIFF
--- a/src/elements/code/CodeElementSpec.tsx
+++ b/src/elements/code/CodeElementSpec.tsx
@@ -24,9 +24,5 @@ export const codeElement = createReactElementSpec(
   (_, errors, __, fieldViewSpecs) => {
     return <CodeElementForm errors={errors} fieldViewSpecs={fieldViewSpecs} />;
   },
-  createValidator({ codeText: [required()] }),
-  {
-    codeText: "",
-    language: "text",
-  }
+  createValidator({ codeText: [required()] })
 );

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -82,15 +82,5 @@ export const createImageElement = (
     createValidator({
       altText: [htmlMaxLength(100), htmlRequired()],
       caption: [htmlRequired()],
-    }),
-    {
-      caption: "",
-      useSrc: { value: true },
-      altText: "",
-      mainImage: { mediaId: undefined, mediaApiUri: undefined, assets: [] },
-      src: "",
-      code: "",
-      optionDropdown: "opt1",
-      customDropdown: "opt1",
-    }
+    })
   );

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -42,13 +42,5 @@ export const createEmbedElement = () =>
       altText: [htmlMaxLength(1000), htmlRequired()],
       embedCode: [htmlRequired()],
       caption: [maxLength(1000)],
-    }),
-    {
-      weighting: "inline (default)",
-      sourceUrl: "",
-      embedCode: "",
-      caption: "",
-      altText: "",
-      required: true,
-    }
+    })
   );

--- a/src/elements/pullquote/PullquoteSpec.tsx
+++ b/src/elements/pullquote/PullquoteSpec.tsx
@@ -22,10 +22,5 @@ export const pullquoteElement = createReactElementSpec(
       <PullquoteElementForm errors={errors} fieldViewSpecs={fieldViewSpecs} />
     );
   },
-  createValidator({ pullquote: [htmlRequired()] }),
-  {
-    pullquote: "",
-    attribution: "",
-    weighting: "supporting",
-  }
+  createValidator({ pullquote: [htmlRequired()] })
 );

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -206,8 +206,11 @@ describe("buildElementPlugin", () => {
         view.dispatch
       );
 
-      const expected =
-        '<testelement type="testElement" has-errors="false"><element-testelement-field1 class="ProsemirrorElement__testElement-field1" fields="{&quot;value&quot;:false}"></element-testelement-field1><element-testelement-field2 class="ProsemirrorElement__testElement-field2"><p>Content</p></element-testelement-field2></testelement>';
+      const expected = trimHtml(`
+        <testelement type="testElement" has-errors="false">
+          <element-testelement-field1 class="ProsemirrorElement__testElement-field1" fields="{&quot;value&quot;:false}"></element-testelement-field1>
+          <element-testelement-field2 class="ProsemirrorElement__testElement-field2"><p>Content</p></element-testelement-field2>
+        </testelement>`);
       expect(getElementAsHTML()).toBe(expected);
     });
 
@@ -226,8 +229,11 @@ describe("buildElementPlugin", () => {
         values: { field1: { value: true } },
       })(view.state, view.dispatch);
 
-      const expected =
-        '<testelement type="testElement" has-errors="false"><element-testelement-field1 class="ProsemirrorElement__testElement-field1" fields="{&quot;value&quot;:true}"></element-testelement-field1></testelement>';
+      const expected = trimHtml(
+        `<testelement type="testElement" has-errors="false">
+          <element-testelement-field1 class="ProsemirrorElement__testElement-field1" fields="{&quot;value&quot;:true}"></element-testelement-field1>
+        </testelement>`
+      );
       expect(getElementAsHTML()).toBe(expected);
     });
 
@@ -246,8 +252,11 @@ describe("buildElementPlugin", () => {
         values: { field1: "<p>Content</p>" },
       })(view.state, view.dispatch);
 
-      const expected =
-        '<testelement type="testElement" has-errors="false"><element-testelement-field1 class="ProsemirrorElement__testElement-field1"><p>Content</p></element-testelement-field1></testelement>';
+      const expected = trimHtml(
+        `<testelement type="testElement" has-errors="false">
+          <element-testelement-field1 class="ProsemirrorElement__testElement-field1"><p>Content</p></element-testelement-field1>
+        </testelement>`
+      );
       expect(getElementAsHTML()).toBe(expected);
     });
 
@@ -270,8 +279,11 @@ describe("buildElementPlugin", () => {
         },
       })(view.state, view.dispatch);
 
-      const expected =
-        '<testelement type="testElement" has-errors="false"><element-testelement-field1 class="ProsemirrorElement__testElement-field1"><p>Content for field1</p></element-testelement-field1><element-testelement-field2 class="ProsemirrorElement__testElement-field2"><p>Content for field2</p></element-testelement-field2></testelement>';
+      const expected = trimHtml(`
+        <testelement type="testElement" has-errors="false">
+          <element-testelement-field1 class="ProsemirrorElement__testElement-field1"><p>Content for field1</p></element-testelement-field1>
+          <element-testelement-field2 class="ProsemirrorElement__testElement-field2"><p>Content for field2</p></element-testelement-field2>
+        </testelement>`);
       expect(getElementAsHTML()).toBe(expected);
     });
 
@@ -293,8 +305,10 @@ describe("buildElementPlugin", () => {
         values: { field1: { arbitraryValue: "hai" } },
       })(view.state, view.dispatch);
 
-      const expected =
-        '<testelement type="testElement" has-errors="false"><element-testelement-field1 class="ProsemirrorElement__testElement-field1" fields="{&quot;arbitraryValue&quot;:&quot;hai&quot;}"></element-testelement-field1></testelement>';
+      const expected = trimHtml(`
+        <testelement type="testElement" has-errors="false">
+          <element-testelement-field1 class="ProsemirrorElement__testElement-field1" fields="{&quot;arbitraryValue&quot;:&quot;hai&quot;}"></element-testelement-field1>
+        </testelement>`);
       expect(getElementAsHTML()).toBe(expected);
     });
   });

--- a/src/plugin/__tests__/elementSpec.spec.ts
+++ b/src/plugin/__tests__/elementSpec.spec.ts
@@ -18,8 +18,7 @@ describe("mount", () => {
           // field1 is derived from the fieldSpec
           fieldViews.field1;
         },
-        () => null,
-        { field1: "text" }
+        () => null
       );
     });
 
@@ -36,8 +35,7 @@ describe("mount", () => {
           // as it is not defined in `fieldSpec` passed into `mount`
           fieldViews.field1;
         },
-        () => null,
-        { notField1: "text" }
+        () => null
       );
     });
   });
@@ -62,8 +60,7 @@ describe("mount", () => {
           // field2 is a boolean b/c it's a checkbox field
           fields.field2.value.valueOf();
           return null;
-        },
-        { field1: "text" }
+        }
       );
     });
 
@@ -81,8 +78,7 @@ describe("mount", () => {
           // as it is not defined in `fieldSpec` passed into `mount`
           fields.doesNotExist;
           return null;
-        },
-        { notField1: "text" }
+        }
       );
     });
   });

--- a/src/plugin/elementSpec.ts
+++ b/src/plugin/elementSpec.ts
@@ -51,8 +51,7 @@ export type Renderer<FSpec extends FieldSpec<string>> = (
 export const createElementSpec = <FSpec extends FieldSpec<string>>(
   fieldSpec: FSpec,
   render: Renderer<FSpec>,
-  validate: Validator<FSpec>,
-  defaultState: Partial<FieldNameToValueMap<FSpec>>
+  validate: Validator<FSpec>
 ): ElementSpec<FSpec> => ({
   fieldSpec,
   createUpdator: (dom, fields, updateState, fieldValues, commands) => {
@@ -62,7 +61,7 @@ export const createElementSpec = <FSpec extends FieldSpec<string>>(
       dom,
       fields,
       (fields) => updateState(fields, !!validate(fields)),
-      Object.assign({}, defaultState, fieldValues),
+      fieldValues,
       commands,
       updater.subscribe
     );

--- a/src/plugin/helpers/test.ts
+++ b/src/plugin/helpers/test.ts
@@ -64,8 +64,7 @@ export const createNoopElement = <FSpec extends FieldSpec<string>>(
   createElementSpec(
     fieldSpec,
     () => null,
-    () => null,
-    {}
+    () => null
   );
 
 export const createEditorWithElements = <

--- a/src/renderers/react/createReactElementSpec.tsx
+++ b/src/renderers/react/createReactElementSpec.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import { render } from "react-dom";
 import { createElementSpec } from "../../plugin/elementSpec";
 import type { Renderer, Validator } from "../../plugin/elementSpec";
-import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
 import type { Consumer } from "../../plugin/types/Consumer";
 import type { FieldSpec } from "../../plugin/types/Element";
 import { ElementProvider } from "./ElementProvider";
@@ -11,8 +10,7 @@ import { ElementProvider } from "./ElementProvider";
 export const createReactElementSpec = <FSpec extends FieldSpec<string>>(
   fieldSpec: FSpec,
   consumer: Consumer<ReactElement, FSpec>,
-  validate: Validator<FSpec>,
-  defaultState: FieldNameToValueMap<FSpec>
+  validate: Validator<FSpec>
 ) => {
   const renderer: Renderer<FSpec> = (
     validate,
@@ -36,5 +34,5 @@ export const createReactElementSpec = <FSpec extends FieldSpec<string>>(
       dom
     );
 
-  return createElementSpec(fieldSpec, renderer, validate, defaultState);
+  return createElementSpec(fieldSpec, renderer, validate);
 };


### PR DESCRIPTION
## What does this change?

Removes our element-level defaults. We ... didn't really use them, except (incorrectly) on initialisation! They were a hangover from a previous design, and there weren't any tests to verify they had an effect.

This fixes an incidental bug where validation errors were not appearing when nodes were initialised on doc serialisation (card [here](https://trello.com/c/ygmh8P87/718-resolve-validation-issue)).

## How to test

- The automated tests should pass, and they should satisfy you that defaults are respected.
- Add content to a required field w/ the DemoImageElement, and refresh the page. The validation message should not appear.