### PR TITLE
feat: Remove typesafety for getNodeFromElementData

### DIFF
--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -467,29 +467,20 @@ describe("buildElementPlugin", () => {
           expect(node?.eq(view.state.doc.firstChild as Node)).toBe(true);
         });
 
-        it("should not permit data that does not match an element", () => {
+        it("should return undefined if the element does not exist in the element map", () => {
           const { getNodeFromElementData, view } = createEditorWithElements(
             { testElement, testElement2 },
             testElementHTML
           );
 
-          getNodeFromElementData(
-            {
-              elementName: "testElement",
-              // @ts-expect-error -- we should not be able to instantiate elements with non-element types
-              values: { notAThing: "This doesn't look like an element" },
-            },
+          const node = getNodeFromElementData(
+            { elementName: "thisIsNotAnElement", values: {} },
             view.state.schema
           );
 
-          getNodeFromElementData(
-            {
-              elementName: "testElement",
-              // @ts-expect-error -- we should not be able to instantiate elements with non-element types
-              values: { field4: "This doesn't look like an element" },
-            },
-            view.state.schema
-          );
+          // We expect the node we've just manually created to match the node
+          // that's been serialised from the defaults
+          expect(node).toBe(undefined);
         });
 
         it("should transform data with the provided transformer", () => {
@@ -510,25 +501,6 @@ describe("buildElementPlugin", () => {
           );
 
           expect(node?.eq(view.state.doc.firstChild as Node)).toBe(true);
-        });
-
-        it("should not accept data that doesn't match the shape expected by the transformer", () => {
-          const { getNodeFromElementData, view } = createEditorWithElements(
-            {
-              testElementWithTransform,
-              testElementWithTransform2,
-            },
-            testElementTransformHTML
-          );
-
-          getNodeFromElementData(
-            {
-              elementName: "testElementWithTransform",
-              // @ts-expect-error -- this value doesn't match the shape expected by our transform function
-              values: { notAThing: { field1: "<p></p>" } },
-            },
-            view.state.schema
-          );
         });
       });
 

--- a/src/plugin/helpers/element.ts
+++ b/src/plugin/helpers/element.ts
@@ -6,7 +6,6 @@ import type {
   ElementSpecMap,
   ExtractDataTypeFromElementSpec,
   ExtractFieldValues,
-  ExtractPartialDataTypeFromElementSpec,
   FieldDescriptions,
   FieldNameToField,
 } from "../types/Element";
@@ -22,10 +21,18 @@ export const createGetNodeFromElementData = <
   {
     elementName,
     values,
-  }: ExtractPartialDataTypeFromElementSpec<ESpecMap, ElementNames>,
+  }: {
+    elementName: string;
+    values: unknown;
+  },
   schema: Schema
 ) => {
-  const element = elementTypeMap[elementName];
+  const element = elementTypeMap[elementName as keyof ESpecMap];
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- this may be falsy.
+  if (!element) {
+    return undefined;
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- we cannot be sure the schema has been amended
   if (!schema.nodes[elementName]) {


### PR DESCRIPTION
## What does this change?

Removes some typesafety for `getNodeFromElementData` in favour of a runtime check. In our CMS, we often have operations that iterate through a series of elements to conditionally produce nodes. Not all of those elements will be managed by this plugin. As a result, a better API is to conditionally return a node _if_ this node is handled by prosemirror-elements.

For example, this code, if strictly typed, will not be possible: 

```ts
const elements = documentElements; // Some of these aren't handled by prosemirror-elements
const nodes = elements.map(getNodeFromElement) // as a result, this will not typecheck
```

We'd have to write something like this, instead:

```ts
const elements = documentElements; // Some of these aren't handled by prosemirror-elements
const nodes = elements.map(element => {
  if (elementIsHandledByProsemirrorElements()) { // This function doesn't exist yet!
    getNodeFromElement(element)
  } else {
    // Do something else with the element
  }
)
```

This results in less work for the consuming code, which would otherwise have to figure out if an element was handled by prosemirror-elements (through a mechanism that doesn't yet exist) before passing it to `getNodeFromElementData`.

## How to test

The automated tests should pass.