### PR TITLE
feat: Add gu element creator

### DIFF
--- a/src/elements/__tests__/createGuElementSpec.spec.tsx
+++ b/src/elements/__tests__/createGuElementSpec.spec.tsx
@@ -1,0 +1,45 @@
+import type { Node } from "prosemirror-model";
+import { createTextField } from "../../plugin/fieldViews/TextFieldView";
+import { createEditorWithElements } from "../../plugin/helpers/test";
+import { createGuElementSpec } from "../createGuElementSpec";
+
+const guElement = createGuElementSpec(
+  { exampleField: createTextField() },
+  () => <p></p>,
+  () => null
+);
+
+describe("createGuElementSpec", () => {
+  it("should transform data with the provided transformer", () => {
+    const {
+      getElementDataFromNode,
+      serializer,
+      view,
+      insertElement,
+    } = createEditorWithElements({
+      guElement,
+    });
+
+    const elementData = {
+      assets: [],
+      fields: { exampleField: "", isMandatory: true },
+    };
+
+    // This is effectively a roundtrip – insert element transforms on the way in ...
+    insertElement({
+      elementName: "guElement",
+      values: elementData,
+    })(view.state, view.dispatch);
+
+    // ... and getElementDataFromNode transforms on the way out.
+    const elementDataFromNode = getElementDataFromNode(
+      view.state.doc.content.firstChild as Node,
+      serializer
+    );
+
+    expect(elementDataFromNode).toEqual({
+      elementName: "guElement",
+      values: elementData,
+    });
+  });
+});

--- a/src/elements/code/CodeElementSpec.tsx
+++ b/src/elements/code/CodeElementSpec.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { createValidator, required } from "../../plugin/helpers/validation";
-import { createGuElementSpec } from "../helpers";
+import { createGuElementSpec } from "../createGuElementSpec";
 import { CodeElementForm } from "./CodeElementForm";
 
 export const codeFields = {

--- a/src/elements/code/CodeElementSpec.tsx
+++ b/src/elements/code/CodeElementSpec.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { createValidator, required } from "../../plugin/helpers/validation";
-import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+import { createGuElementSpec } from "../helpers";
 import { CodeElementForm } from "./CodeElementForm";
 
 export const codeFields = {
@@ -19,7 +19,7 @@ export const codeFields = {
   ]),
 };
 
-export const codeElement = createReactElementSpec(
+export const codeElement = createGuElementSpec(
   codeFields,
   (_, errors, __, fields) => {
     return <CodeElementForm errors={errors} fields={fields} />;

--- a/src/elements/createGuElementSpec.ts
+++ b/src/elements/createGuElementSpec.ts
@@ -1,15 +1,20 @@
 import type { ReactElement } from "react";
-import type { Validator } from "../../plugin/elementSpec";
-import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
-import type { Consumer } from "../../plugin/types/Consumer";
-import type { FieldDescriptions } from "../../plugin/types/Element";
-import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+import type { Validator } from "../plugin/elementSpec";
+import type { FieldNameToValueMap } from "../plugin/fieldViews/helpers";
+import type { Consumer } from "../plugin/types/Consumer";
+import type { FieldDescriptions } from "../plugin/types/Element";
+import { createReactElementSpec } from "../renderers/react/createReactElementSpec";
 
 type FlexibleModelElement<FDesc extends FieldDescriptions<string>> = {
   fields: Omit<FieldNameToValueMap<FDesc>, "assets"> & { isMandatory: boolean };
-  assets: Pick<FieldNameToValueMap<FDesc>, "assets">;
+  assets: string[];
 };
 
+/**
+ * Creates an element that is rendered by React, and transforms its data
+ * into a format compatible with flexible-model. See the model at
+ * https://github.com/guardian/flexible-model/blob/main/src/main/thrift/content.thrift
+ */
 export const createGuElementSpec = <FDesc extends FieldDescriptions<string>>(
   FieldDescriptions: FDesc,
   consumer: Consumer<ReactElement, FDesc>,
@@ -18,7 +23,7 @@ export const createGuElementSpec = <FDesc extends FieldDescriptions<string>>(
 ) => {
   return createReactElementSpec(FieldDescriptions, consumer, validate, {
     transformElementDataIn: ({
-      assets,
+      assets = [],
       fields,
     }: FlexibleModelElement<FDesc>) => {
       return { ...fields, assets } as FieldNameToValueMap<FDesc>;
@@ -28,7 +33,7 @@ export const createGuElementSpec = <FDesc extends FieldDescriptions<string>>(
       ...fields
     }: FieldNameToValueMap<FDesc>) => {
       return {
-        assets,
+        assets: assets || [],
         fields: { ...fields, isMandatory },
       } as FlexibleModelElement<FDesc>;
     },

--- a/src/elements/helpers/index.ts
+++ b/src/elements/helpers/index.ts
@@ -1,0 +1,36 @@
+import type { ReactElement } from "react";
+import type { Validator } from "../../plugin/elementSpec";
+import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
+import type { Consumer } from "../../plugin/types/Consumer";
+import type { FieldDescriptions } from "../../plugin/types/Element";
+import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+
+type FlexibleModelElement<FDesc extends FieldDescriptions<string>> = {
+  fields: Omit<FieldNameToValueMap<FDesc>, "assets"> & { isMandatory: boolean };
+  assets: Pick<FieldNameToValueMap<FDesc>, "assets">;
+};
+
+export const createGuElementSpec = <FDesc extends FieldDescriptions<string>>(
+  FieldDescriptions: FDesc,
+  consumer: Consumer<ReactElement, FDesc>,
+  validate: Validator<FDesc>,
+  isMandatory = true
+) => {
+  return createReactElementSpec(FieldDescriptions, consumer, validate, {
+    transformElementDataIn: ({
+      assets,
+      fields,
+    }: FlexibleModelElement<FDesc>) => {
+      return { ...fields, assets } as FieldNameToValueMap<FDesc>;
+    },
+    transformElementDataOut: ({
+      assets,
+      ...fields
+    }: FieldNameToValueMap<FDesc>) => {
+      return {
+        assets,
+        fields: { ...fields, isMandatory },
+      } as FlexibleModelElement<FDesc>;
+    },
+  });
+};


### PR DESCRIPTION
## What does this change?

Adds a new function, `createGuElement`, to take care of boilerplate when creating Guardian-specific Elements. This function makes two assumptions:

- you want to use React to render the element, with the standard `ElementWrapper`
- you need to transform the flat fields generated by prosemirror-elements to fit the [`flexible-model` format.](https://github.com/guardian/flexible-model/blob/main/src/main/thrift/content.thrift)

Eventually this function is intended to live in a specific gu-elements package, alongside the Guardian-specific elements that currently live alongside it in the `elements` folder.

## How to test

The automated test should pass. It roundtrips element data, expressed in the flexible-model format, into and out of a prosemirror node.

## Dev notes

This PR (incorrectly!) assumes that the assets will always be available in the root fields object, or undefined. My presumption is that we're not going to know where those assets live, generically – so we'll likely need to specify that in some way in this function.

Not quite sure how to do that yet, but in the absence of an element with assets, this PR gets us off the ground.