### PR TITLE
fix: Fixes element wrapper arrows not updating correctly

### DIFF
--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -183,10 +183,10 @@ const buildCommands = (predicate: Predicate) => (
 
 // this forces our view to update every time an edit is made by inserting
 // a decoration right on top of it and updating it's attributes
-const createDecorations = (name: string) => (state: EditorState) => {
+const createUpdateDecorations = () => (state: EditorState) => {
   const decorations: Decoration[] = [];
   state.doc.descendants((node, pos) => {
-    if (node.type.name === name) {
+    if (node.attrs.addUpdateDecoration) {
       decorations.push(
         Decoration.node(
           pos,
@@ -227,7 +227,7 @@ const htmlToDoc = (parser: DOMParser, html: string) => {
 export {
   buildCommands,
   defaultPredicate,
-  createDecorations,
+  createUpdateDecorations,
   createParsers,
   docToHtml,
   htmlToDoc,

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -35,6 +35,10 @@ const getNodeSpecForElement = (
     ).join(" "),
     attrs: {
       type: elementName,
+      //Used to determine which nodes show have a forced update decoartion applied. See prosemirror.ts
+      addUpdateDecoration: {
+        default: true,
+      },
       hasErrors: {
         default: false,
       },

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -35,7 +35,7 @@ const getNodeSpecForElement = (
     ).join(" "),
     attrs: {
       type: elementName,
-      //Used to determine which nodes show have a forced update decoartion applied. See prosemirror.ts
+      // Used to determine which nodes should receive update decorations, which force them to update when the document changes. See `createUpdateDecorations` in prosemirror.ts.
       addUpdateDecoration: {
         default: true,
       },

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -10,10 +10,10 @@ import type {
 import type { FieldNameToValueMap } from "./fieldViews/helpers";
 import { getElementFieldViewFromType } from "./helpers/plugin";
 import type { Commands } from "./helpers/prosemirror";
-import { createDecorations } from "./helpers/prosemirror";
+import { createUpdateDecorations } from "./helpers/prosemirror";
 import { getFieldNameFromNode } from "./nodeSpec";
 
-const decorations = createDecorations("imageElement");
+const decorations = createUpdateDecorations();
 const pluginKey = new PluginKey("prosemirror_elements");
 
 export type PluginState = { hasErrors: boolean };


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR fixes a small issue with the element wrapper arrows not updating correctly. This can mean it's possible for the element to become stuck in a single position. 

The fix works by building on an existing solution which applies an invisible decoration to all elements, ensuring any updates are caught and process. This decoration was only previously applied to the image element as the decoration was looking for an element with a certain name.

There may be nice and more performant ways of ensuring these arrows update, but this will resolve the issue for now.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Using this branch, do the wrapper arrows function correctly?

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

before: 
![ELEM_Wrapper_ISSUE_before](https://user-images.githubusercontent.com/4633246/130104219-dc46a904-dd00-4bb8-b81f-3ac20d39f239.gif)

after: 
![ELEM_Wrapper_ISSUE](https://user-images.githubusercontent.com/4633246/130104337-8e03a6b3-c427-4cd2-ad0f-d81422c098b8.gif)


## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [x] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
