### PR TITLE
feat: Add custom groupName to elements

### DIFF
--- a/src/plugin/__tests__/elementSpec.spec.ts
+++ b/src/plugin/__tests__/elementSpec.spec.ts
@@ -98,6 +98,14 @@ describe("mount", () => {
       expect(nodeSpec.get("testElement2")).toMatchObject({ content: "" });
     });
 
+    it("should add a custom group if specified", () => {
+      const testElement1 = createNoopElement({});
+      const { nodeSpec } = buildElementPlugin({ testElement1 }, "customGroup");
+      expect(nodeSpec.get("testElement1")).toMatchObject({
+        group: "customGroup",
+      });
+    });
+
     it("should create child nodes for each element field, and the parent node should include them in its content expression", () => {
       const testElement1 = createNoopElement({
         field1: {

--- a/src/plugin/element.ts
+++ b/src/plugin/element.ts
@@ -25,6 +25,7 @@ export const buildElementPlugin = <
   ESpecMap extends ElementSpecMap<FDesc, ElementNames, ExternalData>
 >(
   elementSpecs: ESpecMap,
+  groupName = "block",
   predicate = defaultPredicate
 ) => {
   const getNodeFromElementData = createGetNodeFromElementData(elementSpecs);
@@ -53,6 +54,7 @@ export const buildElementPlugin = <
     nodeSpec = nodeSpec.append(
       getNodeSpecFromFieldDescriptions(
         elementName,
+        groupName,
         elementSpecs[elementName].fieldDescriptions
       )
     );

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -9,6 +9,7 @@ export const getNodeSpecFromFieldDescriptions = <
   FDesc extends FieldDescriptions<string>
 >(
   elementName: string,
+  groupName: string,
   fieldDescriptions: FDesc
 ): OrderedMap<NodeSpec> => {
   const propSpecs = Object.entries(fieldDescriptions).reduce(
@@ -18,16 +19,17 @@ export const getNodeSpecFromFieldDescriptions = <
   );
 
   return propSpecs.append(
-    getNodeSpecForElement(elementName, fieldDescriptions)
+    getNodeSpecForElement(elementName, groupName, fieldDescriptions)
   );
 };
 
 const getNodeSpecForElement = (
   elementName: string,
+  groupName: string,
   fieldDescription: FieldDescriptions<string>
 ): NodeSpec => ({
   [elementName]: {
-    group: "block",
+    group: groupName,
     content: getDeterministicFieldOrder(
       Object.keys(fieldDescription).map((fieldName) =>
         getNodeNameFromField(fieldName, elementName)


### PR DESCRIPTION
## What does this change?

At the moment, we hardcode our group name into the element nodeSpec. This doesn't work in our CMS, which expects an 'element' group. Other consumers may expect other groups – so, this PR allows the consumer to specify, defaulting to 'block', as it's already present in the default schema and will make it easy to experiment with this library.

## How to test

- The new automated test should pass.
- You should be able to see the new groupName in the schema.