### PR TITLE
style: Ergonomic type renaming

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -2,7 +2,7 @@ import { FocusStyleManager } from "@guardian/src-foundations/utils";
 import type OrderedMap from "orderedmap";
 import { collab } from "prosemirror-collab";
 import { exampleSetup } from "prosemirror-example-setup";
-import type { DOMOutputSpec, Node, NodeSpec } from "prosemirror-model";
+import type { Node, NodeSpec } from "prosemirror-model";
 import { Schema } from "prosemirror-model";
 import { schema as basicSchema } from "prosemirror-schema-basic";
 import { EditorState } from "prosemirror-state";

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -51,20 +51,8 @@ const {
   pullquoteElement,
 });
 
-const restrictedParagraph = {
-  content: "text*",
-  marks: "em",
-  group: "block",
-  parseDOM: [{ tag: "restricted-p" }],
-  toDOM() {
-    return ["restricted-p", 0] as DOMOutputSpec;
-  },
-};
-
 const schema = new Schema({
-  nodes: (basicSchema.spec.nodes as OrderedMap<NodeSpec>)
-    .append(nodeSpec)
-    .append({ restrictedParagraph }),
+  nodes: (basicSchema.spec.nodes as OrderedMap<NodeSpec>).append(nodeSpec),
   marks: basicSchema.spec.marks,
 });
 

--- a/src/editorial-source-components/FieldWrapper.tsx
+++ b/src/editorial-source-components/FieldWrapper.tsx
@@ -1,22 +1,22 @@
 import type { FieldView as TFieldView } from "../plugin/fieldViews/FieldView";
-import type { FieldViewSpec } from "../plugin/types/Element";
+import type { Field } from "../plugin/types/Element";
 import { FieldView } from "../renderers/react/FieldView";
 import { InputGroup } from "./InputGroup";
 import { InputHeading } from "./InputHeading";
 
 type Props<F> = {
-  fieldViewSpec: F;
+  field: F;
   errors: string[];
   label: string;
 };
 
-export const Field = <F extends FieldViewSpec<TFieldView<unknown>>>({
-  fieldViewSpec,
+export const FieldWrapper = <F extends Field<TFieldView<unknown>>>({
+  field,
   errors,
   label,
 }: Props<F>) => (
   <InputGroup>
     <InputHeading label={label} errors={errors} />
-    <FieldView fieldViewSpec={fieldViewSpec} hasErrors={!!errors.length} />
+    <FieldView field={field} hasErrors={!!errors.length} />
   </InputGroup>
 );

--- a/src/elements/code/CodeElementForm.tsx
+++ b/src/elements/code/CodeElementForm.tsx
@@ -1,29 +1,26 @@
 import React from "react";
-import { Field } from "../../editorial-source-components/Field";
-import type { FieldNameToFieldViewSpec } from "../../plugin/types/Element";
+import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import type { FieldNameToField } from "../../plugin/types/Element";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import type { codeFields } from "./CodeElementSpec";
 
 type Props = {
   errors: Record<string, string[]>;
-  fieldViewSpecs: FieldNameToFieldViewSpec<typeof codeFields>;
+  fields: FieldNameToField<typeof codeFields>;
 };
 
 export const CodeElementTestId = "CodeElement";
 
 export const CodeElementForm: React.FunctionComponent<Props> = ({
   errors,
-  fieldViewSpecs,
+  fields,
 }) => (
   <div data-cy={CodeElementTestId}>
-    <Field
+    <FieldWrapper
       label="Code"
-      fieldViewSpec={fieldViewSpecs.codeText}
+      field={fields.codeText}
       errors={errors.codeText}
     />
-    <CustomDropdownView
-      label="Language"
-      fieldViewSpec={fieldViewSpecs.language}
-    />
+    <CustomDropdownView label="Language" field={fields.language} />
   </div>
 );

--- a/src/elements/code/CodeElementSpec.tsx
+++ b/src/elements/code/CodeElementSpec.tsx
@@ -22,7 +22,7 @@ export const codeFields = {
 export const codeElement = createReactElementSpec(
   codeFields,
   (_, errors, __, fieldViewSpecs) => {
-    return <CodeElementForm errors={errors} fieldViewSpecs={fieldViewSpecs} />;
+    return <CodeElementForm errors={errors} fields={fieldViewSpecs} />;
   },
   createValidator({ codeText: [required()] })
 );

--- a/src/elements/code/CodeElementSpec.tsx
+++ b/src/elements/code/CodeElementSpec.tsx
@@ -21,8 +21,8 @@ export const codeFields = {
 
 export const codeElement = createReactElementSpec(
   codeFields,
-  (_, errors, __, fieldViewSpecs) => {
-    return <CodeElementForm errors={errors} fields={fieldViewSpecs} />;
+  (_, errors, __, fields) => {
+    return <CodeElementForm errors={errors} fields={fields} />;
   },
   createValidator({ codeText: [required()] })
 );

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -80,12 +80,12 @@ export const createImageElement = (
 ) =>
   createReactElementSpec(
     createImageFields(onSelect, onCrop),
-    (fields, errors, __, fieldViewSpecs) => {
+    (fieldValues, errors, __, fields) => {
       return (
         <ImageElementForm
           fields={fields}
           errors={errors}
-          fieldViewSpecs={fieldViewSpecs}
+          fieldValues={fieldValues}
         />
       );
     },

--- a/src/elements/demo-image/DemoImageElementForm.tsx
+++ b/src/elements/demo-image/DemoImageElementForm.tsx
@@ -1,22 +1,17 @@
 import React from "react";
-import { Field } from "../../editorial-source-components/Field";
+import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
 import { Label } from "../../editorial-source-components/Label";
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
-import type {
-  CustomFieldViewSpec,
-  FieldNameToFieldViewSpec,
-} from "../../plugin/types/Element";
+import type { CustomField, FieldNameToField } from "../../plugin/types/Element";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import { getFieldViewTestId } from "../../renderers/react/FieldView";
 import { useCustomFieldViewState } from "../../renderers/react/useCustomFieldViewState";
 import type { createImageFields, SetMedia } from "./DemoImageElement";
 
 type Props = {
-  fields: FieldNameToValueMap<ReturnType<typeof createImageFields>>;
+  fieldValues: FieldNameToValueMap<ReturnType<typeof createImageFields>>;
   errors: Record<string, string[]>;
-  fieldViewSpecs: FieldNameToFieldViewSpec<
-    ReturnType<typeof createImageFields>
-  >;
+  fields: FieldNameToField<ReturnType<typeof createImageFields>>;
 };
 
 export const ImageElementTestId = "ImageElement";
@@ -25,69 +20,62 @@ export const UpdateAltTextButtonId = "UpdateAltTextButton";
 export const ImageElementForm: React.FunctionComponent<Props> = ({
   fields,
   errors,
-  fieldViewSpecs,
+  fieldValues,
 }) => (
   <div data-cy={ImageElementTestId}>
-    <Field
+    <FieldWrapper
       label="Caption"
-      fieldViewSpec={fieldViewSpecs.caption}
+      field={fields.caption}
       errors={errors.caption}
     />
-    <Field
+    <FieldWrapper
       label="Alt text"
-      fieldViewSpec={fieldViewSpecs.altText}
+      field={fields.altText}
       errors={errors.altText}
     />
     <button
       data-cy={UpdateAltTextButtonId}
-      onClick={() => fieldViewSpecs.altText.update("Default alt text")}
+      onClick={() => fields.altText.update("Default alt text")}
     >
       Programmatically update alt text
     </button>
-    <Field
-      fieldViewSpec={fieldViewSpecs.restrictedTextField}
+    <FieldWrapper
+      field={fields.restrictedTextField}
       label="Restricted Text Field"
       errors={errors.restrictedTextField}
     />
-    <Field label="Src" fieldViewSpec={fieldViewSpecs.src} errors={errors.src} />
-    <Field
-      label="Code"
-      fieldViewSpec={fieldViewSpecs.code}
-      errors={errors.code}
-    />
-    <Field
+    <FieldWrapper label="Src" field={fields.src} errors={errors.src} />
+    <FieldWrapper label="Code" field={fields.code} errors={errors.code} />
+    <FieldWrapper
       label="Use image source?"
-      fieldViewSpec={fieldViewSpecs.useSrc}
+      field={fields.useSrc}
       errors={errors.useSrc}
     />
-    <Field
+    <FieldWrapper
       label="Options"
-      fieldViewSpec={fieldViewSpecs.optionDropdown}
+      field={fields.optionDropdown}
       errors={errors.optionDropdown}
     />
     <ImageView
-      fieldViewSpec={fieldViewSpecs.mainImage}
+      field={fields.mainImage}
       onChange={(_, __, ___, description) => {
-        fieldViewSpecs.altText.update(description);
-        fieldViewSpecs.caption.update(description);
+        fields.altText.update(description);
+        fields.caption.update(description);
       }}
     />
-    <CustomDropdownView
-      label="Options"
-      fieldViewSpec={fieldViewSpecs.customDropdown}
-    />
+    <CustomDropdownView label="Options" field={fields.customDropdown} />
     <hr />
     <Label>Element errors</Label>
     <pre>{JSON.stringify(errors)}</pre>
     <hr />
     <Label>Element values</Label>
-    <pre>{JSON.stringify(fields)}</pre>
+    <pre>{JSON.stringify(fieldValues)}</pre>
   </div>
 );
 
 type ImageViewProps = {
   onChange: SetMedia;
-  fieldViewSpec: CustomFieldViewSpec<
+  field: CustomField<
     {
       mediaId?: string;
       mediaApiUri?: string;
@@ -100,10 +88,8 @@ type ImageViewProps = {
   >;
 };
 
-const ImageView = ({ fieldViewSpec, onChange }: ImageViewProps) => {
-  const [imageFields, setImageFieldsRef] = useCustomFieldViewState(
-    fieldViewSpec
-  );
+const ImageView = ({ field, onChange }: ImageViewProps) => {
+  const [imageFields, setImageFieldsRef] = useCustomFieldViewState(field);
 
   const setMedia = (
     mediaId: string,
@@ -118,7 +104,7 @@ const ImageView = ({ fieldViewSpec, onChange }: ImageViewProps) => {
   };
 
   return (
-    <div data-cy={getFieldViewTestId(fieldViewSpec.name)}>
+    <div data-cy={getFieldViewTestId(field.name)}>
       {imageFields.assets.length > 0 ? (
         <img style={{ width: "25%" }} src={imageFields.assets[0]}></img>
       ) : null}
@@ -127,23 +113,19 @@ const ImageView = ({ fieldViewSpec, onChange }: ImageViewProps) => {
         <button
           onClick={() => {
             if (imageFields.mediaId) {
-              fieldViewSpec.fieldDescription.props.onCropImage(
+              field.description.props.onCropImage(
                 imageFields.mediaId,
                 setMedia
               );
             } else {
-              fieldViewSpec.fieldDescription.props.onSelectImage(setMedia);
+              field.description.props.onSelectImage(setMedia);
             }
           }}
         >
           Crop Image
         </button>
       ) : (
-        <button
-          onClick={() =>
-            fieldViewSpec.fieldDescription.props.onSelectImage(setMedia)
-          }
-        >
+        <button onClick={() => field.description.props.onSelectImage(setMedia)}>
           Choose Image
         </button>
       )}

--- a/src/elements/demo-image/DemoImageElementForm.tsx
+++ b/src/elements/demo-image/DemoImageElementForm.tsx
@@ -127,12 +127,12 @@ const ImageView = ({ fieldViewSpec, onChange }: ImageViewProps) => {
         <button
           onClick={() => {
             if (imageFields.mediaId) {
-              fieldViewSpec.fieldSpec.props.onCropImage(
+              fieldViewSpec.fieldDescription.props.onCropImage(
                 imageFields.mediaId,
                 setMedia
               );
             } else {
-              fieldViewSpec.fieldSpec.props.onSelectImage(setMedia);
+              fieldViewSpec.fieldDescription.props.onSelectImage(setMedia);
             }
           }}
         >
@@ -140,7 +140,9 @@ const ImageView = ({ fieldViewSpec, onChange }: ImageViewProps) => {
         </button>
       ) : (
         <button
-          onClick={() => fieldViewSpec.fieldSpec.props.onSelectImage(setMedia)}
+          onClick={() =>
+            fieldViewSpec.fieldDescription.props.onSelectImage(setMedia)
+          }
         >
           Choose Image
         </button>

--- a/src/elements/embed/EmbedForm.tsx
+++ b/src/elements/embed/EmbedForm.tsx
@@ -1,51 +1,51 @@
 import React from "react";
-import { Field } from "../../editorial-source-components/Field";
+import { FieldWrapper } from "../../e../../editorial-source-components/FieldWrapper"
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
-import type { FieldNameToFieldViewSpec } from "../../plugin/types/Element";
+import type { FieldNameToField } from "../../plugin/types/Element";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import type { embedFields } from "./EmbedSpec";
 
 type Props = {
-  fields: FieldNameToValueMap<typeof embedFields>;
+  fieldValues: FieldNameToValueMap<typeof embedFields>;
   errors: Record<string, string[]>;
-  fieldViewSpecMap: FieldNameToFieldViewSpec<typeof embedFields>;
+  fields: FieldNameToField<typeof embedFields>;
 };
 
 export const EmbedElementTestId = "EmbedElement";
 
 export const EmbedElementForm: React.FunctionComponent<Props> = ({
   errors,
-  fieldViewSpecMap: fieldViewSpecs,
+  fields,
 }) => (
   <div data-cy={EmbedElementTestId}>
     <CustomDropdownView
-      fieldViewSpec={fieldViewSpecs.weighting}
+      field={fields.weighting}
       label="Weighting"
       errors={errors.weighting}
     />
-    <Field
-      fieldViewSpec={fieldViewSpecs.sourceUrl}
+    <FieldWrapper
+      field={fields.sourceUrl}
       errors={errors.sourceUrl}
       label="Source URL"
     />
-    <Field
-      fieldViewSpec={fieldViewSpecs.embedCode}
+    <FieldWrapper
+      field={fields.embedCode}
       errors={errors.embedCode}
       label="Embed code"
     />
-    <Field
-      fieldViewSpec={fieldViewSpecs.caption}
+    <FieldWrapper
+      field={fields.caption}
       errors={errors.caption}
       label="Caption"
     />
-    <Field
-      fieldViewSpec={fieldViewSpecs.altText}
+    <FieldWrapper
+      field={fields.altText}
       errors={errors.altText}
       label="Alt text"
     />
     <CustomCheckboxView
-      fieldViewSpec={fieldViewSpecs.required}
+      field={fields.required}
       errors={errors.required}
       label="This element is required for publication"
     />

--- a/src/elements/embed/EmbedForm.tsx
+++ b/src/elements/embed/EmbedForm.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { FieldWrapper } from "../../e../../editorial-source-components/FieldWrapper";
+import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
 import type { FieldNameToField } from "../../plugin/types/Element";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";

--- a/src/elements/embed/EmbedForm.tsx
+++ b/src/elements/embed/EmbedForm.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { FieldWrapper } from "../../e../../editorial-source-components/FieldWrapper"
+import { FieldWrapper } from "../../e../../editorial-source-components/FieldWrapper";
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
 import type { FieldNameToField } from "../../plugin/types/Element";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -29,12 +29,12 @@ export const embedFields = {
 export const createEmbedElement = () =>
   createReactElementSpec(
     embedFields,
-    (fields, errors, __, fieldViewSpecs) => {
+    (fieldValues, errors, __, fields) => {
       return (
         <EmbedElementForm
           fields={fields}
           errors={errors}
-          fieldViewSpecMap={fieldViewSpecs}
+          fieldValues={fieldValues}
         />
       );
     },

--- a/src/elements/pullquote/PullquoteForm.tsx
+++ b/src/elements/pullquote/PullquoteForm.tsx
@@ -7,34 +7,31 @@ import type { pullquoteFields } from "./PullquoteSpec";
 
 type Props = {
   errors: Record<string, string[]>;
-  fieldViewSpecs: FieldNameToField<typeof pullquoteFields>;
+  fields: FieldNameToField<typeof pullquoteFields>;
 };
 
 export const PullquoteElementTestId = "PullquoteElement";
 
 export const PullquoteElementForm: React.FunctionComponent<Props> = ({
   errors,
-  fieldViewSpecs,
+  fields,
 }) => (
   <div data-cy={PullquoteElementTestId}>
     <Columns>
       <Column width={2 / 3}>
         <FieldWrapper
           label="Pullquote"
-          field={fieldViewSpecs.pullquote}
+          field={fields.pullquote}
           errors={errors.pullquote}
         />
       </Column>
       <Column width={1 / 3}>
         <FieldWrapper
           label="Attribution"
-          field={fieldViewSpecs.attribution}
+          field={fields.attribution}
           errors={errors.attribution}
         />
-        <CustomDropdownView
-          label="Weighting"
-          field={fieldViewSpecs.weighting}
-        />
+        <CustomDropdownView label="Weighting" field={fields.weighting} />
       </Column>
     </Columns>
   </div>

--- a/src/elements/pullquote/PullquoteForm.tsx
+++ b/src/elements/pullquote/PullquoteForm.tsx
@@ -1,13 +1,13 @@
 import { Column, Columns } from "@guardian/src-layout";
 import React from "react";
-import { Field } from "../../editorial-source-components/Field";
-import type { FieldNameToFieldViewSpec } from "../../plugin/types/Element";
+import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import type { FieldNameToField } from "../../plugin/types/Element";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import type { pullquoteFields } from "./PullquoteSpec";
 
 type Props = {
   errors: Record<string, string[]>;
-  fieldViewSpecs: FieldNameToFieldViewSpec<typeof pullquoteFields>;
+  fieldViewSpecs: FieldNameToField<typeof pullquoteFields>;
 };
 
 export const PullquoteElementTestId = "PullquoteElement";
@@ -19,21 +19,21 @@ export const PullquoteElementForm: React.FunctionComponent<Props> = ({
   <div data-cy={PullquoteElementTestId}>
     <Columns>
       <Column width={2 / 3}>
-        <Field
+        <FieldWrapper
           label="Pullquote"
-          fieldViewSpec={fieldViewSpecs.pullquote}
+          field={fieldViewSpecs.pullquote}
           errors={errors.pullquote}
         />
       </Column>
       <Column width={1 / 3}>
-        <Field
+        <FieldWrapper
           label="Attribution"
-          fieldViewSpec={fieldViewSpecs.attribution}
+          field={fieldViewSpecs.attribution}
           errors={errors.attribution}
         />
         <CustomDropdownView
           label="Weighting"
-          fieldViewSpec={fieldViewSpecs.weighting}
+          field={fieldViewSpecs.weighting}
         />
       </Column>
     </Columns>

--- a/src/elements/pullquote/PullquoteSpec.tsx
+++ b/src/elements/pullquote/PullquoteSpec.tsx
@@ -17,10 +17,8 @@ export const pullquoteFields = {
 
 export const pullquoteElement = createReactElementSpec(
   pullquoteFields,
-  (_, errors, __, fieldViewSpecs) => {
-    return (
-      <PullquoteElementForm errors={errors} fieldViewSpecs={fieldViewSpecs} />
-    );
+  (_, errors, __, fields) => {
+    return <PullquoteElementForm errors={errors} fields={fields} />;
   },
   createValidator({ pullquote: [htmlRequired()] })
 );

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -1,7 +1,7 @@
 import type { Node } from "prosemirror-model";
 import { buildElementPlugin } from "../element";
 import { createElementSpec } from "../elementSpec";
-import type { CustomField } from "../fieldViews/CustomFieldView";
+import type { CustomFieldDescription } from "../fieldViews/CustomFieldView";
 import {
   createEditorWithElements,
   createNoopElement,
@@ -73,7 +73,7 @@ describe("buildElementPlugin", () => {
         field2: {
           type: "custom",
           defaultValue: { arbitraryValue: "hai" },
-        } as CustomField<{ arbitraryValue: string }>,
+        } as CustomFieldDescription<{ arbitraryValue: string }>,
       });
       const { insertElement } = buildElementPlugin({ testElement });
       insertElement({
@@ -99,7 +99,7 @@ describe("buildElementPlugin", () => {
             props: {
               callback,
             },
-          } as CustomField<
+          } as CustomFieldDescription<
             { arbitraryValue: string },
             { callback: () => void }
           >,
@@ -177,7 +177,7 @@ describe("buildElementPlugin", () => {
         field1: {
           type: "custom",
           defaultValue: { arbitraryValue: "hai" },
-        } as CustomField<{ arbitraryValue: string }>,
+        } as CustomFieldDescription<{ arbitraryValue: string }>,
       });
       const { insertElement } = buildElementPlugin({ testElement });
       insertElement({
@@ -293,7 +293,7 @@ describe("buildElementPlugin", () => {
         field1: {
           type: "custom",
           defaultValue: { arbitraryValue: "hai" },
-        } as CustomField<{ arbitraryValue: string }>,
+        } as CustomFieldDescription<{ arbitraryValue: string }>,
       });
       const {
         view,

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -90,7 +90,7 @@ describe("buildElementPlugin", () => {
         return;
       };
 
-      const createFieldSpec = (callback: () => void) => {
+      const createFieldDescriptions = (callback: () => void) => {
         return {
           field1: { type: "richText" },
           field2: {
@@ -106,7 +106,7 @@ describe("buildElementPlugin", () => {
         } as const;
       };
 
-      const testElement = createNoopElement(createFieldSpec(noop));
+      const testElement = createNoopElement(createFieldDescriptions(noop));
 
       const { insertElement } = buildElementPlugin({ testElement });
       insertElement({

--- a/src/plugin/__tests__/elementSpec.spec.ts
+++ b/src/plugin/__tests__/elementSpec.spec.ts
@@ -7,15 +7,15 @@ import { getNodeNameFromField } from "../nodeSpec";
 describe("mount", () => {
   describe("fieldView typesafety", () => {
     it("should provide typesafe fieldView to its consumer", () => {
-      const fieldSpec = {
+      const fieldDescriptions = {
         field1: {
           type: "richText",
         },
       } as const;
       createElementSpec(
-        fieldSpec,
+        fieldDescriptions,
         (_, __, fieldViews) => {
-          // field1 is derived from the fieldSpec
+          // field1 is derived from the fieldDescriptions
           fieldViews.field1;
         },
         () => null
@@ -23,16 +23,16 @@ describe("mount", () => {
     });
 
     it("should not typecheck when fields are not provided", () => {
-      const fieldSpec = {
+      const fieldDescriptions = {
         notField1: {
           type: "richText",
         },
       } as const;
       createElementSpec(
-        fieldSpec,
+        fieldDescriptions,
         (_, __, fieldViews) => {
           // @ts-expect-error – field1 is not available on this object,
-          // as it is not defined in `fieldSpec` passed into `mount`
+          // as it is not defined in `fieldDescriptions` passed into `mount`
           fieldViews.field1;
         },
         () => null
@@ -42,7 +42,7 @@ describe("mount", () => {
 
   describe("validator typesafety", () => {
     it("should provide typesafe fields to its validator", () => {
-      const fieldSpec = {
+      const fieldDescriptions = {
         field1: {
           type: "richText",
         },
@@ -52,10 +52,10 @@ describe("mount", () => {
         },
       } as const;
       createElementSpec(
-        fieldSpec,
+        fieldDescriptions,
         () => () => undefined,
         (fields) => {
-          // field1 is derived from the fieldSpec, and is a string b/c it's a richText field
+          // field1 is derived from the fieldDescriptions, and is a string b/c it's a richText field
           fields.field1.toString();
           // field2 is a boolean b/c it's a checkbox field
           fields.field2.value.valueOf();
@@ -65,17 +65,17 @@ describe("mount", () => {
     });
 
     it("should not typecheck when fields are not provided", () => {
-      const fieldSpec = {
+      const fieldDescriptions = {
         notField1: {
           type: "richText",
         },
       } as const;
       createElementSpec(
-        fieldSpec,
+        fieldDescriptions,
         () => () => undefined,
         (fields) => {
           // @ts-expect-error – field1 is not available on this object,
-          // as it is not defined in `fieldSpec` passed into `mount`
+          // as it is not defined in `fieldDescriptions` passed into `mount`
           fields.doesNotExist;
           return null;
         }
@@ -122,7 +122,7 @@ describe("mount", () => {
     describe("fields", () => {
       describe("richText", () => {
         it("should allow the user to specify custom toDOM and parseDOM properties on richText fields", () => {
-          const fieldSpec = {
+          const fieldDescriptions = {
             field1: {
               type: "richText" as const,
               nodeSpec: {
@@ -133,22 +133,22 @@ describe("mount", () => {
             },
           };
 
-          const testElement1 = createNoopElement(fieldSpec);
+          const testElement1 = createNoopElement(fieldDescriptions);
           const { nodeSpec } = buildElementPlugin({ testElement1 });
 
           expect(
             nodeSpec.get(getNodeNameFromField("field1", "testElement1"))
           ).toEqual({
-            content: fieldSpec.field1.nodeSpec.content,
-            toDOM: fieldSpec.field1.nodeSpec.toDOM,
-            parseDOM: fieldSpec.field1.nodeSpec.parseDOM,
+            content: fieldDescriptions.field1.nodeSpec.content,
+            toDOM: fieldDescriptions.field1.nodeSpec.toDOM,
+            parseDOM: fieldDescriptions.field1.nodeSpec.parseDOM,
           });
         });
       });
 
       describe("text", () => {
         it("should provide a default inline node spec", () => {
-          const fieldSpec = {
+          const fieldDescriptions = {
             field1: {
               type: "text" as const,
               isMultiline: false,
@@ -157,7 +157,7 @@ describe("mount", () => {
             },
           };
 
-          const testElement1 = createNoopElement(fieldSpec);
+          const testElement1 = createNoopElement(fieldDescriptions);
           const { nodeSpec } = buildElementPlugin({ testElement1 });
           const field1NodeSpec = nodeSpec.get(
             getNodeNameFromField("field1", "testElement1")
@@ -171,14 +171,14 @@ describe("mount", () => {
 
       describe("checkbox", () => {
         it("should specify the appropriate fields on checkbox fields", () => {
-          const fieldSpec = {
+          const fieldDescriptions = {
             field1: {
               type: "checkbox" as const,
               defaultValue: { value: true },
             },
           };
 
-          const testElement1 = createNoopElement(fieldSpec);
+          const testElement1 = createNoopElement(fieldDescriptions);
           const { nodeSpec } = buildElementPlugin({ testElement1 });
           expect(
             nodeSpec.get(getNodeNameFromField("field1", "testElement1"))
@@ -197,14 +197,14 @@ describe("mount", () => {
 
       describe("custom", () => {
         it("should specify the appropriate fields for custom fields", () => {
-          const fieldSpec = {
+          const fieldDescriptions = {
             field1: {
               type: "custom",
               defaultValue: { arbitraryField: "hai" },
             } as CustomField<{ arbitraryField: string }>,
           };
 
-          const testElement1 = createNoopElement(fieldSpec);
+          const testElement1 = createNoopElement(fieldDescriptions);
           const { nodeSpec } = buildElementPlugin({ testElement1 });
           expect(
             nodeSpec.get(getNodeNameFromField("field1", "testElement1"))

--- a/src/plugin/__tests__/elementSpec.spec.ts
+++ b/src/plugin/__tests__/elementSpec.spec.ts
@@ -1,6 +1,6 @@
 import { buildElementPlugin } from "../element";
 import { createElementSpec } from "../elementSpec";
-import type { CustomField } from "../fieldViews/CustomFieldView";
+import type { CustomFieldDescription } from "../fieldViews/CustomFieldView";
 import { createNoopElement } from "../helpers/test";
 import { getNodeNameFromField } from "../nodeSpec";
 
@@ -201,7 +201,7 @@ describe("mount", () => {
             field1: {
               type: "custom",
               defaultValue: { arbitraryField: "hai" },
-            } as CustomField<{ arbitraryField: string }>,
+            } as CustomFieldDescription<{ arbitraryField: string }>,
           };
 
           const testElement1 = createNoopElement(fieldDescriptions);

--- a/src/plugin/element.ts
+++ b/src/plugin/element.ts
@@ -6,12 +6,12 @@ import {
   createGetNodeFromElementData,
 } from "./helpers/element";
 import { buildCommands, defaultPredicate } from "./helpers/prosemirror";
-import { getNodeSpecFromFieldSpec } from "./nodeSpec";
+import { getNodeSpecFromFieldDescriptions } from "./nodeSpec";
 import { createPlugin } from "./plugin";
 import type {
   ElementSpecMap,
   ExtractPartialDataTypeFromElementSpec,
-  FieldSpec,
+  FieldDescriptions,
 } from "./types/Element";
 
 /**
@@ -19,10 +19,10 @@ import type {
  * by those elements, and a method to insert elements into the document.
  */
 export const buildElementPlugin = <
-  FSpec extends FieldSpec<keyof FSpec>,
+  FDesc extends FieldDescriptions<keyof FDesc>,
   ElementNames extends keyof ESpecMap,
   ExternalData,
-  ESpecMap extends ElementSpecMap<FSpec, ElementNames, ExternalData>
+  ESpecMap extends ElementSpecMap<FDesc, ElementNames, ExternalData>
 >(
   elementSpecs: ESpecMap,
   predicate = defaultPredicate
@@ -51,7 +51,10 @@ export const buildElementPlugin = <
   let nodeSpec: OrderedMap<NodeSpec> = OrderedMap.from({});
   for (const elementName in elementSpecs) {
     nodeSpec = nodeSpec.append(
-      getNodeSpecFromFieldSpec(elementName, elementSpecs[elementName].fieldSpec)
+      getNodeSpecFromFieldDescriptions(
+        elementName,
+        elementSpecs[elementName].fieldDescriptions
+      )
     );
   }
 

--- a/src/plugin/elementSpec.ts
+++ b/src/plugin/elementSpec.ts
@@ -2,23 +2,25 @@ import type { FieldNameToValueMap } from "./fieldViews/helpers";
 import type { CommandCreator, Commands } from "./types/Commands";
 import type {
   ElementSpec,
+  FieldDescriptions,
   FieldNameToFieldViewSpec,
-  FieldSpec,
   Transformers,
 } from "./types/Element";
 
-type Subscriber<FSpec extends FieldSpec<string>> = (
-  fields: FieldNameToValueMap<FSpec>,
+type Subscriber<FDesc extends FieldDescriptions<string>> = (
+  fields: FieldNameToValueMap<FDesc>,
   commands: ReturnType<CommandCreator>
 ) => void;
 
-type Updater<FSpec extends FieldSpec<string>> = {
-  update: Subscriber<FSpec>;
-  subscribe: (s: Subscriber<FSpec>) => void;
+type Updater<FDesc extends FieldDescriptions<string>> = {
+  update: Subscriber<FDesc>;
+  subscribe: (s: Subscriber<FDesc>) => void;
 };
 
-const createUpdater = <FSpec extends FieldSpec<string>>(): Updater<FSpec> => {
-  let sub: Subscriber<FSpec> = () => undefined;
+const createUpdater = <
+  FDesc extends FieldDescriptions<string>
+>(): Updater<FDesc> => {
+  let sub: Subscriber<FDesc> = () => undefined;
   return {
     subscribe: (fn) => {
       sub = fn;
@@ -27,41 +29,41 @@ const createUpdater = <FSpec extends FieldSpec<string>>(): Updater<FSpec> => {
   };
 };
 
-export type Validator<FSpec extends FieldSpec<string>> = (
-  fields: FieldNameToValueMap<FSpec>
+export type Validator<FDesc extends FieldDescriptions<string>> = (
+  fields: FieldNameToValueMap<FDesc>
 ) => null | Record<string, string[]>;
 
-export type Renderer<FSpec extends FieldSpec<string>> = (
-  validate: Validator<FSpec>,
+export type Renderer<FDesc extends FieldDescriptions<string>> = (
+  validate: Validator<FDesc>,
   // The HTMLElement representing the node parent. The renderer can mount onto this node.
   dom: HTMLElement,
   // The HTMLElement representing the node's children, if there are any. The renderer can
   // choose to append this node if it needs to render children.
-  fieldViewSpecs: FieldNameToFieldViewSpec<FSpec>,
-  updateState: (fields: FieldNameToValueMap<FSpec>) => void,
-  fields: FieldNameToValueMap<FSpec>,
+  fieldViewSpecs: FieldNameToFieldViewSpec<FDesc>,
+  updateState: (fields: FieldNameToValueMap<FDesc>) => void,
+  fields: FieldNameToValueMap<FDesc>,
   commands: Commands,
   subscribe: (
     fn: (
-      fields: FieldNameToValueMap<FSpec>,
+      fields: FieldNameToValueMap<FDesc>,
       commands: ReturnType<CommandCreator>
     ) => void
   ) => void
 ) => void;
 
 export const createElementSpec = <
-  FSpec extends FieldSpec<string>,
+  FDesc extends FieldDescriptions<string>,
   ExternalData
 >(
-  fieldSpec: FSpec,
-  render: Renderer<FSpec>,
-  validate: Validator<FSpec>,
-  transformers?: Transformers<FSpec, ExternalData>
-): ElementSpec<FSpec, ExternalData> => ({
-  fieldSpec,
+  fieldDescriptions: FDesc,
+  render: Renderer<FDesc>,
+  validate: Validator<FDesc>,
+  transformers?: Transformers<FDesc, ExternalData>
+): ElementSpec<FDesc, ExternalData> => ({
+  fieldDescriptions,
   transformers,
   createUpdator: (dom, fields, updateState, fieldValues, commands) => {
-    const updater = createUpdater<FSpec>();
+    const updater = createUpdater<FDesc>();
     render(
       validate,
       dom,

--- a/src/plugin/elementSpec.ts
+++ b/src/plugin/elementSpec.ts
@@ -39,9 +39,9 @@ export type Renderer<FDesc extends FieldDescriptions<string>> = (
   dom: HTMLElement,
   // The HTMLElement representing the node's children, if there are any. The renderer can
   // choose to append this node if it needs to render children.
-  fieldViewSpecs: FieldNameToField<FDesc>,
+  fields: FieldNameToField<FDesc>,
   updateState: (fields: FieldNameToValueMap<FDesc>) => void,
-  fields: FieldNameToValueMap<FDesc>,
+  fieldValues: FieldNameToValueMap<FDesc>,
   commands: Commands,
   subscribe: (
     fn: (

--- a/src/plugin/elementSpec.ts
+++ b/src/plugin/elementSpec.ts
@@ -3,7 +3,7 @@ import type { CommandCreator, Commands } from "./types/Commands";
 import type {
   ElementSpec,
   FieldDescriptions,
-  FieldNameToFieldViewSpec,
+  FieldNameToField,
   Transformers,
 } from "./types/Element";
 
@@ -39,7 +39,7 @@ export type Renderer<FDesc extends FieldDescriptions<string>> = (
   dom: HTMLElement,
   // The HTMLElement representing the node's children, if there are any. The renderer can
   // choose to append this node if it needs to render children.
-  fieldViewSpecs: FieldNameToFieldViewSpec<FDesc>,
+  fieldViewSpecs: FieldNameToField<FDesc>,
   updateState: (fields: FieldNameToValueMap<FDesc>) => void,
   fields: FieldNameToValueMap<FDesc>,
   commands: Commands,

--- a/src/plugin/fieldViews/CheckboxFieldView.ts
+++ b/src/plugin/fieldViews/CheckboxFieldView.ts
@@ -5,11 +5,11 @@ import type { BaseFieldDescription } from "./FieldView";
 
 export type CheckboxValue = { value: boolean };
 
-export interface CheckboxField extends BaseFieldDescription<CheckboxValue> {
+export interface CheckboxFieldDescription extends BaseFieldDescription<CheckboxValue> {
   type: typeof CheckboxFieldView.fieldName;
 }
 
-export const createCheckBox = (defaultValue: boolean): CheckboxField => ({
+export const createCheckBox = (defaultValue: boolean): CheckboxFieldDescription => ({
   type: CheckboxFieldView.fieldName,
   defaultValue: { value: defaultValue },
 });

--- a/src/plugin/fieldViews/CheckboxFieldView.ts
+++ b/src/plugin/fieldViews/CheckboxFieldView.ts
@@ -1,11 +1,11 @@
 import type { Node } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
 import { AttributeFieldView } from "./AttributeFieldView";
-import type { BaseFieldSpec } from "./FieldView";
+import type { BaseFieldDescription } from "./FieldView";
 
 export type CheckboxValue = { value: boolean };
 
-export interface CheckboxField extends BaseFieldSpec<CheckboxValue> {
+export interface CheckboxField extends BaseFieldDescription<CheckboxValue> {
   type: typeof CheckboxFieldView.fieldName;
 }
 

--- a/src/plugin/fieldViews/CheckboxFieldView.ts
+++ b/src/plugin/fieldViews/CheckboxFieldView.ts
@@ -5,11 +5,14 @@ import type { BaseFieldDescription } from "./FieldView";
 
 export type CheckboxValue = { value: boolean };
 
-export interface CheckboxFieldDescription extends BaseFieldDescription<CheckboxValue> {
+export interface CheckboxFieldDescription
+  extends BaseFieldDescription<CheckboxValue> {
   type: typeof CheckboxFieldView.fieldName;
 }
 
-export const createCheckBox = (defaultValue: boolean): CheckboxFieldDescription => ({
+export const createCheckBox = (
+  defaultValue: boolean
+): CheckboxFieldDescription => ({
   type: CheckboxFieldView.fieldName,
   defaultValue: { value: defaultValue },
 });

--- a/src/plugin/fieldViews/CustomFieldView.ts
+++ b/src/plugin/fieldViews/CustomFieldView.ts
@@ -3,7 +3,7 @@ import type { EditorView } from "prosemirror-view";
 import type { BaseFieldDescription, FieldView } from "./FieldView";
 import { FieldType } from "./FieldView";
 
-export interface CustomField<Data = unknown, Props = unknown>
+export interface CustomFieldDescription<Data = unknown, Props = unknown>
   extends BaseFieldDescription<Data> {
   type: typeof CustomFieldView.fieldName;
   defaultValue: Data;
@@ -13,7 +13,7 @@ export interface CustomField<Data = unknown, Props = unknown>
 export const createCustomField = <Data, Props>(
   defaultValue: Data,
   props: Props
-): CustomField<Data, Props> => ({
+): CustomFieldDescription<Data, Props> => ({
   type: "custom" as const,
   defaultValue,
   props,

--- a/src/plugin/fieldViews/CustomFieldView.ts
+++ b/src/plugin/fieldViews/CustomFieldView.ts
@@ -1,10 +1,10 @@
 import type { Node } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
-import type { BaseFieldSpec, FieldView } from "./FieldView";
+import type { BaseFieldDescription, FieldView } from "./FieldView";
 import { FieldType } from "./FieldView";
 
 export interface CustomField<Data = unknown, Props = unknown>
-  extends BaseFieldSpec<Data> {
+  extends BaseFieldDescription<Data> {
   type: typeof CustomFieldView.fieldName;
   defaultValue: Data;
   props: Props;

--- a/src/plugin/fieldViews/DropdownFieldView.ts
+++ b/src/plugin/fieldViews/DropdownFieldView.ts
@@ -1,12 +1,12 @@
 import type { Node } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
 import { AttributeFieldView } from "./AttributeFieldView";
-import type { BaseFieldSpec } from "./FieldView";
+import type { BaseFieldDescription } from "./FieldView";
 
 export type Option<Data> = { text: string; value: Data };
 type Options<Data> = ReadonlyArray<Option<Data>>;
 
-export interface DropdownField extends BaseFieldSpec<string> {
+export interface DropdownField extends BaseFieldDescription<string> {
   type: typeof DropdownFieldView.fieldName;
   options: ReadonlyArray<Option<string>>;
 }

--- a/src/plugin/fieldViews/DropdownFieldView.ts
+++ b/src/plugin/fieldViews/DropdownFieldView.ts
@@ -6,7 +6,7 @@ import type { BaseFieldDescription } from "./FieldView";
 export type Option<Data> = { text: string; value: Data };
 type Options<Data> = ReadonlyArray<Option<Data>>;
 
-export interface DropdownField extends BaseFieldDescription<string> {
+export interface DropdownFieldDescription extends BaseFieldDescription<string> {
   type: typeof DropdownFieldView.fieldName;
   options: ReadonlyArray<Option<string>>;
 }
@@ -14,7 +14,7 @@ export interface DropdownField extends BaseFieldDescription<string> {
 export const createDropDownField = (
   options: Options<string>,
   defaultValue: string
-): DropdownField => ({
+): DropdownFieldDescription => ({
   type: DropdownFieldView.fieldName,
   options,
   defaultValue,

--- a/src/plugin/fieldViews/FieldView.ts
+++ b/src/plugin/fieldViews/FieldView.ts
@@ -4,7 +4,7 @@ import type { Decoration, DecorationSet } from "prosemirror-view";
 /**
  * The specification for an element field, to be modelled as a Node in Prosemirror.
  */
-export interface BaseFieldSpec<DefaultValue extends unknown> {
+export interface BaseFieldDescription<DefaultValue extends unknown> {
   // The data type of the field.
   type: string;
   defaultValue?: DefaultValue;

--- a/src/plugin/fieldViews/RichTextFieldView.ts
+++ b/src/plugin/fieldViews/RichTextFieldView.ts
@@ -7,7 +7,7 @@ import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import type { BaseFieldDescription } from "./FieldView";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
 
-export interface RichTextField extends BaseFieldDescription<string> {
+export interface RichTextFieldDescription extends BaseFieldDescription<string> {
   type: typeof RichTextFieldView.fieldName;
   createPlugins?: (schema: Schema) => Plugin[];
   nodeSpec?: Partial<NodeSpec>;
@@ -21,7 +21,7 @@ type RichTextOptions = {
 export const createRichTextField = ({
   createPlugins,
   nodeSpec,
-}: RichTextOptions): RichTextField => ({
+}: RichTextOptions): RichTextFieldDescription => ({
   type: RichTextFieldView.fieldName,
   createPlugins,
   nodeSpec,
@@ -38,7 +38,7 @@ type FlatRichTextOptions = RichTextOptions & {
 export const createFlatRichTextField = ({
   createPlugins,
   nodeSpec,
-}: FlatRichTextOptions): RichTextField =>
+}: FlatRichTextOptions): RichTextFieldDescription =>
   createRichTextField({
     createPlugins: (schema) => {
       const br = schema.nodes.hard_break;
@@ -71,7 +71,7 @@ export const createFlatRichTextField = ({
  * Create a rich text field with a default setup. Largely for demonstrative
  * purposes, as library users are likely to want different defaults.
  */
-export const createDefaultRichTextField = (): RichTextField =>
+export const createDefaultRichTextField = (): RichTextFieldDescription =>
   createRichTextField({ createPlugins: (schema) => exampleSetup({ schema }) });
 
 export class RichTextFieldView extends ProseMirrorFieldView {

--- a/src/plugin/fieldViews/RichTextFieldView.ts
+++ b/src/plugin/fieldViews/RichTextFieldView.ts
@@ -4,10 +4,10 @@ import { keymap } from "prosemirror-keymap";
 import type { Node, NodeSpec, Schema } from "prosemirror-model";
 import type { EditorState, Plugin, Transaction } from "prosemirror-state";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
-import type { BaseFieldSpec } from "./FieldView";
+import type { BaseFieldDescription } from "./FieldView";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
 
-export interface RichTextField extends BaseFieldSpec<string> {
+export interface RichTextField extends BaseFieldDescription<string> {
   type: typeof RichTextFieldView.fieldName;
   createPlugins?: (schema: Schema) => Plugin[];
   nodeSpec?: Partial<NodeSpec>;

--- a/src/plugin/fieldViews/TextFieldView.ts
+++ b/src/plugin/fieldViews/TextFieldView.ts
@@ -5,10 +5,10 @@ import { keymap } from "prosemirror-keymap";
 import type { Node, Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
-import type { BaseFieldSpec } from "./FieldView";
+import type { BaseFieldDescription } from "./FieldView";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
 
-export interface TextField extends BaseFieldSpec<string> {
+export interface TextField extends BaseFieldDescription<string> {
   type: typeof TextFieldView.fieldName;
   // Can this field display over multiple lines? This will
   // insert line breaks (<br>) when the user hits the Enter key.

--- a/src/plugin/fieldViews/TextFieldView.ts
+++ b/src/plugin/fieldViews/TextFieldView.ts
@@ -8,7 +8,7 @@ import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import type { BaseFieldDescription } from "./FieldView";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
 
-export interface TextField extends BaseFieldDescription<string> {
+export interface TextFieldDescription extends BaseFieldDescription<string> {
   type: typeof TextFieldView.fieldName;
   // Can this field display over multiple lines? This will
   // insert line breaks (<br>) when the user hits the Enter key.
@@ -30,7 +30,7 @@ export const createTextField = (
     rows: 1,
   },
   isCode = false
-): TextField => ({
+): TextFieldDescription => ({
   type: TextFieldView.fieldName,
   isMultiline,
   rows,
@@ -51,7 +51,7 @@ export class TextFieldView extends ProseMirrorFieldView {
     offset: number,
     // The initial decorations for the FieldView.
     decorations: DecorationSet | Decoration[],
-    { isMultiline, rows, isCode }: TextField
+    { isMultiline, rows, isCode }: TextFieldDescription
   ) {
     const keymapping: Record<string, Command> = {
       "Mod-z": () => undo(outerView.state, outerView.dispatch),

--- a/src/plugin/fieldViews/helpers.ts
+++ b/src/plugin/fieldViews/helpers.ts
@@ -1,4 +1,4 @@
-import type { FieldSpec } from "../types/Element";
+import type { FieldDescriptions } from "../types/Element";
 import { CheckboxFieldView } from "./CheckboxFieldView";
 import type { CheckboxValue } from "./CheckboxFieldView";
 import type { CustomField } from "./CustomFieldView";
@@ -29,21 +29,21 @@ export type FieldTypeToViewMap<Field> = {
  * A map from all FieldView types to the serialised values they create at runtime.
  */
 export type FieldTypeToValueMap<
-  FSpec extends FieldSpec<string>,
-  Name extends keyof FSpec
+  FDesc extends FieldDescriptions<string>,
+  Name extends keyof FDesc
 > = {
   [TextFieldView.fieldName]: string;
   [RichTextFieldView.fieldName]: string;
   [CheckboxFieldView.fieldName]: CheckboxValue;
   [DropdownFieldView.fieldName]: string;
-  [CustomFieldView.fieldName]: FSpec[Name] extends CustomField<infer Data>
+  [CustomFieldView.fieldName]: FDesc[Name] extends CustomField<infer Data>
     ? Data
     : never;
 };
 
 /**
- * Get the values that would be provided by the given FieldSpec at runtime,
- * keyed by their names. For example, for the FieldSpec:
+ * Get the values that would be provided by the given FieldDescriptions at runtime,
+ * keyed by their names. For example, for the FieldDescriptions:
  *
  * `{ altText: { type: "richText" }, isVisible: { type: "checkbox" }}`
  *
@@ -51,6 +51,8 @@ export type FieldTypeToValueMap<
  *
  * `{ altText: string }, { isVisible: { value: boolean }}`
  */
-export type FieldNameToValueMap<FSpec extends FieldSpec<keyof FSpec>> = {
-  [Name in keyof FSpec]: FieldTypeToValueMap<FSpec, Name>[FSpec[Name]["type"]];
+export type FieldNameToValueMap<
+  FDesc extends FieldDescriptions<keyof FDesc>
+> = {
+  [Name in keyof FDesc]: FieldTypeToValueMap<FDesc, Name>[FDesc[Name]["type"]];
 };

--- a/src/plugin/fieldViews/helpers.ts
+++ b/src/plugin/fieldViews/helpers.ts
@@ -1,7 +1,7 @@
 import type { FieldDescriptions } from "../types/Element";
 import { CheckboxFieldView } from "./CheckboxFieldView";
 import type { CheckboxValue } from "./CheckboxFieldView";
-import type { CustomField } from "./CustomFieldView";
+import type { CustomFieldDescription } from "./CustomFieldView";
 import { CustomFieldView } from "./CustomFieldView";
 import { DropdownFieldView } from "./DropdownFieldView";
 import { RichTextFieldView } from "./RichTextFieldView";
@@ -20,7 +20,7 @@ export type FieldTypeToViewMap<Field> = {
   [RichTextFieldView.fieldName]: RichTextFieldView;
   [CheckboxFieldView.fieldName]: CheckboxFieldView;
   [DropdownFieldView.fieldName]: DropdownFieldView;
-  [CustomFieldView.fieldName]: Field extends CustomField<infer Data>
+  [CustomFieldView.fieldName]: Field extends CustomFieldDescription<infer Data>
     ? CustomFieldView<Data>
     : never;
 };
@@ -36,7 +36,9 @@ export type FieldTypeToValueMap<
   [RichTextFieldView.fieldName]: string;
   [CheckboxFieldView.fieldName]: CheckboxValue;
   [DropdownFieldView.fieldName]: string;
-  [CustomFieldView.fieldName]: FDesc[Name] extends CustomField<infer Data>
+  [CustomFieldView.fieldName]: FDesc[Name] extends CustomFieldDescription<
+    infer Data
+  >
     ? Data
     : never;
 };

--- a/src/plugin/helpers/element.ts
+++ b/src/plugin/helpers/element.ts
@@ -8,7 +8,7 @@ import type {
   ExtractFieldValues,
   ExtractPartialDataTypeFromElementSpec,
   FieldDescriptions,
-  FieldNameToFieldViewSpec,
+  FieldNameToField,
 } from "../types/Element";
 
 export const createGetNodeFromElementData = <
@@ -72,7 +72,7 @@ export const createGetElementDataFromNode = <
   node.forEach((node) => {
     const fieldName = getFieldNameFromNode(
       node
-    ) as keyof FieldNameToFieldViewSpec<FDesc>;
+    ) as keyof FieldNameToField<FDesc>;
     const fieldDescriptions = element.fieldDescriptions[fieldName];
     const fieldType = fieldTypeToViewMap[fieldDescriptions.type].fieldType;
 

--- a/src/plugin/helpers/element.ts
+++ b/src/plugin/helpers/element.ts
@@ -7,15 +7,15 @@ import type {
   ExtractDataTypeFromElementSpec,
   ExtractFieldValues,
   ExtractPartialDataTypeFromElementSpec,
+  FieldDescriptions,
   FieldNameToFieldViewSpec,
-  FieldSpec,
 } from "../types/Element";
 
 export const createGetNodeFromElementData = <
-  FSpec extends FieldSpec<keyof FSpec>,
+  FDesc extends FieldDescriptions<keyof FDesc>,
   ElementNames extends keyof ESpecMap,
   ExternalData,
-  ESpecMap extends ElementSpecMap<FSpec, ElementNames, ExternalData>
+  ESpecMap extends ElementSpecMap<FDesc, ElementNames, ExternalData>
 >(
   elementTypeMap: ESpecMap
 ) => (
@@ -40,8 +40,8 @@ export const createGetNodeFromElementData = <
 
   const nodes = createNodesForFieldValues(
     schema,
-    element.fieldSpec,
-    transformedValues as FieldNameToValueMap<FSpec>,
+    element.fieldDescriptions,
+    transformedValues as FieldNameToValueMap<FDesc>,
     elementName
   );
 
@@ -54,10 +54,10 @@ export const createGetNodeFromElementData = <
 };
 
 export const createGetElementDataFromNode = <
-  FSpec extends FieldSpec<keyof FSpec>,
+  FDesc extends FieldDescriptions<keyof FDesc>,
   ElementNames extends keyof ESpecMap,
   ExternalData,
-  ESpecMap extends ElementSpecMap<FSpec, ElementNames, ExternalData>
+  ESpecMap extends ElementSpecMap<FDesc, ElementNames, ExternalData>
 >(
   elementTypeMap: ESpecMap
 ) => (node: Node, serializer: DOMSerializer) => {
@@ -67,14 +67,14 @@ export const createGetElementDataFromNode = <
   // We gather the values from each child as we iterate over the
   // node, to update the renderer. It's difficult to be typesafe here,
   // as the Node's name value is loosely typed as `string`, and so we
-  // cannot index into the element `fieldSpec` to discover the appropriate type.
+  // cannot index into the element `fieldDescriptions` to discover the appropriate type.
   const values: Record<string, unknown> = {};
   node.forEach((node) => {
     const fieldName = getFieldNameFromNode(
       node
-    ) as keyof FieldNameToFieldViewSpec<FSpec>;
-    const fieldSpec = element.fieldSpec[fieldName];
-    const fieldType = fieldTypeToViewMap[fieldSpec.type].fieldType;
+    ) as keyof FieldNameToFieldViewSpec<FDesc>;
+    const fieldDescriptions = element.fieldDescriptions[fieldName];
+    const fieldType = fieldTypeToViewMap[fieldDescriptions.type].fieldType;
 
     values[fieldName] =
       fieldType === "ATTRIBUTES"

--- a/src/plugin/helpers/plugin.ts
+++ b/src/plugin/helpers/plugin.ts
@@ -5,7 +5,7 @@ import { CustomFieldView } from "../fieldViews/CustomFieldView";
 import { DropdownFieldView } from "../fieldViews/DropdownFieldView";
 import { RichTextFieldView } from "../fieldViews/RichTextFieldView";
 import { TextFieldView } from "../fieldViews/TextFieldView";
-import type { Field } from "../types/Element";
+import type { FieldDescription } from "../types/Element";
 
 type Options = {
   node: Node;
@@ -16,7 +16,7 @@ type Options = {
 };
 
 export const getElementFieldViewFromType = (
-  field: Field,
+  field: FieldDescription,
   { node, view, getPos, offset, innerDecos }: Options
 ) => {
   switch (field.type) {

--- a/src/plugin/helpers/test.ts
+++ b/src/plugin/helpers/test.ts
@@ -7,7 +7,7 @@ import { EditorState, Plugin, PluginKey } from "prosemirror-state";
 import { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import { buildElementPlugin } from "../element";
 import { createElementSpec } from "../elementSpec";
-import type { ElementSpecMap, FieldSpec } from "../types/Element";
+import type { ElementSpecMap, FieldDescriptions } from "../types/Element";
 import { createParsers } from "./prosemirror";
 
 const initialPhrase = "deco";
@@ -58,19 +58,19 @@ export const trimHtml = (html: string) => html.replace(/>\s+</g, "><").trim();
 /**
  * Create an element which renders nothing. Useful when testing schema output.
  */
-export const createNoopElement = <FSpec extends FieldSpec<string>>(
-  fieldSpec: FSpec
+export const createNoopElement = <FDesc extends FieldDescriptions<string>>(
+  fieldDescriptions: FDesc
 ) =>
   createElementSpec(
-    fieldSpec,
+    fieldDescriptions,
     () => null,
     () => null
   );
 
 export const createEditorWithElements = <
-  FSpec extends FieldSpec<keyof FSpec>,
+  FDesc extends FieldDescriptions<keyof FDesc>,
   ElementNames extends keyof ESpecMap,
-  ESpecMap extends ElementSpecMap<FSpec, ElementNames>
+  ESpecMap extends ElementSpecMap<FDesc, ElementNames>
 >(
   elements: ESpecMap,
   initialHTML = ""

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -1,12 +1,12 @@
 import type { FieldNameToValueMap } from "../fieldViews/helpers";
-import type { FieldSpec } from "../types/Element";
+import type { FieldDescriptions } from "../types/Element";
 
 type Validator = (fieldValue: unknown) => string[];
 
 export const createValidator = (
   fieldValidationMap: Record<string, Validator[]>
-) => <FSpec extends FieldSpec<string>>(
-  fieldValues: FieldNameToValueMap<FSpec>
+) => <FDesc extends FieldDescriptions<string>>(
+  fieldValues: FieldNameToValueMap<FDesc>
 ): Record<string, string[]> => {
   const errors: Record<string, string[]> = {};
 

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -4,8 +4,8 @@ import type { Decoration, DecorationSet, EditorProps } from "prosemirror-view";
 import type {
   ElementSpec,
   ElementSpecMap,
+  FieldDescriptions,
   FieldNameToFieldViewSpec,
-  FieldSpec,
 } from "../plugin/types/Element";
 import type { FieldNameToValueMap } from "./fieldViews/helpers";
 import { getElementFieldViewFromType } from "./helpers/plugin";
@@ -21,10 +21,10 @@ export type PluginState = { hasErrors: boolean };
 export const createPlugin = <
   ElementNames extends string,
   ExternalData,
-  FSpec extends FieldSpec<string>
+  FDesc extends FieldDescriptions<string>
 >(
   elementsSpec: {
-    [elementName in ElementNames]: ElementSpec<FSpec, ExternalData>;
+    [elementName in ElementNames]: ElementSpec<FDesc, ExternalData>;
   },
   commands: Commands
 ): Plugin<PluginState, Schema> => {
@@ -57,7 +57,7 @@ export const createPlugin = <
     props: {
       decorations,
       nodeViews: createNodeViews(
-        elementsSpec as ElementSpecMap<FSpec, ElementNames>,
+        elementsSpec as ElementSpecMap<FDesc, ElementNames>,
         commands
       ),
     },
@@ -68,9 +68,9 @@ type NodeViewSpec = NonNullable<EditorProps["nodeViews"]>;
 
 const createNodeViews = <
   ElementNames extends string,
-  FSpec extends FieldSpec<string>
+  FDesc extends FieldDescriptions<string>
 >(
-  elementsSpec: ElementSpecMap<FSpec, ElementNames>,
+  elementsSpec: ElementSpecMap<FDesc, ElementNames>,
   commands: Commands
 ): NodeViewSpec => {
   const nodeViews = {} as NodeViewSpec;
@@ -88,38 +88,38 @@ const createNodeViews = <
 type NodeViewCreator = NodeViewSpec[keyof NodeViewSpec];
 
 const createNodeView = <
-  FSpec extends FieldSpec<string>,
+  FDesc extends FieldDescriptions<string>,
   ElementName extends string
 >(
   elementName: ElementName,
-  element: ElementSpec<FSpec>,
+  element: ElementSpec<FDesc>,
   commands: Commands
 ): NodeViewCreator => (initNode, view, _getPos, _, innerDecos) => {
   const dom = document.createElement("div");
   dom.contentEditable = "false";
   const getPos = typeof _getPos === "boolean" ? () => 0 : _getPos;
 
-  const fieldViewSpecs = {} as FieldNameToFieldViewSpec<FSpec>;
+  const fieldViewSpecs = {} as FieldNameToFieldViewSpec<FDesc>;
 
   initNode.forEach((node, offset) => {
     const name = getFieldNameFromNode(
       node
-    ) as keyof FieldNameToFieldViewSpec<FSpec>;
+    ) as keyof FieldNameToFieldViewSpec<FDesc>;
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- unsure why this triggers
     if (fieldViewSpecs[name]) {
       throw new Error(
         `[prosemirror-elements]: Attempted to instantiate a nodeView with type ${name}, but another instance with that name has already been created.`
       );
     }
-    const fieldSpec = element.fieldSpec[name];
+    const fieldDescriptions = element.fieldDescriptions[name];
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- strictly, we should check.
-    if (!fieldSpec) {
+    if (!fieldDescriptions) {
       throw new Error(
         `[prosemirror-elements]: Attempted to instantiate a nodeView with type ${name}, but could not find the associate field`
       );
     }
 
-    const fieldView = getElementFieldViewFromType(fieldSpec, {
+    const fieldView = getElementFieldViewFromType(fieldDescriptions, {
       node,
       view,
       getPos,
@@ -128,7 +128,7 @@ const createNodeView = <
     });
 
     fieldViewSpecs[name] = ({
-      fieldSpec,
+      fieldDescription: fieldDescriptions,
       name,
       fieldView,
       // We coerce types here: it's difficult to prove we've the right shape here
@@ -137,7 +137,7 @@ const createNodeView = <
       // help to defend when something's wrong.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- as above
       update: (value: unknown) => fieldView.update(value as any),
-    } as unknown) as FieldNameToFieldViewSpec<FSpec>[typeof name];
+    } as unknown) as FieldNameToFieldViewSpec<FDesc>[typeof name];
   });
 
   const getValuesFromNode = (
@@ -147,18 +147,18 @@ const createNodeView = <
     // We gather the values from each child as we iterate over the
     // node, to update the renderer. It's difficult to be typesafe here,
     // as the Node's name value is loosely typed as `string`, and so we
-    // cannot index into the element `fieldSpec` to discover the appropriate type.
+    // cannot index into the element `fieldDescription` to discover the appropriate type.
     const fieldValues: Record<string, unknown> = {};
     node.forEach((node, offset) => {
       const fieldName = getFieldNameFromNode(
         node
-      ) as keyof FieldNameToFieldViewSpec<FSpec>;
+      ) as keyof FieldNameToFieldViewSpec<FDesc>;
       const fieldViewSpec = fieldViewSpecs[fieldName];
       fieldViewSpec.fieldView.onUpdate(node, offset, decos);
       fieldValues[fieldName] = fieldViewSpec.fieldView.getNodeValue(node);
     });
 
-    return fieldValues as FieldNameToValueMap<FSpec>;
+    return fieldValues as FieldNameToValueMap<FDesc>;
   };
 
   const update = element.createUpdator(

--- a/src/plugin/types/Consumer.ts
+++ b/src/plugin/types/Consumer.ts
@@ -1,5 +1,5 @@
 import type { FieldNameToValueMap } from "../fieldViews/helpers";
-import type { FieldDescriptions, FieldNameToFieldViewSpec } from "./Element";
+import type { FieldDescriptions, FieldNameToField } from "./Element";
 import type { Errors } from "./Errors";
 
 export type Consumer<
@@ -9,5 +9,5 @@ export type Consumer<
   fieldValues: FieldNameToValueMap<FDesc>,
   errors: Errors,
   updateFields: (fieldValues: FieldNameToValueMap<FDesc>) => void,
-  fields: FieldNameToFieldViewSpec<FDesc>
+  fields: FieldNameToField<FDesc>
 ) => ConsumerResult;

--- a/src/plugin/types/Consumer.ts
+++ b/src/plugin/types/Consumer.ts
@@ -1,10 +1,13 @@
 import type { FieldNameToValueMap } from "../fieldViews/helpers";
-import type { FieldNameToFieldViewSpec, FieldSpec } from "./Element";
+import type { FieldDescriptions, FieldNameToFieldViewSpec } from "./Element";
 import type { Errors } from "./Errors";
 
-export type Consumer<ConsumerResult, FSpec extends FieldSpec<string>> = (
-  fieldValues: FieldNameToValueMap<FSpec>,
+export type Consumer<
+  ConsumerResult,
+  FDesc extends FieldDescriptions<string>
+> = (
+  fieldValues: FieldNameToValueMap<FDesc>,
   errors: Errors,
-  updateFields: (fieldValues: FieldNameToValueMap<FSpec>) => void,
-  fields: FieldNameToFieldViewSpec<FSpec>
+  updateFields: (fieldValues: FieldNameToValueMap<FDesc>) => void,
+  fields: FieldNameToFieldViewSpec<FDesc>
 ) => ConsumerResult;

--- a/src/plugin/types/Element.ts
+++ b/src/plugin/types/Element.ts
@@ -54,27 +54,25 @@ export type NonCustomFieldViews =
   | RichTextFieldView
   | CheckboxFieldView;
 
-export interface FieldViewSpec<F> {
-  fieldView: F;
-  fieldDescription: FieldDescription;
+export interface Field<F> {
+  view: F;
+  description: FieldDescription;
   name: string;
   update: (value: F extends FieldView<infer Value> ? Value : never) => void;
 }
 
-export interface CustomFieldViewSpec<Data = unknown, Props = unknown>
-  extends FieldViewSpec<CustomFieldView<Data>> {
-  fieldDescription: CustomFieldDescription<Data, Props>;
+export interface CustomField<Data = unknown, Props = unknown>
+  extends Field<CustomFieldView<Data>> {
+  description: CustomFieldDescription<Data, Props>;
 }
 
-export type FieldNameToFieldViewSpec<
-  FDesc extends FieldDescriptions<string>
-> = {
+export type FieldNameToField<FDesc extends FieldDescriptions<string>> = {
   [name in Extract<
     keyof FDesc,
     string
   >]: FDesc[name] extends CustomFieldDescription<infer Data, infer Props>
-    ? CustomFieldViewSpec<Data, Props>
-    : FieldViewSpec<FieldTypeToViewMap<FDesc[name]>[FDesc[name]["type"]]>;
+    ? CustomField<Data, Props>
+    : Field<FieldTypeToViewMap<FDesc[name]>[FDesc[name]["type"]]>;
 };
 
 export type Transformers<
@@ -97,7 +95,7 @@ export type ElementSpec<
   transformers?: Transformers<FDesc, ExternalData>;
   createUpdator: (
     dom: HTMLElement,
-    fields: FieldNameToFieldViewSpec<FDesc>,
+    fields: FieldNameToField<FDesc>,
     updateState: (
       fields: FieldNameToValueMap<FDesc>,
       hasErrors: boolean

--- a/src/plugin/types/Element.ts
+++ b/src/plugin/types/Element.ts
@@ -23,18 +23,21 @@ import type {
 import type { TextField, TextFieldView } from "../fieldViews/TextFieldView";
 import type { CommandCreator } from "./Commands";
 
-export type Field =
+export type FieldDescription =
   | TextField
   | RichTextField
   | CheckboxField
   | CustomField
   | DropdownField;
 
-export type FieldSpec<Names extends string> = Record<Names, Field>;
+export type FieldDescriptions<Names extends string> = Record<
+  Names,
+  FieldDescription
+>;
 
-export type SchemaFromElementFieldSpec<
-  FSpec extends FieldSpec<string>
-> = Schema<Extract<keyof FSpec, string>>;
+export type SchemaFromElementFieldDescriptions<
+  FDesc extends FieldDescriptions<string>
+> = Schema<Extract<keyof FDesc, string>>;
 
 export type FieldViews =
   | TextFieldView
@@ -50,60 +53,65 @@ export type NonCustomFieldViews =
 
 export interface FieldViewSpec<F> {
   fieldView: F;
-  fieldSpec: Field;
+  fieldDescription: FieldDescription;
   name: string;
   update: (value: F extends FieldView<infer Value> ? Value : never) => void;
 }
 
 export interface CustomFieldViewSpec<Data = unknown, Props = unknown>
   extends FieldViewSpec<CustomFieldView<Data>> {
-  fieldSpec: CustomField<Data, Props>;
+  fieldDescription: CustomField<Data, Props>;
 }
 
-export type FieldNameToFieldViewSpec<FSpec extends FieldSpec<string>> = {
-  [name in Extract<keyof FSpec, string>]: FSpec[name] extends CustomField<
+export type FieldNameToFieldViewSpec<
+  FDesc extends FieldDescriptions<string>
+> = {
+  [name in Extract<keyof FDesc, string>]: FDesc[name] extends CustomField<
     infer Data,
     infer Props
   >
     ? CustomFieldViewSpec<Data, Props>
-    : FieldViewSpec<FieldTypeToViewMap<FSpec[name]>[FSpec[name]["type"]]>;
+    : FieldViewSpec<FieldTypeToViewMap<FDesc[name]>[FDesc[name]["type"]]>;
 };
 
-export type Transformers<FSpec extends FieldSpec<string>, ExternalData> = {
+export type Transformers<
+  FDesc extends FieldDescriptions<string>,
+  ExternalData
+> = {
   transformElementDataIn: (
     inputData: ExternalData
-  ) => FieldNameToValueMap<FSpec>;
+  ) => FieldNameToValueMap<FDesc>;
   transformElementDataOut: (
-    outputData: FieldNameToValueMap<FSpec>
+    outputData: FieldNameToValueMap<FDesc>
   ) => ExternalData;
 };
 
 export type ElementSpec<
-  FSpec extends FieldSpec<string>,
+  FDesc extends FieldDescriptions<string>,
   ExternalData = unknown
 > = {
-  fieldSpec: FSpec;
-  transformers?: Transformers<FSpec, ExternalData>;
+  fieldDescriptions: FDesc;
+  transformers?: Transformers<FDesc, ExternalData>;
   createUpdator: (
     dom: HTMLElement,
-    fields: FieldNameToFieldViewSpec<FSpec>,
+    fields: FieldNameToFieldViewSpec<FDesc>,
     updateState: (
-      fields: FieldNameToValueMap<FSpec>,
+      fields: FieldNameToValueMap<FDesc>,
       hasErrors: boolean
     ) => void,
-    initFields: FieldNameToValueMap<FSpec>,
+    initFields: FieldNameToValueMap<FDesc>,
     commands: ReturnType<CommandCreator>
   ) => (
-    fields: FieldNameToValueMap<FSpec>,
+    fields: FieldNameToValueMap<FDesc>,
     commands: ReturnType<CommandCreator>
   ) => void;
 };
 
 export type ElementSpecMap<
-  FSpec extends FieldSpec<string>,
+  FDesc extends FieldDescriptions<string>,
   ElementNames extends string,
   ExternalData = unknown
-> = Record<ElementNames, ElementSpec<FSpec, ExternalData>>;
+> = Record<ElementNames, ElementSpec<FDesc, ExternalData>>;
 
 export type ExtractFieldValues<ESpec> = ESpec extends ElementSpec<
   infer F,

--- a/src/plugin/types/Element.ts
+++ b/src/plugin/types/Element.ts
@@ -1,14 +1,14 @@
 import type { Schema } from "prosemirror-model";
 import type {
-  CheckboxField,
+  CheckboxFieldDescription,
   CheckboxFieldView,
 } from "../fieldViews/CheckboxFieldView";
 import type {
-  CustomField,
+  CustomFieldDescription,
   CustomFieldView,
 } from "../fieldViews/CustomFieldView";
 import type {
-  DropdownField,
+  DropdownFieldDescription,
   DropdownFieldView,
 } from "../fieldViews/DropdownFieldView";
 import type { FieldView } from "../fieldViews/FieldView";
@@ -17,18 +17,21 @@ import type {
   FieldTypeToViewMap,
 } from "../fieldViews/helpers";
 import type {
-  RichTextField,
+  RichTextFieldDescription,
   RichTextFieldView,
 } from "../fieldViews/RichTextFieldView";
-import type { TextField, TextFieldView } from "../fieldViews/TextFieldView";
+import type {
+  TextFieldDescription,
+  TextFieldView,
+} from "../fieldViews/TextFieldView";
 import type { CommandCreator } from "./Commands";
 
 export type FieldDescription =
-  | TextField
-  | RichTextField
-  | CheckboxField
-  | CustomField
-  | DropdownField;
+  | TextFieldDescription
+  | RichTextFieldDescription
+  | CheckboxFieldDescription
+  | CustomFieldDescription
+  | DropdownFieldDescription;
 
 export type FieldDescriptions<Names extends string> = Record<
   Names,
@@ -60,16 +63,16 @@ export interface FieldViewSpec<F> {
 
 export interface CustomFieldViewSpec<Data = unknown, Props = unknown>
   extends FieldViewSpec<CustomFieldView<Data>> {
-  fieldDescription: CustomField<Data, Props>;
+  fieldDescription: CustomFieldDescription<Data, Props>;
 }
 
 export type FieldNameToFieldViewSpec<
   FDesc extends FieldDescriptions<string>
 > = {
-  [name in Extract<keyof FDesc, string>]: FDesc[name] extends CustomField<
-    infer Data,
-    infer Props
-  >
+  [name in Extract<
+    keyof FDesc,
+    string
+  >]: FDesc[name] extends CustomFieldDescription<infer Data, infer Props>
     ? CustomFieldViewSpec<Data, Props>
     : FieldViewSpec<FieldTypeToViewMap<FDesc[name]>[FDesc[name]["type"]]>;
 };

--- a/src/renderers/react/ElementProvider.tsx
+++ b/src/renderers/react/ElementProvider.tsx
@@ -5,8 +5,8 @@ import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
 import type { Commands } from "../../plugin/types/Commands";
 import type { Consumer } from "../../plugin/types/Consumer";
 import type {
-  FieldNameToFieldViewSpec,
   FieldDescriptions,
+  FieldNameToField,
 } from "../../plugin/types/Element";
 import type { Errors } from "../../plugin/types/Errors";
 import { ElementWrapper } from "./ElementWrapper";
@@ -32,7 +32,7 @@ type IProps<FDesc extends FieldDescriptions<string>> = {
   onStateChange: (fields: FieldNameToValueMap<FDesc>) => void;
   validate: Validator<FDesc>;
   consumer: Consumer<ReactElement, FDesc>;
-  fields: FieldNameToFieldViewSpec<FDesc>;
+  fields: FieldNameToField<FDesc>;
 };
 
 type IState<FDesc extends FieldDescriptions<string>> = {
@@ -40,10 +40,9 @@ type IState<FDesc extends FieldDescriptions<string>> = {
   fieldValues: FieldNameToValueMap<FDesc>;
 };
 
-export class ElementProvider<FDesc extends FieldDescriptions<string>> extends Component<
-  IProps<FDesc>,
-  IState<FDesc>
-> {
+export class ElementProvider<
+  FDesc extends FieldDescriptions<string>
+> extends Component<IProps<FDesc>, IState<FDesc>> {
   constructor(props: IProps<FDesc>) {
     super(props);
 

--- a/src/renderers/react/ElementProvider.tsx
+++ b/src/renderers/react/ElementProvider.tsx
@@ -6,13 +6,13 @@ import type { Commands } from "../../plugin/types/Commands";
 import type { Consumer } from "../../plugin/types/Consumer";
 import type {
   FieldNameToFieldViewSpec,
-  FieldSpec,
+  FieldDescriptions,
 } from "../../plugin/types/Element";
 import type { Errors } from "../../plugin/types/Errors";
 import { ElementWrapper } from "./ElementWrapper";
 
-const fieldErrors = <FSpec extends FieldSpec<string>>(
-  fields: FieldNameToValueMap<FSpec>,
+const fieldErrors = <FDesc extends FieldDescriptions<string>>(
+  fields: FieldNameToValueMap<FDesc>,
   errors: Errors | null
 ) =>
   Object.keys(fields).reduce(
@@ -23,28 +23,28 @@ const fieldErrors = <FSpec extends FieldSpec<string>>(
     {}
   );
 
-type IProps<FSpec extends FieldSpec<string>> = {
+type IProps<FDesc extends FieldDescriptions<string>> = {
   subscribe: (
-    fn: (fields: FieldNameToValueMap<FSpec>, commands: Commands) => void
+    fn: (fields: FieldNameToValueMap<FDesc>, commands: Commands) => void
   ) => void;
   commands: Commands;
-  fieldValues: FieldNameToValueMap<FSpec>;
-  onStateChange: (fields: FieldNameToValueMap<FSpec>) => void;
-  validate: Validator<FSpec>;
-  consumer: Consumer<ReactElement, FSpec>;
-  fields: FieldNameToFieldViewSpec<FSpec>;
+  fieldValues: FieldNameToValueMap<FDesc>;
+  onStateChange: (fields: FieldNameToValueMap<FDesc>) => void;
+  validate: Validator<FDesc>;
+  consumer: Consumer<ReactElement, FDesc>;
+  fields: FieldNameToFieldViewSpec<FDesc>;
 };
 
-type IState<FSpec extends FieldSpec<string>> = {
+type IState<FDesc extends FieldDescriptions<string>> = {
   commands: Commands;
-  fieldValues: FieldNameToValueMap<FSpec>;
+  fieldValues: FieldNameToValueMap<FDesc>;
 };
 
-export class ElementProvider<FSpec extends FieldSpec<string>> extends Component<
-  IProps<FSpec>,
-  IState<FSpec>
+export class ElementProvider<FDesc extends FieldDescriptions<string>> extends Component<
+  IProps<FDesc>,
+  IState<FDesc>
 > {
-  constructor(props: IProps<FSpec>) {
+  constructor(props: IProps<FDesc>) {
     super(props);
 
     this.updateFields = this.updateFields.bind(this);
@@ -74,7 +74,7 @@ export class ElementProvider<FSpec extends FieldSpec<string>> extends Component<
     this.props.onStateChange(this.state.fieldValues);
   }
 
-  updateState(state: Partial<IState<FSpec>>, notifyListeners: boolean): void {
+  updateState(state: Partial<IState<FDesc>>, notifyListeners: boolean): void {
     this.setState(
       { ...this.state, ...state },
       () => notifyListeners && this.onStateChange()

--- a/src/renderers/react/FieldView.tsx
+++ b/src/renderers/react/FieldView.tsx
@@ -1,31 +1,31 @@
 import { useEffect, useRef } from "react";
 import { Editor } from "../../editorial-source-components/Editor";
 import type { FieldView as TFieldView } from "../../plugin/fieldViews/FieldView";
-import type { FieldViewSpec } from "../../plugin/types/Element";
+import type { Field } from "../../plugin/types/Element";
 
-type Props<F extends FieldViewSpec<unknown>> = {
-  fieldViewSpec: F;
+type Props<F extends Field<unknown>> = {
+  field: F;
   hasErrors?: boolean;
 };
 
 export const getFieldViewTestId = (name: string) => `FieldView-${name}`;
 
-export const FieldView = <F extends FieldViewSpec<TFieldView<unknown>>>({
-  fieldViewSpec,
+export const FieldView = <F extends Field<TFieldView<unknown>>>({
+  field,
   hasErrors = false,
 }: Props<F>) => {
   const editorRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
-    if (!editorRef.current || !fieldViewSpec.fieldView.fieldViewElement) {
+    if (!editorRef.current || !field.view.fieldViewElement) {
       return;
     }
-    editorRef.current.appendChild(fieldViewSpec.fieldView.fieldViewElement);
+    editorRef.current.appendChild(field.view.fieldViewElement);
   }, []);
 
   return (
     <Editor
       hasErrors={hasErrors}
-      data-cy={getFieldViewTestId(fieldViewSpec.name)}
+      data-cy={getFieldViewTestId(field.name)}
       ref={editorRef}
     ></Editor>
   );

--- a/src/renderers/react/createReactElementSpec.tsx
+++ b/src/renderers/react/createReactElementSpec.tsx
@@ -4,19 +4,22 @@ import { render } from "react-dom";
 import { createElementSpec } from "../../plugin/elementSpec";
 import type { Renderer, Validator } from "../../plugin/elementSpec";
 import type { Consumer } from "../../plugin/types/Consumer";
-import type { FieldSpec, Transformers } from "../../plugin/types/Element";
+import type {
+  FieldDescriptions,
+  Transformers,
+} from "../../plugin/types/Element";
 import { ElementProvider } from "./ElementProvider";
 
 export const createReactElementSpec = <
-  FSpec extends FieldSpec<string>,
+  FDesc extends FieldDescriptions<string>,
   ExternalData
 >(
-  fieldSpec: FSpec,
-  consumer: Consumer<ReactElement, FSpec>,
-  validate: Validator<FSpec>,
-  transformers?: Transformers<FSpec, ExternalData>
+  FieldDescriptions: FDesc,
+  consumer: Consumer<ReactElement, FDesc>,
+  validate: Validator<FDesc>,
+  transformers?: Transformers<FDesc, ExternalData>
 ) => {
-  const renderer: Renderer<FSpec> = (
+  const renderer: Renderer<FDesc> = (
     validate,
     dom,
     fields,
@@ -26,7 +29,7 @@ export const createReactElementSpec = <
     subscribe
   ) =>
     render(
-      <ElementProvider<FSpec>
+      <ElementProvider<FDesc>
         subscribe={subscribe}
         onStateChange={updateState}
         fields={fields}
@@ -38,5 +41,5 @@ export const createReactElementSpec = <
       dom
     );
 
-  return createElementSpec(fieldSpec, renderer, validate, transformers);
+  return createElementSpec(FieldDescriptions, renderer, validate, transformers);
 };

--- a/src/renderers/react/customFieldViewComponents/CustomCheckboxView.tsx
+++ b/src/renderers/react/customFieldViewComponents/CustomCheckboxView.tsx
@@ -1,20 +1,20 @@
 import { CustomCheckbox } from "../../../editorial-source-components/CustomCheckbox";
-import type { CustomFieldViewSpec } from "../../../plugin/types/Element";
+import type { CustomField } from "../../../plugin/types/Element";
 import { getFieldViewTestId } from "../FieldView";
 import { useCustomFieldViewState } from "../useCustomFieldViewState";
 
 type CustomCheckboxViewProps = {
-  fieldViewSpec: CustomFieldViewSpec<boolean, boolean>;
+  field: CustomField<boolean, boolean>;
   errors: string[];
   label: string;
 };
 
 export const CustomCheckboxView = ({
-  fieldViewSpec,
+  field,
   errors,
   label,
 }: CustomCheckboxViewProps) => {
-  const [boolean, setBoolean] = useCustomFieldViewState(fieldViewSpec);
+  const [boolean, setBoolean] = useCustomFieldViewState(field);
   return (
     <CustomCheckbox
       checked={boolean}
@@ -25,7 +25,7 @@ export const CustomCheckboxView = ({
           setBoolean.current(!boolean);
         }
       }}
-      dataCy={getFieldViewTestId(fieldViewSpec.name)}
+      dataCy={getFieldViewTestId(field.name)}
     />
   );
 };

--- a/src/renderers/react/customFieldViewComponents/CustomDropdownView.tsx
+++ b/src/renderers/react/customFieldViewComponents/CustomDropdownView.tsx
@@ -22,7 +22,7 @@ export const CustomDropdownView = ({
   return (
     <InputGroup>
       <CustomDropdown
-        options={fieldViewSpec.fieldSpec.props}
+        options={fieldViewSpec.fieldDescription.props}
         selected={selectedElement}
         label={label}
         onChange={(event) => {

--- a/src/renderers/react/customFieldViewComponents/CustomDropdownView.tsx
+++ b/src/renderers/react/customFieldViewComponents/CustomDropdownView.tsx
@@ -1,28 +1,26 @@
 import { CustomDropdown } from "../../../editorial-source-components/CustomDropdown";
 import { InputGroup } from "../../../editorial-source-components/InputGroup";
 import type { Option } from "../../../plugin/fieldViews/DropdownFieldView";
-import type { CustomFieldViewSpec } from "../../../plugin/types/Element";
+import type { CustomField } from "../../../plugin/types/Element";
 import { getFieldViewTestId } from "../FieldView";
 import { useCustomFieldViewState } from "../useCustomFieldViewState";
 
 type CustomDropdownViewProps = {
-  fieldViewSpec: CustomFieldViewSpec<string, Array<Option<string>>>;
+  field: CustomField<string, Array<Option<string>>>;
   errors?: string[];
   label: string;
 };
 
 export const CustomDropdownView = ({
-  fieldViewSpec,
+  field,
   errors = [],
   label,
 }: CustomDropdownViewProps) => {
-  const [selectedElement, setSelectFieldsRef] = useCustomFieldViewState(
-    fieldViewSpec
-  );
+  const [selectedElement, setSelectFieldsRef] = useCustomFieldViewState(field);
   return (
     <InputGroup>
       <CustomDropdown
-        options={fieldViewSpec.fieldDescription.props}
+        options={field.description.props}
         selected={selectedElement}
         label={label}
         onChange={(event) => {
@@ -31,7 +29,7 @@ export const CustomDropdownView = ({
           }
         }}
         error={errors.join(", ")}
-        dataCy={getFieldViewTestId(fieldViewSpec.name)}
+        dataCy={getFieldViewTestId(field.name)}
       />
     </InputGroup>
   );

--- a/src/renderers/react/useCustomFieldViewState.ts
+++ b/src/renderers/react/useCustomFieldViewState.ts
@@ -1,29 +1,29 @@
 import type { MutableRefObject } from "react";
 import { useEffect, useRef, useState } from "react";
 import { CustomFieldView } from "../../plugin/fieldViews/CustomFieldView";
-import type { CustomFieldViewSpec } from "../../plugin/types/Element";
+import type { CustomField } from "../../plugin/types/Element";
 
 export const useCustomFieldViewState = <Data extends unknown>({
-  fieldDescription,
-  fieldView,
-}: CustomFieldViewSpec<Data>): [
+  description,
+  view,
+}: CustomField<Data>): [
   Data,
   MutableRefObject<((fields: Data) => void) | undefined>
 ] => {
-  const [fieldValue, setFieldValue] = useState(fieldDescription.defaultValue);
+  const [fieldValue, setFieldValue] = useState(description.defaultValue);
 
   const updateRef = useRef<(fields: Data) => void>();
 
   useEffect(() => {
-    if (!(fieldView instanceof CustomFieldView)) {
+    if (!(view instanceof CustomFieldView)) {
       console.error(
-        `[prosemirror-elements]: An CustomFieldView component was passed a fieldView that wasn't a CustomFieldView. Instead it got a ${typeof fieldView}`
+        `[prosemirror-elements]: An CustomFieldView component was passed a fieldView that wasn't a CustomFieldView. Instead it got a ${typeof view}`
       );
       return;
     }
-    updateRef.current = fieldView.subscribe(setFieldValue);
+    updateRef.current = view.subscribe(setFieldValue);
 
-    return () => fieldView.unsubscribe(setFieldValue);
+    return () => view.unsubscribe(setFieldValue);
   }, []);
 
   return [fieldValue, updateRef];

--- a/src/renderers/react/useCustomFieldViewState.ts
+++ b/src/renderers/react/useCustomFieldViewState.ts
@@ -4,13 +4,13 @@ import { CustomFieldView } from "../../plugin/fieldViews/CustomFieldView";
 import type { CustomFieldViewSpec } from "../../plugin/types/Element";
 
 export const useCustomFieldViewState = <Data extends unknown>({
-  fieldSpec,
+  fieldDescription,
   fieldView,
 }: CustomFieldViewSpec<Data>): [
   Data,
   MutableRefObject<((fields: Data) => void) | undefined>
 ] => {
-  const [fieldValue, setFieldValue] = useState(fieldSpec.defaultValue);
+  const [fieldValue, setFieldValue] = useState(fieldDescription.defaultValue);
 
   const updateRef = useRef<(fields: Data) => void>();
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR aims to improve the readability of the library by making a few helpful renames to important types:

Field -> FieldDescription
FieldSpecs -> FieldDescriptions

FieldViewSpec -> Field
 Properties: 
 - fieldSpec -> description
 - fieldView -> view

Field (React component) -> FieldWrapper

This should make setting up new elements and their views easier to understand intuitively and reasoning with the type system more natural. 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This change should be a no-op and make no functional changes. Consider how this renamed types and arguments affect how easy it is to understand the api and create new elements. 

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Comparing our API and type system to our [vision document](https://github.com/guardian/prosemirror-elements/blob/main/docs/vision.md), the plugin should  "abstract the complexity of adding nested content and provide developers with a clear intuitive interface".
