### PR TITLE
feat: Create Image Element

### DIFF
--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -85,7 +85,7 @@ export const changeTestDecoString = (newTestString: string) => {
 export const addImageElement = (values: Record<string, unknown> = {}) => {
   cy.window().then((win: WindowType) => {
     const { view, insertElement } = win.PM_ELEMENTS;
-    insertElement({ elementName: "imageElement", values })(
+    insertElement({ elementName: "demoImageElement", values })(
       view.state,
       view.dispatch
     );
@@ -129,16 +129,16 @@ export const getSerialisedHtml = ({
           mainImageValue.mediaApiUri ?? "undefined"
         }&quot;,&quot;assets&quot;${mainImageValue.assets}`
       : `&quot;assets&quot;:[]`;
-  return trimHtml(`<div pme-element-type="imageElement" has-errors="false">
-    <div pme-field-name="imageElement_altText">${altTextValue}</div>
-    <div pme-field-name="imageElement_caption">${captionValue}</div>
-    <div pme-field-name="imageElement_code">${codeValue}</div>
-    <div pme-field-name="imageElement_customDropdown" fields="&quot;${customDropdownValue}&quot;"></div>
-    <div pme-field-name="imageElement_mainImage" fields="{${mainImageFields}}"></div>
-    <div pme-field-name="imageElement_optionDropdown" fields="&quot;${optionValue}&quot;"></div>
-    <div pme-field-name="imageElement_restrictedTextField">${restrictedTextValue}</div>
-    <div pme-field-name="imageElement_src">${srcValue}</div>
-    <div pme-field-name="imageElement_useSrc" fields="${useSrcValue}"></div>
+  return trimHtml(`<div pme-element-type="demoImageElement" has-errors="false">
+    <div pme-field-name="demoImageElement_altText">${altTextValue}</div>
+    <div pme-field-name="demoImageElement_caption">${captionValue}</div>
+    <div pme-field-name="demoImageElement_code">${codeValue}</div>
+    <div pme-field-name="demoImageElement_customDropdown" fields="&quot;${customDropdownValue}&quot;"></div>
+    <div pme-field-name="demoImageElement_mainImage" fields="{${mainImageFields}}"></div>
+    <div pme-field-name="demoImageElement_optionDropdown" fields="&quot;${optionValue}&quot;"></div>
+    <div pme-field-name="demoImageElement_restrictedTextField">${restrictedTextValue}</div>
+    <div pme-field-name="demoImageElement_src">${srcValue}</div>
+    <div pme-field-name="demoImageElement_useSrc" fields="${useSrcValue}"></div>
   </div><p>First paragraph</p><p>Second paragraph</p>`);
 };
 

--- a/demo/helpers.ts
+++ b/demo/helpers.ts
@@ -1,3 +1,4 @@
+import type { DemoSetMedia } from "../src/elements/demo-image/DemoImageElement";
 import type { Asset, SetMedia } from "../src/elements/image/ImageElement";
 
 type GridAsset = {
@@ -6,9 +7,7 @@ type GridAsset = {
   secureUrl: string;
 };
 
-export const onGridMessage = (setMedia: SetMedia, modal: HTMLElement) => ({
-  data,
-}: {
+type GridResponse = {
   data: {
     image: {
       data: {
@@ -29,7 +28,11 @@ export const onGridMessage = (setMedia: SetMedia, modal: HTMLElement) => ({
       };
     };
   };
-}) => {
+};
+
+export const onGridMessage = (setMedia: DemoSetMedia, modal: HTMLElement) => ({
+  data,
+}: GridResponse) => {
   modal.style.display = "None";
   const gridAssetToAsset = (
     gridAsset: GridAsset,
@@ -50,16 +53,16 @@ export const onGridMessage = (setMedia: SetMedia, modal: HTMLElement) => ({
   setMedia(
     data.image.data.id,
     data.crop.data.specification.uri,
-    // data.crop.data.assets.map((_) => _.secureUrl),
-    // data.image.data.metadata.description
-    data.crop.data.assets
-      .map((asset) => gridAssetToAsset(asset))
-      .concat(gridAssetToAsset(data.crop.data.master, true)),
-    data.image.data.metadata.suppliersReference
+    data.crop.data.assets.map((_) => _.secureUrl),
+    data.image.data.metadata.description
+    // data.crop.data.assets
+    //   .map((asset) => gridAssetToAsset(asset))
+    //   .concat(gridAssetToAsset(data.crop.data.master, true)),
+    // data.image.data.metadata.suppliersReference
   );
 };
 
-export const onSelectImage = (setMedia: SetMedia) => {
+export const onSelectImage = (setMedia: DemoSetMedia) => {
   const modal = document.querySelector(".modal") as HTMLElement;
   modal.style.display = "Inherit";
 
@@ -83,7 +86,7 @@ export const onSelectImage = (setMedia: SetMedia) => {
   );
 };
 
-export const onCropImage = (setMedia: SetMedia, mediaId?: string) => {
+export const onDemoCropImage = (mediaId: string, setMedia: DemoSetMedia) => {
   const modal = document.querySelector(".modal") as HTMLElement;
 
   (document.querySelector(
@@ -108,3 +111,29 @@ export const onCropImage = (setMedia: SetMedia, mediaId?: string) => {
     { once: false }
   );
 };
+
+// export const onCropImage = (setMedia: SetMedia, mediaId?: string) => {
+//   const modal = document.querySelector(".modal") as HTMLElement;
+
+//   (document.querySelector(
+//     ".modal__body iframe"
+//   ) as HTMLIFrameElement).src = mediaId
+//     ? `https://media.test.dev-gutools.co.uk/images/${mediaId}`
+//     : `https://media.test.dev-gutools.co.uk/`;
+
+//   modal.style.display = "Inherit";
+//   const listener = onGridMessage(setMedia, modal);
+
+//   window.addEventListener("message", listener, {
+//     once: true,
+//   });
+
+//   document.querySelector(".modal__dismiss")?.addEventListener(
+//     "click",
+//     () => {
+//       window.removeEventListener("message", listener);
+//       modal.style.display = "None";
+//     },
+//     { once: false }
+//   );
+// };

--- a/demo/helpers.ts
+++ b/demo/helpers.ts
@@ -14,6 +14,8 @@ type GridResponse = {
         metadata: {
           description: string;
           suppliersReference: string;
+          source: string;
+          byline: string;
         };
         id: string;
       };
@@ -66,14 +68,17 @@ const handleGridResponse = (setMedia: SetMedia) => ({ data }: GridResponse) => {
     };
   };
 
-  setMedia(
-    data.image.data.id,
-    data.crop.data.specification.uri,
-    data.crop.data.assets
+  setMedia({
+    mediaId: data.image.data.id,
+    mediaApiUri: data.crop.data.specification.uri,
+    assets: data.crop.data.assets
       .map((asset) => gridAssetToAsset(asset))
       .concat(gridAssetToAsset(data.crop.data.master, true)),
-    data.image.data.metadata.suppliersReference
-  );
+    suppliersReference: data.image.data.metadata.suppliersReference,
+    caption: data.image.data.metadata.description,
+    photographer: data.image.data.metadata.byline,
+    source: data.image.data.metadata.source,
+  });
 };
 
 export const onSelectImage = (setMedia: DemoSetMedia) => {

--- a/demo/helpers.ts
+++ b/demo/helpers.ts
@@ -55,14 +55,16 @@ export const onSelectImage = (setMedia: SetMedia) => {
   );
 };
 
-export const onCropImage = (mediaId: string, setMedia: SetMedia) => {
+export const onCropImage = (setMedia: SetMedia, mediaId?: string) => {
   const modal = document.querySelector(".modal") as HTMLElement;
-  modal.style.display = "Inherit";
 
   (document.querySelector(
     ".modal__body iframe"
-  ) as HTMLIFrameElement).src = `https://media.test.dev-gutools.co.uk/images/${mediaId}`;
+  ) as HTMLIFrameElement).src = mediaId
+    ? `https://media.test.dev-gutools.co.uk/images/${mediaId}`
+    : `https://media.test.dev-gutools.co.uk/`;
 
+  modal.style.display = "Inherit";
   const listener = onGridMessage(setMedia, modal);
 
   window.addEventListener("message", listener, {

--- a/demo/helpers.ts
+++ b/demo/helpers.ts
@@ -30,10 +30,26 @@ type GridResponse = {
   };
 };
 
-export const onGridMessage = (setMedia: DemoSetMedia, modal: HTMLElement) => ({
+const onGridMessage = (
+  handleGridResponse: (gridResponse: GridResponse) => void,
+  modal: HTMLElement
+) => (response: GridResponse) => {
+  modal.style.display = "None";
+  handleGridResponse(response);
+};
+
+const demoHandleGridResponse = (demoSetMedia: DemoSetMedia) => ({
   data,
 }: GridResponse) => {
-  modal.style.display = "None";
+  demoSetMedia(
+    data.image.data.id,
+    data.crop.data.specification.uri,
+    data.crop.data.assets.map((_) => _.secureUrl),
+    data.image.data.metadata.description
+  );
+};
+
+const handleGridResponse = (setMedia: SetMedia) => ({ data }: GridResponse) => {
   const gridAssetToAsset = (
     gridAsset: GridAsset,
     isMaster: boolean | undefined = undefined
@@ -53,12 +69,10 @@ export const onGridMessage = (setMedia: DemoSetMedia, modal: HTMLElement) => ({
   setMedia(
     data.image.data.id,
     data.crop.data.specification.uri,
-    data.crop.data.assets.map((_) => _.secureUrl),
-    data.image.data.metadata.description
-    // data.crop.data.assets
-    //   .map((asset) => gridAssetToAsset(asset))
-    //   .concat(gridAssetToAsset(data.crop.data.master, true)),
-    // data.image.data.metadata.suppliersReference
+    data.crop.data.assets
+      .map((asset) => gridAssetToAsset(asset))
+      .concat(gridAssetToAsset(data.crop.data.master, true)),
+    data.image.data.metadata.suppliersReference
   );
 };
 
@@ -70,7 +84,7 @@ export const onSelectImage = (setMedia: DemoSetMedia) => {
     ".modal__body iframe"
   ) as HTMLIFrameElement).src = `https://media.test.dev-gutools.co.uk/`;
 
-  const listener = onGridMessage(setMedia, modal);
+  const listener = onGridMessage(demoHandleGridResponse(setMedia), modal);
 
   window.addEventListener("message", listener, {
     once: true,
@@ -96,7 +110,7 @@ export const onDemoCropImage = (mediaId: string, setMedia: DemoSetMedia) => {
     : `https://media.test.dev-gutools.co.uk/`;
 
   modal.style.display = "Inherit";
-  const listener = onGridMessage(setMedia, modal);
+  const listener = onGridMessage(demoHandleGridResponse(setMedia), modal);
 
   window.addEventListener("message", listener, {
     once: true,
@@ -112,28 +126,28 @@ export const onDemoCropImage = (mediaId: string, setMedia: DemoSetMedia) => {
   );
 };
 
-// export const onCropImage = (setMedia: SetMedia, mediaId?: string) => {
-//   const modal = document.querySelector(".modal") as HTMLElement;
+export const onCropImage = (setMedia: SetMedia, mediaId?: string) => {
+  const modal = document.querySelector(".modal") as HTMLElement;
 
-//   (document.querySelector(
-//     ".modal__body iframe"
-//   ) as HTMLIFrameElement).src = mediaId
-//     ? `https://media.test.dev-gutools.co.uk/images/${mediaId}`
-//     : `https://media.test.dev-gutools.co.uk/`;
+  (document.querySelector(
+    ".modal__body iframe"
+  ) as HTMLIFrameElement).src = mediaId
+    ? `https://media.test.dev-gutools.co.uk/images/${mediaId}`
+    : `https://media.test.dev-gutools.co.uk/`;
 
-//   modal.style.display = "Inherit";
-//   const listener = onGridMessage(setMedia, modal);
+  modal.style.display = "Inherit";
+  const listener = onGridMessage(handleGridResponse(setMedia), modal);
 
-//   window.addEventListener("message", listener, {
-//     once: true,
-//   });
+  window.addEventListener("message", listener, {
+    once: true,
+  });
 
-//   document.querySelector(".modal__dismiss")?.addEventListener(
-//     "click",
-//     () => {
-//       window.removeEventListener("message", listener);
-//       modal.style.display = "None";
-//     },
-//     { once: false }
-//   );
-// };
+  document.querySelector(".modal__dismiss")?.addEventListener(
+    "click",
+    () => {
+      window.removeEventListener("message", listener);
+      modal.style.display = "None";
+    },
+    { once: false }
+  );
+};

--- a/demo/helpers.ts
+++ b/demo/helpers.ts
@@ -1,4 +1,10 @@
-import type { SetMedia } from "../src/elements/demo-image/DemoImageElement";
+import type { Asset, SetMedia } from "../src/elements/image/ImageElement";
+
+type GridAsset = {
+  mimeType: string;
+  dimensions: { width: number; height: number };
+  secureUrl: string;
+};
 
 export const onGridMessage = (setMedia: SetMedia, modal: HTMLElement) => ({
   data,
@@ -8,6 +14,7 @@ export const onGridMessage = (setMedia: SetMedia, modal: HTMLElement) => ({
       data: {
         metadata: {
           description: string;
+          suppliersReference: string;
         };
         id: string;
       };
@@ -17,17 +24,38 @@ export const onGridMessage = (setMedia: SetMedia, modal: HTMLElement) => ({
         specification: {
           uri: string;
         };
-        assets: Array<{ secureUrl: string }>;
+        assets: GridAsset[];
+        master: GridAsset;
       };
     };
   };
 }) => {
   modal.style.display = "None";
+  const gridAssetToAsset = (
+    gridAsset: GridAsset,
+    isMaster: boolean | undefined = undefined
+  ): Asset => {
+    return {
+      url: gridAsset.secureUrl,
+      mimeType: gridAsset.mimeType,
+      fields: {
+        width: gridAsset.dimensions.width,
+        height: gridAsset.dimensions.height,
+        isMaster,
+      },
+      assetType: "image",
+    };
+  };
+
   setMedia(
     data.image.data.id,
     data.crop.data.specification.uri,
-    data.crop.data.assets.map((_) => _.secureUrl),
-    data.image.data.metadata.description
+    // data.crop.data.assets.map((_) => _.secureUrl),
+    // data.image.data.metadata.description
+    data.crop.data.assets
+      .map((asset) => gridAssetToAsset(asset))
+      .concat(gridAssetToAsset(data.crop.data.master, true)),
+    data.image.data.metadata.suppliersReference
   );
 };
 

--- a/demo/helpers.ts
+++ b/demo/helpers.ts
@@ -140,7 +140,7 @@ export const onCropImage = (setMedia: SetMedia, mediaId?: string) => {
     ? `https://media.test.dev-gutools.co.uk/images/${mediaId}`
     : `https://media.test.dev-gutools.co.uk/`;
 
-  modal.style.display = "Inherit";
+  modal.style.display = "inherit";
   const listener = onGridMessage(handleGridResponse(setMedia), modal);
 
   window.addEventListener("message", listener, {
@@ -151,7 +151,7 @@ export const onCropImage = (setMedia: SetMedia, mediaId?: string) => {
     "click",
     () => {
       window.removeEventListener("message", listener);
-      modal.style.display = "None";
+      modal.style.display = "none";
     },
     { once: false }
   );

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -9,10 +9,11 @@ import { EditorState } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import {
   codeElement,
+  createImageElement as createDemoImageElement,
   createEmbedElement,
-  createImageElement,
   pullquoteElement,
 } from "../src";
+import { createImageElement } from "../src/elements/image/ImageElement";
 import { buildElementPlugin } from "../src/plugin/element";
 import {
   createParsers,
@@ -45,7 +46,7 @@ const {
   hasErrors,
   nodeSpec,
 } = buildElementPlugin({
-  imageElement: createImageElement(onSelectImage, onCropImage),
+  imageElement: createDemoImageElement(onSelectImage, onCropImage),
   embedElement: createEmbedElement(),
   codeElement,
   pullquoteElement,

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -24,7 +24,7 @@ import {
 import { testDecorationPlugin } from "../src/plugin/helpers/test";
 import { CollabServer, EditorConnection } from "./collab/CollabServer";
 import { createSelectionCollabPlugin } from "./collab/SelectionPlugin";
-import { onDemoCropImage, onSelectImage } from "./helpers";
+import { onCropImage, onDemoCropImage, onSelectImage } from "./helpers";
 import type { WindowType } from "./types";
 
 // Only show focus when the user is keyboard navigating, not when
@@ -38,7 +38,7 @@ const pullquoteElementName = "pullquoteElement";
 
 type Name =
   | typeof embedElementName
-  //| typeof imageElementName
+  | typeof imageElementName
   | typeof demoImageElementName
   | typeof codeElementName
   | typeof pullquoteElementName;
@@ -50,7 +50,7 @@ const {
   nodeSpec,
 } = buildElementPlugin({
   demoImageElement: createDemoImageElement(onSelectImage, onDemoCropImage),
-  //imageElement: createImageElement(onCropImage),
+  imageElement: createImageElement(onCropImage),
   embedElement: createEmbedElement(),
   codeElement,
   pullquoteElement,
@@ -165,13 +165,26 @@ const createEditor = (server: CollabServer) => {
     })
   );
 
-  // editorElement.appendChild(
-  //   createElementButton("Add image element", imageElementName, {
-  //     altText: "",
-  //     caption: "",
-  //     useSrc: { value: false },
-  //   })
-  // );
+  const imageElementButton = document.createElement("button");
+  imageElementButton.innerHTML = "Add image element";
+  imageElementButton.id = imageElementName;
+  imageElementButton.addEventListener("click", () => {
+    const setMedia = (
+      mediaId: string,
+      mediaApiUri: string,
+      assets: Asset[],
+      suppliersReference: string
+    ) => {
+      insertElement({
+        elementName: imageElementName,
+        values: {
+          mainImage: { assets, suppliersReference, mediaId, mediaApiUri },
+        },
+      })(view.state, view.dispatch);
+    };
+    onCropImage(setMedia);
+  });
+  editorElement.appendChild(imageElementButton);
 
   editorElement.appendChild(
     createElementButton("Add pullquote element", pullquoteElementName, {
@@ -187,23 +200,6 @@ const createEditor = (server: CollabServer) => {
       language: "Plain text",
     })
   );
-  // const elementButton = document.createElement("button");
-  // elementButton.innerHTML = "Element";
-  // elementButton.id = "element";
-  // elementButton.addEventListener("click", () => {
-  //   const setMedia = (
-  //     mediaId: string,
-  //     mediaApiUri: string,
-  //     assets: Asset[],
-  //     suppliersReference: string
-  //   ) => {
-  //     insertElement("imageElement", {
-  //       mainImage: { assets, suppliersReference, mediaId, mediaApiUri },
-  //     })(view.state, view.dispatch);
-  //   };
-  //   onCropImage(setMedia);
-  // });
-  // editorElement.appendChild(elementButton);
 
   new EditorConnection(view, server, clientID, `User ${clientID}`, (state) => {
     highlightErrors(state);

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -170,10 +170,21 @@ const createEditor = (server: CollabServer) => {
   imageElementButton.id = imageElementName;
   imageElementButton.addEventListener("click", () => {
     const setMedia = (mediaPayload: MediaPayload) => {
-      const { mediaId, mediaApiUri, assets, suppliersReference } = mediaPayload;
+      const {
+        mediaId,
+        mediaApiUri,
+        assets,
+        suppliersReference,
+        caption,
+        photographer,
+        source,
+      } = mediaPayload;
       insertElement({
         elementName: imageElementName,
         values: {
+          caption,
+          photographer,
+          source,
           mainImage: { assets, suppliersReference, mediaId, mediaApiUri },
         },
       })(view.state, view.dispatch);

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -2,12 +2,7 @@ import { FocusStyleManager } from "@guardian/src-foundations/utils";
 import type OrderedMap from "orderedmap";
 import { collab } from "prosemirror-collab";
 import { exampleSetup } from "prosemirror-example-setup";
-import type {
-  DOMOutputSpec,
-  MarkSpec,
-  Node,
-  NodeSpec,
-} from "prosemirror-model";
+import type { MarkSpec, Node, NodeSpec } from "prosemirror-model";
 import { Schema } from "prosemirror-model";
 import { schema as basicSchema, marks } from "prosemirror-schema-basic";
 import { EditorState } from "prosemirror-state";
@@ -61,16 +56,6 @@ const {
   pullquoteElement,
 });
 
-const restrictedParagraph = {
-  content: "text*",
-  marks: "em",
-  group: "block",
-  parseDOM: [{ tag: "restricted-p" }],
-  toDOM() {
-    return ["restricted-p", 0] as DOMOutputSpec;
-  },
-};
-
 const strike: MarkSpec = {
   parseDOM: [{ tag: "s" }, { tag: "del" }, { tag: "strike" }],
   toDOM() {
@@ -79,9 +64,7 @@ const strike: MarkSpec = {
 };
 
 const schema = new Schema({
-  nodes: (basicSchema.spec.nodes as OrderedMap<NodeSpec>)
-    .append(nodeSpec)
-    .append({ restrictedParagraph }),
+  nodes: (basicSchema.spec.nodes as OrderedMap<NodeSpec>).append(nodeSpec),
   marks: { ...marks, strike },
 });
 

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -24,7 +24,7 @@ import {
 import { testDecorationPlugin } from "../src/plugin/helpers/test";
 import { CollabServer, EditorConnection } from "./collab/CollabServer";
 import { createSelectionCollabPlugin } from "./collab/SelectionPlugin";
-import { onCropImage, onSelectImage } from "./helpers";
+import { onDemoCropImage, onSelectImage } from "./helpers";
 import type { WindowType } from "./types";
 
 // Only show focus when the user is keyboard navigating, not when
@@ -38,7 +38,7 @@ const pullquoteElementName = "pullquoteElement";
 
 type Name =
   | typeof embedElementName
-  | typeof imageElementName
+  //| typeof imageElementName
   | typeof demoImageElementName
   | typeof codeElementName
   | typeof pullquoteElementName;
@@ -49,7 +49,7 @@ const {
   hasErrors,
   nodeSpec,
 } = buildElementPlugin({
-  demoImageElement: createDemoImageElement(onSelectImage, onCropImage),
+  demoImageElement: createDemoImageElement(onSelectImage, onDemoCropImage),
   //imageElement: createImageElement(onCropImage),
   embedElement: createEmbedElement(),
   codeElement,
@@ -158,20 +158,20 @@ const createEditor = (server: CollabServer) => {
   );
 
   editorElement.appendChild(
-    createElementButton("Add demo image element", imageElementName, {
+    createElementButton("Add demo image element", demoImageElementName, {
       altText: "",
       caption: "",
       useSrc: { value: false },
     })
   );
 
-  editorElement.appendChild(
-    createElementButton("Add demo image element", imageElementName, {
-      altText: "",
-      caption: "",
-      useSrc: { value: false },
-    })
-  );
+  // editorElement.appendChild(
+  //   createElementButton("Add image element", imageElementName, {
+  //     altText: "",
+  //     caption: "",
+  //     useSrc: { value: false },
+  //   })
+  // );
 
   editorElement.appendChild(
     createElementButton("Add pullquote element", pullquoteElementName, {

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -13,7 +13,7 @@ import {
   createEmbedElement,
   pullquoteElement,
 } from "../src";
-import type { Asset } from "../src/elements/image/ImageElement";
+import type { MediaPayload } from "../src/elements/image/ImageElement";
 import { createImageElement } from "../src/elements/image/ImageElement";
 import { buildElementPlugin } from "../src/plugin/element";
 import {
@@ -169,12 +169,8 @@ const createEditor = (server: CollabServer) => {
   imageElementButton.innerHTML = "Add image element";
   imageElementButton.id = imageElementName;
   imageElementButton.addEventListener("click", () => {
-    const setMedia = (
-      mediaId: string,
-      mediaApiUri: string,
-      assets: Asset[],
-      suppliersReference: string
-    ) => {
+    const setMedia = (mediaPayload: MediaPayload) => {
+      const { mediaId, mediaApiUri, assets, suppliersReference } = mediaPayload;
       insertElement({
         elementName: imageElementName,
         values: {

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -2,9 +2,14 @@ import { FocusStyleManager } from "@guardian/src-foundations/utils";
 import type OrderedMap from "orderedmap";
 import { collab } from "prosemirror-collab";
 import { exampleSetup } from "prosemirror-example-setup";
-import type { Node, NodeSpec } from "prosemirror-model";
+import type {
+  DOMOutputSpec,
+  MarkSpec,
+  Node,
+  NodeSpec,
+} from "prosemirror-model";
 import { Schema } from "prosemirror-model";
-import { schema as basicSchema } from "prosemirror-schema-basic";
+import { schema as basicSchema, marks } from "prosemirror-schema-basic";
 import { EditorState } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import {
@@ -56,9 +61,28 @@ const {
   pullquoteElement,
 });
 
+const restrictedParagraph = {
+  content: "text*",
+  marks: "em",
+  group: "block",
+  parseDOM: [{ tag: "restricted-p" }],
+  toDOM() {
+    return ["restricted-p", 0] as DOMOutputSpec;
+  },
+};
+
+const strike: MarkSpec = {
+  parseDOM: [{ tag: "s" }, { tag: "del" }, { tag: "strike" }],
+  toDOM() {
+    return ["s"];
+  },
+};
+
 const schema = new Schema({
-  nodes: (basicSchema.spec.nodes as OrderedMap<NodeSpec>).append(nodeSpec),
-  marks: basicSchema.spec.marks,
+  nodes: (basicSchema.spec.nodes as OrderedMap<NodeSpec>)
+    .append(nodeSpec)
+    .append({ restrictedParagraph }),
+  marks: { ...marks, strike },
 });
 
 const { serializer, parser } = createParsers(schema);

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -9,12 +9,12 @@ import { EditorState } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import {
   codeElement,
-  createImageElement as createDemoImageElement,
+  createDemoImageElement,
   createEmbedElement,
+  createImageElement,
   pullquoteElement,
 } from "../src";
 import type { MediaPayload } from "../src/elements/image/ImageElement";
-import { createImageElement } from "../src/elements/image/ImageElement";
 import { buildElementPlugin } from "../src/plugin/element";
 import {
   createParsers,

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -13,6 +13,7 @@ import {
   createEmbedElement,
   pullquoteElement,
 } from "../src";
+import type { Asset } from "../src/elements/image/ImageElement";
 import { createImageElement } from "../src/elements/image/ImageElement";
 import { buildElementPlugin } from "../src/plugin/element";
 import {
@@ -31,12 +32,14 @@ import type { WindowType } from "./types";
 FocusStyleManager.onlyShowFocusOnTabs();
 const embedElementName = "embedElement";
 const imageElementName = "imageElement";
+const demoImageElementName = "demoImageElement";
 const codeElementName = "codeElement";
 const pullquoteElementName = "pullquoteElement";
 
 type Name =
   | typeof embedElementName
   | typeof imageElementName
+  | typeof demoImageElementName
   | typeof codeElementName
   | typeof pullquoteElementName;
 
@@ -46,7 +49,8 @@ const {
   hasErrors,
   nodeSpec,
 } = buildElementPlugin({
-  imageElement: createDemoImageElement(onSelectImage, onCropImage),
+  demoImageElement: createDemoImageElement(onSelectImage, onCropImage),
+  //imageElement: createImageElement(onCropImage),
   embedElement: createEmbedElement(),
   codeElement,
   pullquoteElement,
@@ -154,12 +158,21 @@ const createEditor = (server: CollabServer) => {
   );
 
   editorElement.appendChild(
-    createElementButton("Add image element", imageElementName, {
+    createElementButton("Add demo image element", imageElementName, {
       altText: "",
       caption: "",
       useSrc: { value: false },
     })
   );
+
+  editorElement.appendChild(
+    createElementButton("Add demo image element", imageElementName, {
+      altText: "",
+      caption: "",
+      useSrc: { value: false },
+    })
+  );
+
   editorElement.appendChild(
     createElementButton("Add pullquote element", pullquoteElementName, {
       pullquote: "",
@@ -174,6 +187,23 @@ const createEditor = (server: CollabServer) => {
       language: "Plain text",
     })
   );
+  // const elementButton = document.createElement("button");
+  // elementButton.innerHTML = "Element";
+  // elementButton.id = "element";
+  // elementButton.addEventListener("click", () => {
+  //   const setMedia = (
+  //     mediaId: string,
+  //     mediaApiUri: string,
+  //     assets: Asset[],
+  //     suppliersReference: string
+  //   ) => {
+  //     insertElement("imageElement", {
+  //       mainImage: { assets, suppliersReference, mediaId, mediaApiUri },
+  //     })(view.state, view.dispatch);
+  //   };
+  //   onCropImage(setMedia);
+  // });
+  // editorElement.appendChild(elementButton);
 
   new EditorConnection(view, server, clientID, `User ${clientID}`, (state) => {
     highlightErrors(state);

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@emotion/core": "^11.0.0",
     "@emotion/react": "^11.1.5",
     "@emotion/styled": "^11.1.5",
+    "@guardian/src-button": "^3.8.0",
     "@guardian/src-checkbox": "^3.8.0",
     "@guardian/src-foundations": "^3.7.0",
     "@guardian/src-icons": "^3.7.0",

--- a/src/editorial-source-components/FieldWrapper.tsx
+++ b/src/editorial-source-components/FieldWrapper.tsx
@@ -8,14 +8,16 @@ type Props<F> = {
   field: F;
   errors: string[];
   label: string;
+  className?: string;
 };
 
 export const FieldWrapper = <F extends Field<TFieldView<unknown>>>({
   field,
   errors,
   label,
+  className,
 }: Props<F>) => (
-  <InputGroup>
+  <InputGroup className={className}>
     <InputHeading label={label} errors={errors} />
     <FieldView field={field} hasErrors={!!errors.length} />
   </InputGroup>

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -74,7 +74,7 @@ export const createImageFields = (
   };
 };
 
-export const createImageElement = (
+export const createDemoImageElement = (
   onSelect: (setSrc: DemoSetMedia) => void,
   onCrop: (mediaId: string, setSrc: DemoSetMedia) => void
 ) =>

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -17,7 +17,7 @@ import {
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { ImageElementForm } from "./DemoImageElementForm";
 
-export type SetMedia = (
+export type DemoSetMedia = (
   mediaId: string,
   mediaApiUri: string,
   assets: string[],
@@ -31,13 +31,13 @@ type ImageField = {
 };
 
 type ImageProps = {
-  onSelectImage: (setMedia: SetMedia) => void;
-  onCropImage: (mediaId: string, setMedia: SetMedia) => void;
+  onSelectImage: (setMedia: DemoSetMedia) => void;
+  onCropImage: (mediaId: string, setMedia: DemoSetMedia) => void;
 };
 
 export const createImageFields = (
-  onSelectImage: (setSrc: SetMedia) => void, // once selected image
-  onCropImage: (mediaId: string, setMedia: SetMedia) => void //have an image choosing which
+  onSelectImage: (setSrc: DemoSetMedia) => void, // once selected image
+  onCropImage: (mediaId: string, setMedia: DemoSetMedia) => void //have an image choosing which
 ) => {
   return {
     caption: createDefaultRichTextField(),
@@ -75,8 +75,8 @@ export const createImageFields = (
 };
 
 export const createImageElement = (
-  onSelect: (setSrc: SetMedia) => void,
-  onCrop: (mediaId: string, setSrc: SetMedia) => void
+  onSelect: (setSrc: DemoSetMedia) => void,
+  onCrop: (mediaId: string, setSrc: DemoSetMedia) => void
 ) =>
   createReactElementSpec(
     createImageFields(onSelect, onCrop),

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -36,8 +36,8 @@ type ImageProps = {
 };
 
 export const createImageFields = (
-  onSelectImage: (setSrc: DemoSetMedia) => void, // once selected image
-  onCropImage: (mediaId: string, setMedia: DemoSetMedia) => void //have an image choosing which
+  onSelectImage: (setSrc: DemoSetMedia) => void,
+  onCropImage: (mediaId: string, setMedia: DemoSetMedia) => void
 ) => {
   return {
     caption: createDefaultRichTextField(),

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -36,8 +36,8 @@ type ImageProps = {
 };
 
 export const createImageFields = (
-  onSelectImage: (setSrc: SetMedia) => void,
-  onCropImage: (mediaId: string, setMedia: SetMedia) => void
+  onSelectImage: (setSrc: SetMedia) => void, // once selected image
+  onCropImage: (mediaId: string, setMedia: SetMedia) => void //have an image choosing which
 ) => {
   return {
     caption: createDefaultRichTextField(),

--- a/src/elements/demo-image/DemoImageElementForm.tsx
+++ b/src/elements/demo-image/DemoImageElementForm.tsx
@@ -6,7 +6,7 @@ import type { CustomField, FieldNameToField } from "../../plugin/types/Element";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import { getFieldViewTestId } from "../../renderers/react/FieldView";
 import { useCustomFieldState } from "../../renderers/react/useCustomFieldViewState";
-import type { createImageFields, SetMedia } from "./DemoImageElement";
+import type { createImageFields, DemoSetMedia } from "./DemoImageElement";
 
 type Props = {
   fieldValues: FieldNameToValueMap<ReturnType<typeof createImageFields>>;
@@ -74,7 +74,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
 );
 
 type ImageViewProps = {
-  onChange: SetMedia;
+  onChange: DemoSetMedia;
   field: CustomField<
     {
       mediaId?: string;
@@ -82,8 +82,8 @@ type ImageViewProps = {
       assets: string[];
     },
     {
-      onSelectImage: (setMedia: SetMedia) => void;
-      onCropImage: (mediaId: string, setMedia: SetMedia) => void;
+      onSelectImage: (setMedia: DemoSetMedia) => void;
+      onCropImage: (mediaId: string, setMedia: DemoSetMedia) => void;
     }
   >;
 };

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { createCheckBox } from "../../plugin/fieldViews/CheckboxFieldView";
+import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
+import type { Option } from "../../plugin/fieldViews/DropdownFieldView";
+import { createDropDownField } from "../../plugin/fieldViews/DropdownFieldView";
+import { createDefaultRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
+import { createTextField } from "../../plugin/fieldViews/TextFieldView";
+import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+
+export const imageFields = {
+  altText: createTextField(),
+  caption: createDefaultRichTextField(),
+  displayText: createCheckBox(true),
+  imageType: createDropDownField(
+    [
+      { text: "Photograph", value: "Photograph" },
+      { text: "Illustration", value: "Illustration" },
+      { text: "Composite", value: "Composite" },
+    ],
+    "Photograph"
+  ),
+  photographer: createTextField(),
+  source: createTextField(),
+  weighting: createDropDownField(
+    [
+      { text: "inline (default)", value: undefined },
+      { text: "supporting", value: "supporting" },
+      { text: "showcase", value: "showcase" },
+      { text: "thumbnail", value: "thumbnail" },
+      { text: "immersive", value: "immersive" },
+    ],
+    undefined
+  ),
+};

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -1,34 +1,89 @@
 import React from "react";
 import { createCheckBox } from "../../plugin/fieldViews/CheckboxFieldView";
 import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
-import type { Option } from "../../plugin/fieldViews/DropdownFieldView";
 import { createDropDownField } from "../../plugin/fieldViews/DropdownFieldView";
 import { createDefaultRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+import { ImageElementForm } from "./ImageElementForm";
 
-export const imageFields = {
-  altText: createTextField(),
-  caption: createDefaultRichTextField(),
-  displayText: createCheckBox(true),
-  imageType: createDropDownField(
-    [
-      { text: "Photograph", value: "Photograph" },
-      { text: "Illustration", value: "Illustration" },
-      { text: "Composite", value: "Composite" },
-    ],
-    "Photograph"
-  ),
-  photographer: createTextField(),
-  source: createTextField(),
-  weighting: createDropDownField(
-    [
-      { text: "inline (default)", value: undefined },
-      { text: "supporting", value: "supporting" },
-      { text: "showcase", value: "showcase" },
-      { text: "thumbnail", value: "thumbnail" },
-      { text: "immersive", value: "immersive" },
-    ],
-    undefined
-  ),
+export type SetMedia = (
+  mediaId: string,
+  mediaApiUri: string,
+  assets: string[]
+) => void;
+
+export type MainImageData = {
+  mediaId?: string | undefined;
+  mediaApiUri?: string | undefined;
+  assets: string[];
 };
+
+export type MainImageProps = {
+  openImageSelector: (setMedia: SetMedia, mediaId?: string) => void;
+};
+
+export const createImageFields = (
+  openImageSelector: (setMedia: SetMedia, mediaId?: string) => void
+) => {
+  return {
+    altText: createTextField(),
+    caption: createDefaultRichTextField(),
+    displayText: createCheckBox(true),
+    imageType: createDropDownField(
+      [
+        { text: "Photograph", value: "Photograph" },
+        { text: "Illustration", value: "Illustration" },
+        { text: "Composite", value: "Composite" },
+      ],
+      "Photograph"
+    ),
+    photographer: createTextField(),
+    mainImage: createCustomField<MainImageData, MainImageProps>(
+      {
+        mediaId: undefined,
+        mediaApiUri: undefined,
+        assets: [],
+      },
+      { openImageSelector }
+    ),
+    source: createTextField(),
+    weighting: createDropDownField(
+      [
+        { text: "inline (default)", value: undefined },
+        { text: "supporting", value: "supporting" },
+        { text: "showcase", value: "showcase" },
+        { text: "thumbnail", value: "thumbnail" },
+        { text: "immersive", value: "immersive" },
+      ],
+      undefined
+    ),
+  };
+};
+
+export const createImageElement = <Name extends string>(
+  name: Name,
+  openImageSelector: (setMedia: SetMedia, mediaId?: string) => void
+) =>
+  createReactElementSpec(
+    name,
+    createImageFields(openImageSelector),
+    (fields, errors, __, fieldViewSpecs) => {
+      return <ImageElementForm fieldViewSpecMap={fieldViewSpecs} />;
+    },
+    () => null,
+    {
+      caption: "",
+      displayText: { value: true },
+      altText: "",
+      source: "",
+      weighting: "supporting",
+      imageType: "Photograph",
+      photographer: "",
+      mainImage: {
+        mediaId: undefined,
+        mediaApiUri: undefined,
+        assets: [],
+      },
+    }
+  );

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -1,8 +1,9 @@
+import { exampleSetup } from "prosemirror-example-setup";
 import React from "react";
 import { createCheckBox } from "../../plugin/fieldViews/CheckboxFieldView";
 import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
 import { createDropDownField } from "../../plugin/fieldViews/DropdownFieldView";
-import { createDefaultRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
+import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import {
   createValidator,
@@ -51,7 +52,12 @@ export const createImageFields = (
 ) => {
   return {
     altText: createTextField(),
-    caption: createDefaultRichTextField(),
+    caption: createFlatRichTextField({
+      createPlugins: (schema) => exampleSetup({ schema }),
+      nodeSpec: {
+        marks: "em strong link strike",
+      },
+    }),
     displayCreditInformation: createCheckBox(true),
     imageType: createDropDownField(
       [

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -88,20 +88,5 @@ export const createImageElement = (
     (fields, errors, __, fieldViewSpecs) => {
       return <ImageElementForm fieldViewSpecMap={fieldViewSpecs} />;
     },
-    () => null,
-    {
-      caption: "",
-      displayCreditInformation: { value: true },
-      altText: "",
-      source: "",
-      weighting: "supporting",
-      imageType: "Photograph",
-      photographer: "",
-      mainImage: {
-        mediaId: undefined,
-        mediaApiUri: undefined,
-        assets: [],
-        suppliersReference: "",
-      },
-    }
+    () => null
   );

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -1,6 +1,5 @@
 import { exampleSetup } from "prosemirror-example-setup";
 import React from "react";
-import { createCheckBox } from "../../plugin/fieldViews/CheckboxFieldView";
 import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
 import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
@@ -57,7 +56,7 @@ export const createImageFields = (
         marks: "em strong link strike",
       },
     }),
-    displayCreditInformation: createCheckBox(true),
+    displayCreditInformation: createCustomField(true, true),
     imageType: createCustomField("Photograph", [
       { text: "Photograph", value: "Photograph" },
       { text: "Illustration", value: "Illustration" },

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -88,12 +88,12 @@ export const createImageElement = (
 ) =>
   createReactElementSpec(
     createImageFields(openImageSelector),
-    (fields, errors, __, fieldViewSpecs) => {
+    (fieldValues, errors, __, fields) => {
       return (
         <ImageElementForm
-          fieldValues={fields}
+          fieldValues={fieldValues}
           errors={errors}
-          fieldViewSpecs={fieldViewSpecs}
+          fields={fields}
         />
       );
     },

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -7,12 +7,17 @@ import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { ImageElementForm } from "./ImageElementForm";
 
-export type SetMedia = (
-  mediaId: string,
-  mediaApiUri: string,
-  assets: Asset[],
-  suppliersReference: string
-) => void;
+export type MediaPayload = {
+  mediaId: string;
+  mediaApiUri: string;
+  assets: Asset[];
+  suppliersReference: string;
+  caption: string;
+  photographer: string;
+  source: string;
+};
+
+export type SetMedia = (mediaPayload: MediaPayload) => void;
 
 export type Asset = {
   assetType: string;

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -10,13 +10,26 @@ import { ImageElementForm } from "./ImageElementForm";
 export type SetMedia = (
   mediaId: string,
   mediaApiUri: string,
-  assets: string[]
+  assets: Asset[],
+  suppliersReference: string
 ) => void;
+
+export type Asset = {
+  assetType: string;
+  mimeType: string;
+  url: string;
+  fields: {
+    width: number;
+    height: number;
+    isMaster: boolean | undefined;
+  };
+};
 
 export type MainImageData = {
   mediaId?: string | undefined;
   mediaApiUri?: string | undefined;
-  assets: string[];
+  assets: Asset[];
+  suppliersReference: string;
 };
 
 export type MainImageProps = {
@@ -29,7 +42,7 @@ export const createImageFields = (
   return {
     altText: createTextField(),
     caption: createDefaultRichTextField(),
-    displayText: createCheckBox(true),
+    displayCreditInformation: createCheckBox(true),
     imageType: createDropDownField(
       [
         { text: "Photograph", value: "Photograph" },
@@ -44,29 +57,28 @@ export const createImageFields = (
         mediaId: undefined,
         mediaApiUri: undefined,
         assets: [],
+        suppliersReference: "",
       },
       { openImageSelector }
     ),
     source: createTextField(),
     weighting: createDropDownField(
       [
-        { text: "inline (default)", value: undefined },
+        { text: "inline (default)", value: "none-selected" },
         { text: "supporting", value: "supporting" },
         { text: "showcase", value: "showcase" },
         { text: "thumbnail", value: "thumbnail" },
         { text: "immersive", value: "immersive" },
       ],
-      undefined
+      "none-selected"
     ),
   };
 };
 
-export const createImageElement = <Name extends string>(
-  name: Name,
+export const createImageElement = (
   openImageSelector: (setMedia: SetMedia, mediaId?: string) => void
 ) =>
   createReactElementSpec(
-    name,
     createImageFields(openImageSelector),
     (fields, errors, __, fieldViewSpecs) => {
       return <ImageElementForm fieldViewSpecMap={fieldViewSpecs} />;
@@ -74,7 +86,7 @@ export const createImageElement = <Name extends string>(
     () => null,
     {
       caption: "",
-      displayText: { value: true },
+      displayCreditInformation: { value: true },
       altText: "",
       source: "",
       weighting: "supporting",
@@ -84,6 +96,7 @@ export const createImageElement = <Name extends string>(
         mediaId: undefined,
         mediaApiUri: undefined,
         assets: [],
+        suppliersReference: "",
       },
     }
   );

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -86,7 +86,12 @@ export const createImageElement = (
   createReactElementSpec(
     createImageFields(openImageSelector),
     (fields, errors, __, fieldViewSpecs) => {
-      return <ImageElementForm fieldViewSpecMap={fieldViewSpecs} />;
+      return (
+        <ImageElementForm
+          fieldValues={fields}
+          fieldViewSpecs={fieldViewSpecs}
+        />
+      );
     },
     () => null
   );

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -4,6 +4,11 @@ import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
 import { createDropDownField } from "../../plugin/fieldViews/DropdownFieldView";
 import { createDefaultRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
+import {
+  createValidator,
+  htmlMaxLength,
+  htmlRequired,
+} from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { ImageElementForm } from "./ImageElementForm";
 
@@ -89,9 +94,15 @@ export const createImageElement = (
       return (
         <ImageElementForm
           fieldValues={fields}
+          errors={errors}
           fieldViewSpecs={fieldViewSpecs}
         />
       );
     },
-    () => null
+    createValidator({
+      caption: [htmlMaxLength(600)],
+      altText: [htmlMaxLength(1000), htmlRequired()],
+      source: [htmlMaxLength(250), htmlRequired()],
+      photographer: [htmlMaxLength(250)],
+    })
   );

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -2,7 +2,6 @@ import { exampleSetup } from "prosemirror-example-setup";
 import React from "react";
 import { createCheckBox } from "../../plugin/fieldViews/CheckboxFieldView";
 import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
-import { createDropDownField } from "../../plugin/fieldViews/DropdownFieldView";
 import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import {
@@ -59,14 +58,11 @@ export const createImageFields = (
       },
     }),
     displayCreditInformation: createCheckBox(true),
-    imageType: createDropDownField(
-      [
-        { text: "Photograph", value: "Photograph" },
-        { text: "Illustration", value: "Illustration" },
-        { text: "Composite", value: "Composite" },
-      ],
-      "Photograph"
-    ),
+    imageType: createCustomField("Photograph", [
+      { text: "Photograph", value: "Photograph" },
+      { text: "Illustration", value: "Illustration" },
+      { text: "Composite", value: "Composite" },
+    ]),
     photographer: createTextField(),
     mainImage: createCustomField<MainImageData, MainImageProps>(
       {
@@ -78,16 +74,13 @@ export const createImageFields = (
       { openImageSelector }
     ),
     source: createTextField(),
-    weighting: createDropDownField(
-      [
-        { text: "inline (default)", value: "none-selected" },
-        { text: "supporting", value: "supporting" },
-        { text: "showcase", value: "showcase" },
-        { text: "thumbnail", value: "thumbnail" },
-        { text: "immersive", value: "immersive" },
-      ],
-      "none-selected"
-    ),
+    weighting: createCustomField("none-selected", [
+      { text: "inline (default)", value: "none-selected" },
+      { text: "supporting", value: "supporting" },
+      { text: "showcase", value: "showcase" },
+      { text: "thumbnail", value: "thumbnail" },
+      { text: "immersive", value: "immersive" },
+    ]),
   };
 };
 

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -51,7 +51,7 @@ export const createImageFields = (
   openImageSelector: (setMedia: SetMedia, mediaId?: string) => void
 ) => {
   return {
-    altText: createTextField(),
+    altText: createTextField({ isMultiline: true, rows: 2 }),
     caption: createFlatRichTextField({
       createPlugins: (schema) => exampleSetup({ schema }),
       nodeSpec: {

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import type {
+  CustomFieldViewSpec,
+  FieldNameToFieldViewSpec,
+} from "../../plugin/types/Element";
+import { FieldView } from "../../renderers/react/FieldView";
+import { useCustomFieldViewState } from "../../renderers/react/useCustomFieldViewState";
+import type {
+  createImageFields,
+  MainImageData,
+  MainImageProps,
+} from "./ImageElement";
+
+type Props = {
+  fieldViewSpecMap: FieldNameToFieldViewSpec<
+    ReturnType<typeof createImageFields>
+  >;
+};
+
+type ImageViewProps = {
+  fieldViewSpec: CustomFieldViewSpec<MainImageData, MainImageProps>;
+};
+
+export const ImageElementTestId = "ImageElement";
+
+export const ImageElementForm: React.FunctionComponent<Props> = ({
+  fieldViewSpecMap: fieldViewSpecs,
+}) => (
+  <div data-cy={ImageElementTestId}>
+    <FieldView fieldViewSpec={fieldViewSpecs.altText} />
+    <FieldView fieldViewSpec={fieldViewSpecs.caption} />
+    <FieldView fieldViewSpec={fieldViewSpecs.photographer} />
+    <FieldView fieldViewSpec={fieldViewSpecs.weighting} />
+    <ImageView fieldViewSpec={fieldViewSpecs.mainImage} />
+  </div>
+);
+
+const ImageView = ({ fieldViewSpec }: ImageViewProps) => {
+  const [imageFields, setImageFieldsRef] = useCustomFieldViewState(
+    fieldViewSpec
+  );
+  const setMedia = (mediaId: string, mediaApiUri: string, assets: string[]) => {
+    if (setImageFieldsRef.current) {
+      setImageFieldsRef.current({ mediaId, mediaApiUri, assets });
+    }
+  };
+  return (
+    <>
+      <div>Test Image Selector</div>
+      <button
+        onClick={() => {
+          fieldViewSpec.fieldSpec.props.openImageSelector(
+            setMedia,
+            imageFields.mediaId
+          );
+        }}
+      >
+        Select Image
+      </button>
+    </>
+  );
+};

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -6,6 +6,7 @@ import type {
 import { FieldView } from "../../renderers/react/FieldView";
 import { useCustomFieldViewState } from "../../renderers/react/useCustomFieldViewState";
 import type {
+  Asset,
   createImageFields,
   MainImageData,
   MainImageProps,
@@ -31,6 +32,8 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
     <FieldView fieldViewSpec={fieldViewSpecs.caption} />
     <FieldView fieldViewSpec={fieldViewSpecs.photographer} />
     <FieldView fieldViewSpec={fieldViewSpecs.weighting} />
+    <FieldView fieldViewSpec={fieldViewSpecs.imageType} />
+    <FieldView fieldViewSpec={fieldViewSpecs.displayCreditInformation} />
     <ImageView fieldViewSpec={fieldViewSpecs.mainImage} />
   </div>
 );
@@ -39,13 +42,24 @@ const ImageView = ({ fieldViewSpec }: ImageViewProps) => {
   const [imageFields, setImageFieldsRef] = useCustomFieldViewState(
     fieldViewSpec
   );
-  const setMedia = (mediaId: string, mediaApiUri: string, assets: string[]) => {
+  const setMedia = (
+    mediaId: string,
+    mediaApiUri: string,
+    assets: Asset[],
+    suppliersReference: string
+  ) => {
     if (setImageFieldsRef.current) {
-      setImageFieldsRef.current({ mediaId, mediaApiUri, assets });
+      setImageFieldsRef.current({
+        mediaId,
+        mediaApiUri,
+        assets,
+        suppliersReference,
+      });
     }
   };
   return (
     <>
+      {JSON.stringify(imageFields)}
       <div>Test Image Selector</div>
       <button
         onClick={() => {

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
 import type {
   CustomFieldViewSpec,
   FieldNameToFieldViewSpec,
@@ -14,7 +15,8 @@ import type {
 } from "./ImageElement";
 
 type Props = {
-  fieldViewSpecMap: FieldNameToFieldViewSpec<
+  fieldValues: FieldNameToValueMap<ReturnType<typeof createImageFields>>;
+  fieldViewSpecs: FieldNameToFieldViewSpec<
     ReturnType<typeof createImageFields>
   >;
 };
@@ -27,11 +29,15 @@ type ImageViewProps = {
 export const ImageElementTestId = "ImageElement";
 
 export const ImageElementForm: React.FunctionComponent<Props> = ({
-  fieldViewSpecMap: fieldViewSpecs,
+  fieldValues,
+  fieldViewSpecs,
 }) => (
   <div data-cy={ImageElementTestId}>
-    <FieldView fieldViewSpec={fieldViewSpecs.altText} />
     <FieldView fieldViewSpec={fieldViewSpecs.caption} />
+    <button onClick={() => fieldViewSpecs.altText.update(fieldValues.caption)}>
+      Copy from caption
+    </button>
+    <FieldView fieldViewSpec={fieldViewSpecs.altText} />
     <FieldView fieldViewSpec={fieldViewSpecs.photographer} />
     <FieldView fieldViewSpec={fieldViewSpecs.weighting} />
     <FieldView fieldViewSpec={fieldViewSpecs.imageType} />

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -39,7 +39,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
     <ImageView
       fieldViewSpec={fieldViewSpecs.mainImage}
       onChange={({ caption, source, photographer }) => {
-        fieldViewSpecs.altText.update(caption);
+        fieldViewSpecs.caption.update(caption);
         fieldViewSpecs.source.update(source);
         fieldViewSpecs.photographer.update(photographer);
       }}

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -126,28 +126,26 @@ const ImageView = ({ field, onChange }: ImageViewProps) => {
     onChange(mediaPayload);
   };
 
-  const masterImageSource = imageFields.assets
-    .filter((image) => image.fields.width >= 1000)
-    .sort((assetA, assetB) => assetA.fields.width - assetB.fields.width)[0]
-    ?.url;
-  const isMaster = (asset: Asset) =>
-    typeof asset.fields.isMaster !== "undefined"
-      ? asset.fields.isMaster
-      : false;
-  const excludeMasterAsset = imageFields.assets.filter(
-    (asset) => !isMaster(asset)
-  );
-  const assetsInAscWidth = excludeMasterAsset
-    .filter((image) => image.fields.width < 1000)
-    .sort((assetA, assetB) => assetA.fields.width - assetB.fields.width)
-    .slice(-1)[0]?.url;
+  const getImageSrc = () => {
+    const desiredWidth = 1200;
+
+    const widthDifference = (width: number) => Math.abs(desiredWidth - width);
+
+    const sortByWidthDifference = (assetA: Asset, assetB: Asset) =>
+      widthDifference(assetA.fields.width) -
+      widthDifference(assetB.fields.width);
+
+    const assets = imageFields.assets
+      .filter((asset) => !asset.fields.isMaster)
+      .sort(sortByWidthDifference);
+
+    return assets.length > 0 ? assets[0].url : undefined;
+  };
+
   return (
     <>
       <div>
-        <img
-          css={imageViewStysles}
-          src={masterImageSource || assetsInAscWidth}
-        />
+        <img css={imageViewStysles} src={getImageSrc()} />
       </div>
       <Button
         priority="primary"

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -1,4 +1,6 @@
 import { css } from "@emotion/react";
+import { Button } from "@guardian/src-button";
+import { SvgCamera } from "@guardian/src-icons";
 import { Column, Columns, Inline } from "@guardian/src-layout";
 import React from "react";
 import { Field } from "../../editorial-source-components/Field";
@@ -68,11 +70,15 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
           errors={errors.caption}
           label="Caption"
         />
-        <button
+        <Button
+          priority="primary"
+          size="xsmall"
+          // icon={<SvgCamera />}
+          iconSide="left"
           onClick={() => fieldViewSpecs.altText.update(fieldValues.caption)}
         >
           Copy from caption
-        </button>
+        </Button>
         <Field
           fieldViewSpec={fieldViewSpecs.altText}
           errors={errors.altText}
@@ -123,7 +129,12 @@ const ImageView = ({ fieldViewSpec, onChange }: ImageViewProps) => {
       {imageFields.assets.length > 0 ? (
         <img src={imageFields.assets[0].url} />
       ) : null}
-      <button
+      <br></br>
+      <Button
+        priority="primary"
+        size="xsmall"
+        icon={<SvgCamera />}
+        iconSide="left"
         onClick={() => {
           fieldViewSpec.fieldSpec.props.openImageSelector(
             setMedia,
@@ -132,7 +143,7 @@ const ImageView = ({ fieldViewSpec, onChange }: ImageViewProps) => {
         }}
       >
         Re-crop image
-      </button>
+      </Button>
     </>
   );
 };

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
+import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
 import type {
   CustomFieldViewSpec,
   FieldNameToFieldViewSpec,
@@ -72,8 +72,9 @@ const ImageView = ({ fieldViewSpec, onChange }: ImageViewProps) => {
   };
   return (
     <>
-      {JSON.stringify(imageFields)}
-      <div>Test Image Selector</div>
+      {imageFields.assets.length > 0 ? (
+        <img src={imageFields.assets[0].url} />
+      ) : null}
       <button
         onClick={() => {
           fieldViewSpec.fieldSpec.props.openImageSelector(
@@ -82,7 +83,7 @@ const ImageView = ({ fieldViewSpec, onChange }: ImageViewProps) => {
           );
         }}
       >
-        Select Image
+        Re-crop image
       </button>
     </>
   );

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -128,10 +128,11 @@ const ImageView = ({ fieldViewSpec, onChange }: ImageViewProps) => {
   };
   return (
     <>
-      {imageFields.assets.length > 0 ? (
-        <img src={imageFields.assets[0].url} />
-      ) : null}
-      <br></br>
+      <div>
+        {imageFields.assets.length > 0 ? (
+          <img src={imageFields.assets[0].url} />
+        ) : null}
+      </div>
       <Button
         priority="primary"
         size="xsmall"

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -3,15 +3,12 @@ import { Button } from "@guardian/src-button";
 import { SvgCamera } from "@guardian/src-icons";
 import { Column, Columns, Inline } from "@guardian/src-layout";
 import React from "react";
-import { Field } from "../../editorial-source-components/Field";
+import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
-import type {
-  CustomFieldViewSpec,
-  FieldNameToFieldViewSpec,
-} from "../../plugin/types/Element";
+import type { CustomField, FieldNameToField } from "../../plugin/types/Element";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
-import { useCustomFieldViewState } from "../../renderers/react/useCustomFieldViewState";
+import { useCustomFieldState } from "../../renderers/react/useCustomFieldViewState";
 import type {
   Asset,
   createImageFields,
@@ -28,48 +25,46 @@ const inlineStyles = css`
 type Props = {
   fieldValues: FieldNameToValueMap<ReturnType<typeof createImageFields>>;
   errors: Record<string, string[]>;
-  fieldViewSpecs: FieldNameToFieldViewSpec<
-    ReturnType<typeof createImageFields>
-  >;
+  fields: FieldNameToField<ReturnType<typeof createImageFields>>;
 };
 
 type ImageViewProps = {
   onChange: SetMedia;
-  fieldViewSpec: CustomFieldViewSpec<MainImageData, MainImageProps>;
+  field: CustomField<MainImageData, MainImageProps>;
 };
 
 export const ImageElementTestId = "ImageElement";
 
 export const ImageElementForm: React.FunctionComponent<Props> = ({
   errors,
-  fieldViewSpecs,
+  fields,
   fieldValues,
 }) => (
   <div data-cy={ImageElementTestId}>
     <Columns>
       <Column width={2 / 5}>
         <CustomDropdownView
-          fieldViewSpec={fieldViewSpecs.weighting}
+          field={fields.weighting}
           label="Weighting"
           errors={errors.weighting}
         />
         <ImageView
-          fieldViewSpec={fieldViewSpecs.mainImage}
+          field={fields.mainImage}
           onChange={({ caption, source, photographer }) => {
-            fieldViewSpecs.caption.update(caption);
-            fieldViewSpecs.source.update(source);
-            fieldViewSpecs.photographer.update(photographer);
+            fields.caption.update(caption);
+            fields.source.update(source);
+            fields.photographer.update(photographer);
           }}
         />
         <CustomDropdownView
-          fieldViewSpec={fieldViewSpecs.imageType}
+          field={fields.imageType}
           label={"Image type"}
           errors={errors.imageType}
         />
       </Column>
       <Column width={3 / 5}>
-        <Field
-          fieldViewSpec={fieldViewSpecs.caption}
+        <FieldWrapper
+          field={fields.caption}
           errors={errors.caption}
           label="Caption"
         />
@@ -78,31 +73,31 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
           size="xsmall"
           // icon={<SvgCamera />}
           iconSide="left"
-          onClick={() => fieldViewSpecs.altText.update(fieldValues.caption)}
+          onClick={() => fields.altText.update(fieldValues.caption)}
         >
           Copy from caption
         </Button>
-        <Field
-          fieldViewSpec={fieldViewSpecs.altText}
+        <FieldWrapper
+          field={fields.altText}
           errors={errors.altText}
           label="Alt text"
         />
         <Inline space={2}>
-          <Field
-            fieldViewSpec={fieldViewSpecs.photographer}
+          <FieldWrapper
+            field={fields.photographer}
             errors={errors.photographer}
             label="Photographer"
             css={inlineStyles}
           />
-          <Field
-            fieldViewSpec={fieldViewSpecs.source}
+          <FieldWrapper
+            field={fields.source}
             errors={errors.source}
             label="Source"
             css={inlineStyles}
           />
         </Inline>
         <CustomCheckboxView
-          fieldViewSpec={fieldViewSpecs.displayCreditInformation}
+          field={fields.displayCreditInformation}
           errors={errors.displayCreditInformation}
           label="Display credit information"
         />
@@ -115,20 +110,16 @@ const imageViewStysles = css`
   width: 100%;
 `;
 
-const ImageView = ({ fieldViewSpec, onChange }: ImageViewProps) => {
-  const [imageFields, setImageFieldsRef] = useCustomFieldViewState(
-    fieldViewSpec
-  );
+const ImageView = ({ field, onChange }: ImageViewProps) => {
+  const [imageFields, setImageFields] = useCustomFieldState(field);
   const setMedia = (mediaPayload: MediaPayload) => {
     const { mediaId, mediaApiUri, assets, suppliersReference } = mediaPayload;
-    if (setImageFieldsRef.current) {
-      setImageFieldsRef.current({
-        mediaId,
-        mediaApiUri,
-        assets,
-        suppliersReference,
-      });
-    }
+    setImageFields({
+      mediaId,
+      mediaApiUri,
+      assets,
+      suppliersReference,
+    });
     onChange(mediaPayload);
   };
 
@@ -161,7 +152,7 @@ const ImageView = ({ fieldViewSpec, onChange }: ImageViewProps) => {
         icon={<SvgCamera />}
         iconSide="left"
         onClick={() => {
-          fieldViewSpec.fieldSpec.props.openImageSelector(
+          field.description.props.openImageSelector(
             setMedia,
             imageFields.mediaId
           );

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -9,6 +9,7 @@ import type {
   CustomFieldViewSpec,
   FieldNameToFieldViewSpec,
 } from "../../plugin/types/Element";
+import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import { useCustomFieldViewState } from "../../renderers/react/useCustomFieldViewState";
 import type {
   createImageFields,
@@ -45,10 +46,10 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
   <div data-cy={ImageElementTestId}>
     <Columns>
       <Column width={2 / 5}>
-        <Field
+        <CustomDropdownView
           fieldViewSpec={fieldViewSpecs.weighting}
-          errors={errors.weighting}
           label="Weighting"
+          errors={errors.weighting}
         />
         <ImageView
           fieldViewSpec={fieldViewSpecs.mainImage}
@@ -58,10 +59,10 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
             fieldViewSpecs.photographer.update(photographer);
           }}
         />
-        <Field
+        <CustomDropdownView
           fieldViewSpec={fieldViewSpecs.imageType}
+          label={"Image type"}
           errors={errors.imageType}
-          label="Image Types"
         />
       </Column>
       <Column width={3 / 5}>

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -68,20 +68,23 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
           errors={errors.caption}
           label="Caption"
         />
-        <Button
-          priority="primary"
-          size="xsmall"
-          // icon={<SvgCamera />}
-          iconSide="left"
-          onClick={() => fields.altText.update(fieldValues.caption)}
-        >
-          Copy from caption
-        </Button>
-        <FieldWrapper
-          field={fields.altText}
-          errors={errors.altText}
-          label="Alt text"
-        />
+        <span>
+          <FieldWrapper
+            field={fields.altText}
+            errors={errors.altText}
+            label="Alt text"
+          />
+        </span>
+        <span>
+          <Button
+            priority="primary"
+            size="xsmall"
+            iconSide="left"
+            onClick={() => fields.altText.update(fieldValues.caption)}
+          >
+            Copy from caption
+          </Button>
+        </span>
         <Inline space={2}>
           <FieldWrapper
             field={fields.photographer}

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -9,6 +9,7 @@ import type {
   CustomFieldViewSpec,
   FieldNameToFieldViewSpec,
 } from "../../plugin/types/Element";
+import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import { useCustomFieldViewState } from "../../renderers/react/useCustomFieldViewState";
 import type {
@@ -99,10 +100,10 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
             css={inlineStyles}
           />
         </Inline>
-        <Field
+        <CustomCheckboxView
           fieldViewSpec={fieldViewSpecs.displayCreditInformation}
           errors={errors.displayCreditInformation}
-          label="Credits"
+          label="Display credit information"
         />
       </Column>
     </Columns>

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -13,6 +13,7 @@ import { CustomCheckboxView } from "../../renderers/react/customFieldViewCompone
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import { useCustomFieldViewState } from "../../renderers/react/useCustomFieldViewState";
 import type {
+  Asset,
   createImageFields,
   MainImageData,
   MainImageProps,
@@ -110,6 +111,10 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
   </div>
 );
 
+const imageViewStysles = css`
+  width: 100%;
+`;
+
 const ImageView = ({ fieldViewSpec, onChange }: ImageViewProps) => {
   const [imageFields, setImageFieldsRef] = useCustomFieldViewState(
     fieldViewSpec
@@ -126,12 +131,29 @@ const ImageView = ({ fieldViewSpec, onChange }: ImageViewProps) => {
     }
     onChange(mediaPayload);
   };
+
+  const masterImageSource = imageFields.assets
+    .filter((image) => image.fields.width >= 1000)
+    .sort((assetA, assetB) => assetA.fields.width - assetB.fields.width)[0]
+    ?.url;
+  const isMaster = (asset: Asset) =>
+    typeof asset.fields.isMaster !== "undefined"
+      ? asset.fields.isMaster
+      : false;
+  const excludeMasterAsset = imageFields.assets.filter(
+    (asset) => !isMaster(asset)
+  );
+  const assetsInAscWidth = excludeMasterAsset
+    .filter((image) => image.fields.width < 1000)
+    .sort((assetA, assetB) => assetA.fields.width - assetB.fields.width)
+    .slice(-1)[0]?.url;
   return (
     <>
       <div>
-        {imageFields.assets.length > 0 ? (
-          <img src={imageFields.assets[0].url} />
-        ) : null}
+        <img
+          css={imageViewStysles}
+          src={masterImageSource || assetsInAscWidth}
+        />
       </div>
       <Button
         priority="primary"

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -35,6 +35,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
     <FieldView fieldViewSpec={fieldViewSpecs.photographer} />
     <FieldView fieldViewSpec={fieldViewSpecs.weighting} />
     <FieldView fieldViewSpec={fieldViewSpecs.imageType} />
+    <FieldView fieldViewSpec={fieldViewSpecs.source} />
     <FieldView fieldViewSpec={fieldViewSpecs.displayCreditInformation} />
     <ImageView
       fieldViewSpec={fieldViewSpecs.mainImage}

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -6,10 +6,11 @@ import type {
 import { FieldView } from "../../renderers/react/FieldView";
 import { useCustomFieldViewState } from "../../renderers/react/useCustomFieldViewState";
 import type {
-  Asset,
   createImageFields,
   MainImageData,
   MainImageProps,
+  MediaPayload,
+  SetMedia,
 } from "./ImageElement";
 
 type Props = {
@@ -19,6 +20,7 @@ type Props = {
 };
 
 type ImageViewProps = {
+  onChange: SetMedia;
   fieldViewSpec: CustomFieldViewSpec<MainImageData, MainImageProps>;
 };
 
@@ -34,20 +36,23 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
     <FieldView fieldViewSpec={fieldViewSpecs.weighting} />
     <FieldView fieldViewSpec={fieldViewSpecs.imageType} />
     <FieldView fieldViewSpec={fieldViewSpecs.displayCreditInformation} />
-    <ImageView fieldViewSpec={fieldViewSpecs.mainImage} />
+    <ImageView
+      fieldViewSpec={fieldViewSpecs.mainImage}
+      onChange={({ caption, source, photographer }) => {
+        fieldViewSpecs.altText.update(caption);
+        fieldViewSpecs.source.update(source);
+        fieldViewSpecs.photographer.update(photographer);
+      }}
+    />
   </div>
 );
 
-const ImageView = ({ fieldViewSpec }: ImageViewProps) => {
+const ImageView = ({ fieldViewSpec, onChange }: ImageViewProps) => {
   const [imageFields, setImageFieldsRef] = useCustomFieldViewState(
     fieldViewSpec
   );
-  const setMedia = (
-    mediaId: string,
-    mediaApiUri: string,
-    assets: Asset[],
-    suppliersReference: string
-  ) => {
+  const setMedia = (mediaPayload: MediaPayload) => {
+    const { mediaId, mediaApiUri, assets, suppliersReference } = mediaPayload;
     if (setImageFieldsRef.current) {
       setImageFieldsRef.current({
         mediaId,
@@ -56,6 +61,7 @@ const ImageView = ({ fieldViewSpec }: ImageViewProps) => {
         suppliersReference,
       });
     }
+    onChange(mediaPayload);
   };
   return (
     <>

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -1,3 +1,5 @@
+import { css } from "@emotion/react";
+import { Column, Columns, Inline } from "@guardian/src-layout";
 import React from "react";
 import { Field } from "../../editorial-source-components/Field";
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
@@ -13,6 +15,10 @@ import type {
   MediaPayload,
   SetMedia,
 } from "./ImageElement";
+
+const inlineStyles = css`
+  width: 40%;
+`;
 
 type Props = {
   fieldValues: FieldNameToValueMap<ReturnType<typeof createImageFields>>;
@@ -35,57 +41,64 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
   fieldValues,
 }) => (
   <div data-cy={ImageElementTestId}>
-    <Field
-      fieldViewSpec={fieldViewSpecs.caption}
-      errors={errors.caption}
-      label="Caption"
-    />
-    <button onClick={() => fieldViewSpecs.altText.update(fieldValues.caption)}>
-      Copy from caption
-    </button>
-    <Field
-      fieldViewSpec={fieldViewSpecs.altText}
-      errors={errors.altText}
-      label="Alt text"
-    />
-    <Field
-      fieldViewSpec={fieldViewSpecs.photographer}
-      errors={errors.photographer}
-      label="Photographer"
-    />
-    <Field
-      fieldViewSpec={fieldViewSpecs.weighting}
-      errors={errors.weighting}
-      label="Weighting"
-    />
-    <Field
-      fieldViewSpec={fieldViewSpecs.imageType}
-      errors={errors.imageType}
-      label="Image Types"
-    />
-    <Field
-      fieldViewSpec={fieldViewSpecs.source}
-      errors={errors.source}
-      label="Source"
-    />
-    <Field
-      fieldViewSpec={fieldViewSpecs.photographer}
-      errors={errors.photographer}
-      label="Photographer"
-    />
-    <Field
-      fieldViewSpec={fieldViewSpecs.displayCreditInformation}
-      errors={errors.displayCreditInformation}
-      label="Credits"
-    />
-    <ImageView
-      fieldViewSpec={fieldViewSpecs.mainImage}
-      onChange={({ caption, source, photographer }) => {
-        fieldViewSpecs.caption.update(caption);
-        fieldViewSpecs.source.update(source);
-        fieldViewSpecs.photographer.update(photographer);
-      }}
-    />
+    <Columns>
+      <Column width={2 / 5}>
+        <Field
+          fieldViewSpec={fieldViewSpecs.weighting}
+          errors={errors.weighting}
+          label="Weighting"
+        />
+        <ImageView
+          fieldViewSpec={fieldViewSpecs.mainImage}
+          onChange={({ caption, source, photographer }) => {
+            fieldViewSpecs.caption.update(caption);
+            fieldViewSpecs.source.update(source);
+            fieldViewSpecs.photographer.update(photographer);
+          }}
+        />
+        <Field
+          fieldViewSpec={fieldViewSpecs.imageType}
+          errors={errors.imageType}
+          label="Image Types"
+        />
+      </Column>
+      <Column width={3 / 5}>
+        <Field
+          fieldViewSpec={fieldViewSpecs.caption}
+          errors={errors.caption}
+          label="Caption"
+        />
+        <button
+          onClick={() => fieldViewSpecs.altText.update(fieldValues.caption)}
+        >
+          Copy from caption
+        </button>
+        <Field
+          fieldViewSpec={fieldViewSpecs.altText}
+          errors={errors.altText}
+          label="Alt text"
+        />
+        <Inline space={2}>
+          <Field
+            fieldViewSpec={fieldViewSpecs.photographer}
+            errors={errors.photographer}
+            label="Photographer"
+            css={inlineStyles}
+          />
+          <Field
+            fieldViewSpec={fieldViewSpecs.source}
+            errors={errors.source}
+            label="Source"
+            css={inlineStyles}
+          />
+        </Inline>
+        <Field
+          fieldViewSpec={fieldViewSpecs.displayCreditInformation}
+          errors={errors.displayCreditInformation}
+          label="Credits"
+        />
+      </Column>
+    </Columns>
   </div>
 );
 

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -1,10 +1,10 @@
 import React from "react";
+import { Field } from "../../editorial-source-components/Field";
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
 import type {
   CustomFieldViewSpec,
   FieldNameToFieldViewSpec,
 } from "../../plugin/types/Element";
-import { FieldView } from "../../renderers/react/FieldView";
 import { useCustomFieldViewState } from "../../renderers/react/useCustomFieldViewState";
 import type {
   createImageFields,
@@ -16,6 +16,7 @@ import type {
 
 type Props = {
   fieldValues: FieldNameToValueMap<ReturnType<typeof createImageFields>>;
+  errors: Record<string, string[]>;
   fieldViewSpecs: FieldNameToFieldViewSpec<
     ReturnType<typeof createImageFields>
   >;
@@ -29,20 +30,54 @@ type ImageViewProps = {
 export const ImageElementTestId = "ImageElement";
 
 export const ImageElementForm: React.FunctionComponent<Props> = ({
-  fieldValues,
+  errors,
   fieldViewSpecs,
+  fieldValues,
 }) => (
   <div data-cy={ImageElementTestId}>
-    <FieldView fieldViewSpec={fieldViewSpecs.caption} />
+    <Field
+      fieldViewSpec={fieldViewSpecs.caption}
+      errors={errors.caption}
+      label="Caption"
+    />
     <button onClick={() => fieldViewSpecs.altText.update(fieldValues.caption)}>
       Copy from caption
     </button>
-    <FieldView fieldViewSpec={fieldViewSpecs.altText} />
-    <FieldView fieldViewSpec={fieldViewSpecs.photographer} />
-    <FieldView fieldViewSpec={fieldViewSpecs.weighting} />
-    <FieldView fieldViewSpec={fieldViewSpecs.imageType} />
-    <FieldView fieldViewSpec={fieldViewSpecs.source} />
-    <FieldView fieldViewSpec={fieldViewSpecs.displayCreditInformation} />
+    <Field
+      fieldViewSpec={fieldViewSpecs.altText}
+      errors={errors.altText}
+      label="Alt text"
+    />
+    <Field
+      fieldViewSpec={fieldViewSpecs.photographer}
+      errors={errors.photographer}
+      label="Photographer"
+    />
+    <Field
+      fieldViewSpec={fieldViewSpecs.weighting}
+      errors={errors.weighting}
+      label="Weighting"
+    />
+    <Field
+      fieldViewSpec={fieldViewSpecs.imageType}
+      errors={errors.imageType}
+      label="Image Types"
+    />
+    <Field
+      fieldViewSpec={fieldViewSpecs.source}
+      errors={errors.source}
+      label="Source"
+    />
+    <Field
+      fieldViewSpec={fieldViewSpecs.photographer}
+      errors={errors.photographer}
+      label="Photographer"
+    />
+    <Field
+      fieldViewSpec={fieldViewSpecs.displayCreditInformation}
+      errors={errors.displayCreditInformation}
+      label="Credits"
+    />
     <ImageView
       fieldViewSpec={fieldViewSpecs.mainImage}
       onChange={({ caption, source, photographer }) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { buildElementPlugin } from "./plugin/element";
-export { createImageElement } from "./elements/demo-image/DemoImageElement";
+export { createDemoImageElement } from "./elements/demo-image/DemoImageElement";
 export { createEmbedElement } from "./elements/embed/EmbedSpec";
 export { pullquoteElement } from "./elements/pullquote/PullquoteSpec";
 export { codeElement } from "./elements/code/CodeElementSpec";
+export { createImageElement } from "./elements/image/ImageElement";

--- a/yarn.lock
+++ b/yarn.lock
@@ -552,6 +552,13 @@
   resolved "https://registry.yarnpkg.com/@guardian/eslint-config/-/eslint-config-0.5.0.tgz#ece14ec90b372932c7bf01992fc6d8ce58f7f26e"
   integrity sha512-THJn0wg7i9YjSVM9ofobsJgS+WH9ybrZH1+0CXLAebp0T53RGtgZUkek82mDg1h3DidsM+f7HSZqoQyrCbPzPw==
 
+"@guardian/src-button@^3.8.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-button/-/src-button-3.8.0.tgz#6c7eee727b0bf283766d36e20929e63131bf82eb"
+  integrity sha512-C7wa10EAe+tbuySuzfsNK/Fppxw8I5/3bdyJ0acZQJaDQxJAzAkraGrhXDfWgNXXjpJXA6j3lLJUBaZE6m+hzA==
+  dependencies:
+    "@guardian/src-helpers" "^3.8.0"
+
 "@guardian/src-checkbox@^3.8.0":
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-checkbox/-/src-checkbox-3.8.0.tgz#d2fb3340f08bcbbe10339868bded3205473427e9"


### PR DESCRIPTION
co-authored with @SHession 

## What does this change?
This PR adds an Image Element replicating the existing Embed element in Composer. However this element includes more functionality and buttons to access the Grid for images.

This PR also:
- adds a `CustomDropDown` which renders a modified Source Dropdown (allowing for clearer displayed text and improved - arrow button).
- includes the use of `createTextField` as a text area allowing for multi line 
- adds a createTextField with multiline capabilities set with a default of 4 lines.
- Field labels included as prop from Component
- Accesses Grid instantly when image element button selected
- Buttons to re crop/change selected image and copy caption to alt text field
- Logic to deal with Assets from Grid defaulting to those of 1000px width and the next largest as a fallback
- Adds styling for width of image to stretch to 100% of column
- Styling includes Source library from buttons and columns
- Adds field data on initial insert image element press
- Update fields on selecting image for source, photographer and caption
- Fixes demo image element with demoSetMedia, decoupling the demo and actual image element
- setMedia object used to house data from Grid and refactor for use with the element, as a MediaPayload type


### Images
| Selecting image | 
<img alt="Screenshot 2021-08-06 at 16 05 00" src="https://user-images.githubusercontent.com/49187886/130616857-e646870a-6b14-4c99-9e10-028109c37893.gif" width="500px"/> 

| Caption button |
<img alt="Screenshot 2021-08-06 at 15 55 00" src="https://user-images.githubusercontent.com/49187886/130617572-cdc78354-531b-4e03-bbbc-57b1a76ec99a.gif"  width="500px"/> 

| Fields input and validation |
<img alt="Screenshot 2021-08-06 at 15 55 00" src="https://user-images.githubusercontent.com/49187886/130618535-70d92a38-41de-4a21-acf7-e47eb96dd23d.gif"  width="500px"/> 

| Re-crop button |
<img alt="Screenshot 2021-08-06 at 15 55 00" src="https://user-images.githubusercontent.com/49187886/130619733-d58065d5-c959-4c4d-b6c0-04960c0327f7.gif"  width="500px"/> 


## How to test
Run `yarn start`
Passes all integration and unit test