### PR TITLE
refactor: Un-nests checkbox field values

### DIFF
--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -138,6 +138,6 @@ export const getSerialisedHtml = ({
     <element-imageelement-optiondropdown class="ProsemirrorElement__imageElement-optionDropdown" fields="&quot;${optionValue}&quot;"></element-imageelement-optiondropdown>
     <element-imageelement-restrictedtextfield class="ProsemirrorElement__imageElement-restrictedTextField">${restrictedTextValue}</element-imageelement-restrictedtextfield>
     <element-imageelement-src class="ProsemirrorElement__imageElement-src">${srcValue}</element-imageelement-src>
-    <element-imageelement-usesrc class="ProsemirrorElement__imageElement-useSrc" fields="{&quot;value&quot;:${useSrcValue}}"></element-imageelement-usesrc>
+    <element-imageelement-usesrc class="ProsemirrorElement__imageElement-useSrc" fields="${useSrcValue}"></element-imageelement-usesrc>
   </imageelement><p>First paragraph</p><p>Second paragraph</p>`);
 };

--- a/src/elements/createGuElementSpec.ts
+++ b/src/elements/createGuElementSpec.ts
@@ -26,7 +26,7 @@ export const createGuElementSpec = <FDesc extends FieldDescriptions<string>>(
       assets = [],
       fields,
     }: FlexibleModelElement<FDesc>) => {
-      return { ...fields, assets } as FieldNameToValueMap<FDesc>;
+      return ({ ...fields, assets } as unknown) as FieldNameToValueMap<FDesc>;
     },
     transformElementDataOut: ({
       assets,

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -154,13 +154,13 @@ describe("buildElementPlugin", () => {
 
     it("should not allow fields to be instantiated with an incorrect type", () => {
       const testElement = createNoopElement({
-        field1: { type: "checkbox", defaultValue: { value: false } },
+        field1: { type: "checkbox", defaultValue: false },
       });
       const { insertElement } = buildElementPlugin({ testElement });
       insertElement({
         elementName: "testElement",
         values: {
-          field1: { value: true },
+          field1: true,
         },
       });
       insertElement({
@@ -193,7 +193,7 @@ describe("buildElementPlugin", () => {
   describe("Element creation and serialisation", () => {
     it("should create an element with default content when no fields are supplied", () => {
       const testElement = createNoopElement({
-        field1: { type: "checkbox", defaultValue: { value: false } },
+        field1: { type: "checkbox", defaultValue: false },
         field2: { type: "richText", defaultValue: "<p>Content</p>" },
       });
       const {
@@ -217,7 +217,7 @@ describe("buildElementPlugin", () => {
 
     it("should fill out fields in ATTRIBUTE nodes", () => {
       const testElement = createNoopElement({
-        field1: { type: "checkbox", defaultValue: { value: false } },
+        field1: { type: "checkbox", defaultValue: false },
       });
       const {
         view,
@@ -227,7 +227,7 @@ describe("buildElementPlugin", () => {
 
       insertElement({
         elementName: "testElement",
-        values: { field1: { value: true } },
+        values: { field1: true },
       })(view.state, view.dispatch);
 
       const expected = trimHtml(
@@ -401,7 +401,7 @@ describe("buildElementPlugin", () => {
       values: {
         field1: "<p></p>",
         field2: "",
-        field3: { value: true },
+        field3: true,
       },
     } as const;
 

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -209,7 +209,7 @@ describe("buildElementPlugin", () => {
 
       const expected = trimHtml(`
         <testelement type="testElement" has-errors="false">
-          <element-testelement-field1 class="ProsemirrorElement__testElement-field1" fields="{&quot;value&quot;:false}"></element-testelement-field1>
+          <element-testelement-field1 class="ProsemirrorElement__testElement-field1" fields="false"></element-testelement-field1>
           <element-testelement-field2 class="ProsemirrorElement__testElement-field2"><p>Content</p></element-testelement-field2>
         </testelement>`);
       expect(getElementAsHTML()).toBe(expected);
@@ -232,7 +232,7 @@ describe("buildElementPlugin", () => {
 
       const expected = trimHtml(
         `<testelement type="testElement" has-errors="false">
-          <element-testelement-field1 class="ProsemirrorElement__testElement-field1" fields="{&quot;value&quot;:true}"></element-testelement-field1>
+          <element-testelement-field1 class="ProsemirrorElement__testElement-field1" fields="true"></element-testelement-field1>
         </testelement>`
       );
       expect(getElementAsHTML()).toBe(expected);
@@ -319,7 +319,7 @@ describe("buildElementPlugin", () => {
           <testelement type="testElement" has-errors="false">
           <element-testelement-field1 class="ProsemirrorElement__testElement-field1"><p></p></element-testelement-field1>
           <element-testelement-field2 class="ProsemirrorElement__testElement-field2"></element-testelement-field2>
-          <element-testelement-field3 class="ProsemirrorElement__testElement-field3" fields="{&quot;value&quot;:true}"></element-testelement-field3>
+          <element-testelement-field3 class="ProsemirrorElement__testElement-field3" fields="true"></element-testelement-field3>
           </testelement>
         `;
 

--- a/src/plugin/__tests__/elementSpec.spec.ts
+++ b/src/plugin/__tests__/elementSpec.spec.ts
@@ -48,7 +48,7 @@ describe("mount", () => {
         },
         field2: {
           type: "checkbox",
-          defaultValue: { value: true },
+          defaultValue: true,
         },
       } as const;
       createElementSpec(
@@ -58,7 +58,7 @@ describe("mount", () => {
           // field1 is derived from the fieldDescriptions, and is a string b/c it's a richText field
           fields.field1.toString();
           // field2 is a boolean b/c it's a checkbox field
-          fields.field2.value.valueOf();
+          fields.field2;
           return null;
         }
       );
@@ -182,7 +182,7 @@ describe("mount", () => {
           const fieldDescriptions = {
             field1: {
               type: "checkbox" as const,
-              defaultValue: { value: true },
+              defaultValue: true,
             },
           };
 

--- a/src/plugin/__tests__/elementSpec.spec.ts
+++ b/src/plugin/__tests__/elementSpec.spec.ts
@@ -58,7 +58,7 @@ describe("mount", () => {
           // field1 is derived from the fieldDescriptions, and is a string b/c it's a richText field
           fields.field1.toString();
           // field2 is a boolean b/c it's a checkbox field
-          fields.field2;
+          fields.field2.valueOf();
           return null;
         }
       );
@@ -194,9 +194,7 @@ describe("mount", () => {
             atom: true,
             attrs: {
               fields: {
-                default: {
-                  value: true,
-                },
+                default: true,
               },
             },
           });

--- a/src/plugin/fieldViews/CheckboxFieldView.ts
+++ b/src/plugin/fieldViews/CheckboxFieldView.ts
@@ -3,7 +3,7 @@ import type { EditorView } from "prosemirror-view";
 import { AttributeFieldView } from "./AttributeFieldView";
 import type { BaseFieldDescription } from "./FieldView";
 
-export type CheckboxValue = { value: boolean };
+export type CheckboxValue = boolean;
 
 export interface CheckboxFieldDescription
   extends BaseFieldDescription<CheckboxValue> {
@@ -14,12 +14,12 @@ export const createCheckBox = (
   defaultValue: boolean
 ): CheckboxFieldDescription => ({
   type: CheckboxFieldView.fieldName,
-  defaultValue: { value: defaultValue },
+  defaultValue,
 });
 
 export class CheckboxFieldView extends AttributeFieldView<CheckboxValue> {
   public static fieldName = "checkbox" as const;
-  public static defaultValue = { value: false };
+  public static defaultValue = false;
   private checkboxElement: HTMLInputElement | undefined = undefined;
 
   constructor(
@@ -40,18 +40,18 @@ export class CheckboxFieldView extends AttributeFieldView<CheckboxValue> {
     return node.attrs.fields as CheckboxValue;
   }
 
-  protected createInnerView({ value }: CheckboxValue): void {
+  protected createInnerView(value: CheckboxValue): void {
     this.checkboxElement = document.createElement("input");
     this.checkboxElement.type = "checkbox";
     this.checkboxElement.checked = value;
     this.checkboxElement.addEventListener("change", (event) =>
-      this.updateOuterEditor({
-        value: Boolean((event.target as HTMLInputElement).checked),
-      })
+      this.updateOuterEditor(
+        Boolean((event.target as HTMLInputElement).checked)
+      )
     );
     this.fieldViewElement.appendChild(this.checkboxElement);
   }
-  protected updateInnerView({ value }: CheckboxValue): void {
+  protected updateInnerView(value: CheckboxValue): void {
     if (this.checkboxElement) {
       this.checkboxElement.checked = value;
     }

--- a/src/plugin/fieldViews/__tests__/AttributeFieldView.spec.ts
+++ b/src/plugin/fieldViews/__tests__/AttributeFieldView.spec.ts
@@ -33,7 +33,7 @@ const testSchema = new Schema({
     text: schema.nodes.text,
     ...(getNodeSpecForField("doc", "testField", {
       type: "checkbox",
-      defaultValue: { value: false },
+      defaultValue: false,
     }) as { testField: NodeSpec }),
   },
 });

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -7,7 +7,6 @@ import type {
   FieldDescriptions,
   FieldNameToField,
 } from "../plugin/types/Element";
-import { CheckboxFieldView } from "./fieldViews/CheckboxFieldView";
 import type { FieldNameToValueMap } from "./fieldViews/helpers";
 import { getElementFieldViewFromType } from "./helpers/plugin";
 import type { Commands } from "./helpers/prosemirror";
@@ -126,31 +125,17 @@ const createNodeView = <
       innerDecos,
     });
 
-    if (fieldView instanceof CheckboxFieldView) {
-      fields[name] = ({
-        description: fieldDescriptions,
-        name,
-        view: fieldView,
-        // We coerce types here: it's difficult to prove we've the right shape here
-        // to the compiler, and we're already beholden to runtime behaviour as there's
-        // no guarantee that the node's `name` matches our spec. The errors above should
-        // help to defend when something's wrong.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- as above
-        update: (value: boolean) => fieldView.update(value),
-      } as unknown) as FieldNameToField<FDesc>[typeof name];
-    } else {
-      fields[name] = ({
-        description: fieldDescriptions,
-        name,
-        view: fieldView,
-        // We coerce types here: it's difficult to prove we've the right shape here
-        // to the compiler, and we're already beholden to runtime behaviour as there's
-        // no guarantee that the node's `name` matches our spec. The errors above should
-        // help to defend when something's wrong.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- as above
-        update: (value: string) => fieldView.update(value),
-      } as unknown) as FieldNameToField<FDesc>[typeof name];
-    }
+    fields[name] = ({
+      description: fieldDescriptions,
+      name,
+      view: fieldView,
+      // We coerce types here: it's difficult to prove we've the right shape here
+      // to the compiler, and we're already beholden to runtime behaviour as there's
+      // no guarantee that the node's `name` matches our spec. The errors above should
+      // help to defend when something's wrong.
+      update: (value: unknown) =>
+        (fieldView.update as (value: unknown) => void)(value),
+    } as unknown) as FieldNameToField<FDesc>[typeof name];
   });
 
   const getValuesFromNode = (

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -7,6 +7,7 @@ import type {
   FieldDescriptions,
   FieldNameToField,
 } from "../plugin/types/Element";
+import { CheckboxFieldView } from "./fieldViews/CheckboxFieldView";
 import type { FieldNameToValueMap } from "./fieldViews/helpers";
 import { getElementFieldViewFromType } from "./helpers/plugin";
 import type { Commands } from "./helpers/prosemirror";
@@ -125,17 +126,31 @@ const createNodeView = <
       innerDecos,
     });
 
-    fields[name] = ({
-      description: fieldDescriptions,
-      name,
-      view: fieldView,
-      // We coerce types here: it's difficult to prove we've the right shape here
-      // to the compiler, and we're already beholden to runtime behaviour as there's
-      // no guarantee that the node's `name` matches our spec. The errors above should
-      // help to defend when something's wrong.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- as above
-      update: (value: unknown) => fieldView.update(value as any),
-    } as unknown) as FieldNameToField<FDesc>[typeof name];
+    if (fieldView instanceof CheckboxFieldView) {
+      fields[name] = ({
+        description: fieldDescriptions,
+        name,
+        view: fieldView,
+        // We coerce types here: it's difficult to prove we've the right shape here
+        // to the compiler, and we're already beholden to runtime behaviour as there's
+        // no guarantee that the node's `name` matches our spec. The errors above should
+        // help to defend when something's wrong.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- as above
+        update: (value: boolean) => fieldView.update(value),
+      } as unknown) as FieldNameToField<FDesc>[typeof name];
+    } else {
+      fields[name] = ({
+        description: fieldDescriptions,
+        name,
+        view: fieldView,
+        // We coerce types here: it's difficult to prove we've the right shape here
+        // to the compiler, and we're already beholden to runtime behaviour as there's
+        // no guarantee that the node's `name` matches our spec. The errors above should
+        // help to defend when something's wrong.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- as above
+        update: (value: string) => fieldView.update(value),
+      } as unknown) as FieldNameToField<FDesc>[typeof name];
+    }
   });
 
   const getValuesFromNode = (


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR un-nests the checkbox field values, which should make them a little easier to work.

Before:
`CheckboxValue = { value: boolean };`

After
`CheckboxValue = boolean;`

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This should be a no-op in terms of functionality but make checkbox fields easier to work with.

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [x] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
