### PR TITLE
feat: Handle passing non-element nodes to getElementDataFromNode

### DIFF
--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -573,7 +573,7 @@ describe("buildElementPlugin", () => {
           );
 
           // Type refinement should work on each element
-          if (element && element.elementName === "testElement") {
+          if (element?.elementName === "testElement") {
             element.values.field1;
             element.values.field2;
             element.values.field3;
@@ -581,7 +581,7 @@ describe("buildElementPlugin", () => {
             element.values.field4;
           }
 
-          if (element && element.elementName === "testElement2") {
+          if (element?.elementName === "testElement2") {
             element.values.field4;
             element.values.field5;
           }
@@ -634,13 +634,13 @@ describe("buildElementPlugin", () => {
             serializer
           );
 
-          if (element && element.elementName === "testElementWithTransform") {
+          if (element?.elementName === "testElementWithTransform") {
             element.values.nestedElementValues.field1;
             // @ts-expect-error -- we should not be able to access properties not on a specific element
             element.values.otherValues;
           }
 
-          if (element && element.elementName === "testElementWithTransform2") {
+          if (element?.elementName === "testElementWithTransform2") {
             element.values.otherValues.field1;
             // @ts-expect-error -- we should not be able to access properties not on a specific element
             element.values.nestedElementValues;

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -522,6 +522,23 @@ describe("buildElementPlugin", () => {
           expect(element).toEqual(testElementValues);
         });
 
+        it("should return undefined, given an non-element node", () => {
+          const {
+            getElementDataFromNode,
+            view,
+            serializer,
+          } = createEditorWithElements({ testElement });
+
+          const element = getElementDataFromNode(
+            view.state.doc.content.firstChild as Node,
+            serializer
+          );
+
+          // We expect the node we've just manually created to match the node
+          // that's been serialised from the defaults
+          expect(element).toEqual(undefined);
+        });
+
         it("should produce element data, given an element node, with multiple elements", () => {
           const {
             getElementDataFromNode,
@@ -556,7 +573,7 @@ describe("buildElementPlugin", () => {
           );
 
           // Type refinement should work on each element
-          if (element.elementName === "testElement") {
+          if (element && element.elementName === "testElement") {
             element.values.field1;
             element.values.field2;
             element.values.field3;
@@ -564,7 +581,7 @@ describe("buildElementPlugin", () => {
             element.values.field4;
           }
 
-          if (element.elementName === "testElement2") {
+          if (element && element.elementName === "testElement2") {
             element.values.field4;
             element.values.field5;
           }
@@ -617,13 +634,13 @@ describe("buildElementPlugin", () => {
             serializer
           );
 
-          if (element.elementName === "testElementWithTransform") {
+          if (element && element.elementName === "testElementWithTransform") {
             element.values.nestedElementValues.field1;
             // @ts-expect-error -- we should not be able to access properties not on a specific element
             element.values.otherValues;
           }
 
-          if (element.elementName === "testElementWithTransform2") {
+          if (element && element.elementName === "testElementWithTransform2") {
             element.values.otherValues.field1;
             // @ts-expect-error -- we should not be able to access properties not on a specific element
             element.values.nestedElementValues;

--- a/src/plugin/helpers/element.ts
+++ b/src/plugin/helpers/element.ts
@@ -10,6 +10,11 @@ import type {
   FieldNameToField,
 } from "../types/Element";
 
+/**
+ * Creates a function that will attempt to create a Prosemirror node from
+ * the given element data. If it does not recognise the element type,
+ * returns undefined.
+ */
 export const createGetNodeFromElementData = <
   FDesc extends FieldDescriptions<keyof FDesc>,
   ElementNames extends keyof ESpecMap,
@@ -60,6 +65,11 @@ export const createGetNodeFromElementData = <
   );
 };
 
+/**
+ * Creates a function that will attempt to extract element data from
+ * the given node. If it does not recognise the node as an element,
+ * returns undefined.
+ */
 export const createGetElementDataFromNode = <
   FDesc extends FieldDescriptions<keyof FDesc>,
   ElementNames extends keyof ESpecMap,
@@ -70,6 +80,11 @@ export const createGetElementDataFromNode = <
 ) => (node: Node, serializer: DOMSerializer) => {
   const elementName = node.attrs.type as ElementNames;
   const element = elementTypeMap[elementName];
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- this may be falsy.
+  if (!element) {
+    return undefined;
+  }
 
   // We gather the values from each child as we iterate over the
   // node, to update the renderer. It's difficult to be typesafe here,


### PR DESCRIPTION
## What does this change?

At the moment, `getElementDataFromNode` always expects to be passed a node representing an element. But how do we know this before we pass one?

This PR alters its signature and implementation to accept any node, and return `undefined` if it receives something it doesn't recognise.

This makes it easy to iterate through a document in consumer code, passing nodes blindly into `getElementDataFromNode` for transformation, and handling them in some other way if we receive `undefined`.

## How to test

The automated tests should pass, and adequately test for this condition.