### PR TITLE
feat: Add transformer functions when getting element data from nodes, and vice versa

### DIFF
--- a/src/plugin/element.ts
+++ b/src/plugin/element.ts
@@ -21,7 +21,8 @@ import type {
 export const buildElementPlugin = <
   FSpec extends FieldSpec<keyof FSpec>,
   ElementNames extends keyof ESpecMap,
-  ESpecMap extends ElementSpecMap<FSpec, ElementNames>
+  ExternalData,
+  ESpecMap extends ElementSpecMap<FSpec, ElementNames, ExternalData>
 >(
   elementSpecs: ESpecMap,
   predicate = defaultPredicate

--- a/src/plugin/elementSpec.ts
+++ b/src/plugin/elementSpec.ts
@@ -4,6 +4,7 @@ import type {
   ElementSpec,
   FieldNameToFieldViewSpec,
   FieldSpec,
+  Transformers,
 } from "./types/Element";
 
 type Subscriber<FSpec extends FieldSpec<string>> = (
@@ -48,12 +49,17 @@ export type Renderer<FSpec extends FieldSpec<string>> = (
   ) => void
 ) => void;
 
-export const createElementSpec = <FSpec extends FieldSpec<string>>(
+export const createElementSpec = <
+  FSpec extends FieldSpec<string>,
+  ExternalData
+>(
   fieldSpec: FSpec,
   render: Renderer<FSpec>,
-  validate: Validator<FSpec>
-): ElementSpec<FSpec> => ({
+  validate: Validator<FSpec>,
+  transformers?: Transformers<FSpec, ExternalData>
+): ElementSpec<FSpec, ExternalData> => ({
   fieldSpec,
+  transformers,
   createUpdator: (dom, fields, updateState, fieldValues, commands) => {
     const updater = createUpdater<FSpec>();
     render(

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -3,6 +3,7 @@ import { Plugin, PluginKey } from "prosemirror-state";
 import type { Decoration, DecorationSet, EditorProps } from "prosemirror-view";
 import type {
   ElementSpec,
+  ElementSpecMap,
   FieldNameToFieldViewSpec,
   FieldSpec,
 } from "../plugin/types/Element";
@@ -19,10 +20,11 @@ export type PluginState = { hasErrors: boolean };
 
 export const createPlugin = <
   ElementNames extends string,
+  ExternalData,
   FSpec extends FieldSpec<string>
 >(
   elementsSpec: {
-    [elementName in ElementNames]: ElementSpec<FSpec>;
+    [elementName in ElementNames]: ElementSpec<FSpec, ExternalData>;
   },
   commands: Commands
 ): Plugin<PluginState, Schema> => {
@@ -54,7 +56,10 @@ export const createPlugin = <
     },
     props: {
       decorations,
-      nodeViews: createNodeViews(elementsSpec, commands),
+      nodeViews: createNodeViews(
+        elementsSpec as ElementSpecMap<FSpec, ElementNames>,
+        commands
+      ),
     },
   });
 };
@@ -65,9 +70,7 @@ const createNodeViews = <
   ElementNames extends string,
   FSpec extends FieldSpec<string>
 >(
-  elementsSpec: {
-    [elementName in ElementNames]: ElementSpec<FSpec>;
-  },
+  elementsSpec: ElementSpecMap<FSpec, ElementNames>,
   commands: Commands
 ): NodeViewSpec => {
   const nodeViews = {} as NodeViewSpec;

--- a/src/renderers/react/createReactElementSpec.tsx
+++ b/src/renderers/react/createReactElementSpec.tsx
@@ -4,13 +4,17 @@ import { render } from "react-dom";
 import { createElementSpec } from "../../plugin/elementSpec";
 import type { Renderer, Validator } from "../../plugin/elementSpec";
 import type { Consumer } from "../../plugin/types/Consumer";
-import type { FieldSpec } from "../../plugin/types/Element";
+import type { FieldSpec, Transformers } from "../../plugin/types/Element";
 import { ElementProvider } from "./ElementProvider";
 
-export const createReactElementSpec = <FSpec extends FieldSpec<string>>(
+export const createReactElementSpec = <
+  FSpec extends FieldSpec<string>,
+  ExternalData
+>(
   fieldSpec: FSpec,
   consumer: Consumer<ReactElement, FSpec>,
-  validate: Validator<FSpec>
+  validate: Validator<FSpec>,
+  transformers?: Transformers<FSpec, ExternalData>
 ) => {
   const renderer: Renderer<FSpec> = (
     validate,
@@ -34,5 +38,5 @@ export const createReactElementSpec = <FSpec extends FieldSpec<string>>(
       dom
     );
 
-  return createElementSpec(fieldSpec, renderer, validate);
+  return createElementSpec(fieldSpec, renderer, validate, transformers);
 };


### PR DESCRIPTION
_co-authored-by: @rhystmills_ 

## What does this change?

Adds the ability to add options transformer functions to an element spec. These transformer functions let consumers transform data between an external representation of element data, and the `prosemirror-elements` representation.

As an example, at the Guardian, flexible-content expresses our elements as 

```ts
{
  elementType: string,
  fields: { ... element fields },
  assets: Asset[]
}
```

Additionally, some elements require additional, static field values, e.g. `isMandatory`, which aren't present in the element fields.

By allowing the consumer to supply a transformer function on a per-element basis, and applying them when `getElementDataFromNode` and `getNodeFromElementData` are called, we can ensure that we keep the internal and external models are kept separate, whilst making getting data in and out of prosemirror documents as simple as possible at the call site.

The signature of the transform object is

```ts
  {
    transformElementDataIn: (external: ExternalData) => {
      // return internal representation
    },
    transformElementDataOut: (internal): ExternalData => {
      // return external representation
    },
  }
```

We can add these transformers to our current elements in subsequent PRs.

## How to test

The automated tests should pass. We've added tests for runtime and type behaviour. It should be clear that:

- The code works!
- Typescript knows about the shape of the data concern, on input and output, and won't tolerate badly-formed data.

## Things to ponder

This makes our types, already fairly dense, even more complex. There's a legitimate question as to whether these transforms belong here – or should be left to consumer code. This approach makes calling our input/output functions really need, but does make declaring an element more complicated.

As an alternative, we could defer this to Composer, complicating the code in Composer but avoiding additional complexity in this library's interface. Thoughts welcome.

One way of reducing this complexity would be to create a helper function, e.g. `createGuElementSpec`, which supplies the default Composer transformer functions so Guardian devs don't have to. (We could add an argument to allow them to pass additional fields, like `isMandatory`, if necessary.)