### PR TITLE
feat: Remove custom tags and classes

### DIFF
--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -129,15 +129,15 @@ export const getSerialisedHtml = ({
           mainImageValue.mediaApiUri ?? "undefined"
         }&quot;,&quot;assets&quot;${mainImageValue.assets}`
       : `&quot;assets&quot;:[]`;
-  return trimHtml(`<imageelement type="imageElement" has-errors="false">
-    <element-imageelement-alttext class="ProsemirrorElement__imageElement-altText">${altTextValue}</element-imageelement-alttext>
-    <element-imageelement-caption class="ProsemirrorElement__imageElement-caption">${captionValue}</element-imageelement-caption>
-    <element-imageelement-code class="ProsemirrorElement__imageElement-code">${codeValue}</element-imageelement-code>
-    <element-imageelement-customdropdown class="ProsemirrorElement__imageElement-customDropdown" fields="&quot;${customDropdownValue}&quot;"></element-imageelement-customdropdown>
-    <element-imageelement-mainimage class="ProsemirrorElement__imageElement-mainImage" fields="{${mainImageFields}}"></element-imageelement-mainimage>
-    <element-imageelement-optiondropdown class="ProsemirrorElement__imageElement-optionDropdown" fields="&quot;${optionValue}&quot;"></element-imageelement-optiondropdown>
-    <element-imageelement-restrictedtextfield class="ProsemirrorElement__imageElement-restrictedTextField">${restrictedTextValue}</element-imageelement-restrictedtextfield>
-    <element-imageelement-src class="ProsemirrorElement__imageElement-src">${srcValue}</element-imageelement-src>
-    <element-imageelement-usesrc class="ProsemirrorElement__imageElement-useSrc" fields="${useSrcValue}"></element-imageelement-usesrc>
-  </imageelement><p>First paragraph</p><p>Second paragraph</p>`);
+  return trimHtml(`<div pm-elements-element-type="imageElement" has-errors="false">
+    <div pm-elements-field-name="imageElement_altText">${altTextValue}</div>
+    <div pm-elements-field-name="imageElement_caption">${captionValue}</div>
+    <div pm-elements-field-name="imageElement_code">${codeValue}</div>
+    <div pm-elements-field-name="imageElement_customDropdown" fields="&quot;${customDropdownValue}&quot;"></div>
+    <div pm-elements-field-name="imageElement_mainImage" fields="{${mainImageFields}}"></div>
+    <div pm-elements-field-name="imageElement_optionDropdown" fields="&quot;${optionValue}&quot;"></div>
+    <div pm-elements-field-name="imageElement_restrictedTextField">${restrictedTextValue}</div>
+    <div pm-elements-field-name="imageElement_src">${srcValue}</div>
+    <div pm-elements-field-name="imageElement_useSrc" fields="${useSrcValue}"></div>
+  </div><p>First paragraph</p><p>Second paragraph</p>`);
 };

--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -129,15 +129,15 @@ export const getSerialisedHtml = ({
           mainImageValue.mediaApiUri ?? "undefined"
         }&quot;,&quot;assets&quot;${mainImageValue.assets}`
       : `&quot;assets&quot;:[]`;
-  return trimHtml(`<div pm-elements-element-type="imageElement" has-errors="false">
-    <div pm-elements-field-name="imageElement_altText">${altTextValue}</div>
-    <div pm-elements-field-name="imageElement_caption">${captionValue}</div>
-    <div pm-elements-field-name="imageElement_code">${codeValue}</div>
-    <div pm-elements-field-name="imageElement_customDropdown" fields="&quot;${customDropdownValue}&quot;"></div>
-    <div pm-elements-field-name="imageElement_mainImage" fields="{${mainImageFields}}"></div>
-    <div pm-elements-field-name="imageElement_optionDropdown" fields="&quot;${optionValue}&quot;"></div>
-    <div pm-elements-field-name="imageElement_restrictedTextField">${restrictedTextValue}</div>
-    <div pm-elements-field-name="imageElement_src">${srcValue}</div>
-    <div pm-elements-field-name="imageElement_useSrc" fields="${useSrcValue}"></div>
+  return trimHtml(`<div pme-element-type="imageElement" has-errors="false">
+    <div pme-field-name="imageElement_altText">${altTextValue}</div>
+    <div pme-field-name="imageElement_caption">${captionValue}</div>
+    <div pme-field-name="imageElement_code">${codeValue}</div>
+    <div pme-field-name="imageElement_customDropdown" fields="&quot;${customDropdownValue}&quot;"></div>
+    <div pme-field-name="imageElement_mainImage" fields="{${mainImageFields}}"></div>
+    <div pme-field-name="imageElement_optionDropdown" fields="&quot;${optionValue}&quot;"></div>
+    <div pme-field-name="imageElement_restrictedTextField">${restrictedTextValue}</div>
+    <div pme-field-name="imageElement_src">${srcValue}</div>
+    <div pme-field-name="imageElement_useSrc" fields="${useSrcValue}"></div>
   </div><p>First paragraph</p><p>Second paragraph</p>`);
 };

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -208,10 +208,10 @@ describe("buildElementPlugin", () => {
       );
 
       const expected = trimHtml(`
-        <testelement type="testElement" has-errors="false">
-          <element-testelement-field1 class="ProsemirrorElement__testElement-field1" fields="false"></element-testelement-field1>
-          <element-testelement-field2 class="ProsemirrorElement__testElement-field2"><p>Content</p></element-testelement-field2>
-        </testelement>`);
+        <div pm-elements-element-type="testElement" has-errors="false">
+          <div pm-elements-field-name="testElement_field1" fields="false"></div>
+          <div pm-elements-field-name="testElement_field2"><p>Content</p></div>
+        </div>`);
       expect(getElementAsHTML()).toBe(expected);
     });
 
@@ -230,11 +230,10 @@ describe("buildElementPlugin", () => {
         values: { field1: true },
       })(view.state, view.dispatch);
 
-      const expected = trimHtml(
-        `<testelement type="testElement" has-errors="false">
-          <element-testelement-field1 class="ProsemirrorElement__testElement-field1" fields="true"></element-testelement-field1>
-        </testelement>`
-      );
+      const expected = trimHtml(`
+        <div pm-elements-element-type="testElement" has-errors="false">
+          <div pm-elements-field-name="testElement_field1" fields="true"></div>
+        </div>`);
       expect(getElementAsHTML()).toBe(expected);
     });
 
@@ -253,11 +252,10 @@ describe("buildElementPlugin", () => {
         values: { field1: "<p>Content</p>" },
       })(view.state, view.dispatch);
 
-      const expected = trimHtml(
-        `<testelement type="testElement" has-errors="false">
-          <element-testelement-field1 class="ProsemirrorElement__testElement-field1"><p>Content</p></element-testelement-field1>
-        </testelement>`
-      );
+      const expected = trimHtml(`
+        <div pm-elements-element-type="testElement" has-errors="false">
+          <div pm-elements-field-name="testElement_field1"><p>Content</p></div>
+        </div>`);
       expect(getElementAsHTML()).toBe(expected);
     });
 
@@ -281,10 +279,10 @@ describe("buildElementPlugin", () => {
       })(view.state, view.dispatch);
 
       const expected = trimHtml(`
-        <testelement type="testElement" has-errors="false">
-          <element-testelement-field1 class="ProsemirrorElement__testElement-field1"><p>Content for field1</p></element-testelement-field1>
-          <element-testelement-field2 class="ProsemirrorElement__testElement-field2"><p>Content for field2</p></element-testelement-field2>
-        </testelement>`);
+        <div pm-elements-element-type="testElement" has-errors="false">
+          <div pm-elements-field-name="testElement_field1"><p>Content for field1</p></div>
+          <div pm-elements-field-name="testElement_field2"><p>Content for field2</p></div>
+        </div>`);
       expect(getElementAsHTML()).toBe(expected);
     });
 
@@ -307,33 +305,33 @@ describe("buildElementPlugin", () => {
       })(view.state, view.dispatch);
 
       const expected = trimHtml(`
-        <testelement type="testElement" has-errors="false">
-          <element-testelement-field1 class="ProsemirrorElement__testElement-field1" fields="{&quot;arbitraryValue&quot;:&quot;hai&quot;}"></element-testelement-field1>
-        </testelement>`);
+        <div pm-elements-element-type="testElement" has-errors="false">
+          <div pm-elements-field-name="testElement_field1" fields="{&quot;arbitraryValue&quot;:&quot;hai&quot;}"></div>
+        </div>`);
       expect(getElementAsHTML()).toBe(expected);
     });
   });
 
   describe("Serialisation/deserialisation", () => {
     const testElementHTML = `
-          <testelement type="testElement" has-errors="false">
-          <element-testelement-field1 class="ProsemirrorElement__testElement-field1"><p></p></element-testelement-field1>
-          <element-testelement-field2 class="ProsemirrorElement__testElement-field2"></element-testelement-field2>
-          <element-testelement-field3 class="ProsemirrorElement__testElement-field3" fields="true"></element-testelement-field3>
-          </testelement>
+          <div pm-elements-element-type="testElement" has-errors="false">
+          <div pm-elements-field-name="testElement_field1"><p></p></div>
+          <div pm-elements-field-name="testElement_field2"></div>
+          <div pm-elements-field-name="testElement_field3" fields="true"></div>
+          </div>
         `;
 
     const testElement2HTML = `
-        <testelement2 type="testElement2" has-errors="false">
-        <element-testelement-field4 class="ProsemirrorElement__testElement-field4"><p></p></element-testelement-field4>
-        <element-testelement-field5 class="ProsemirrorElement__testElement-field5"></element-testelement-field5>
-        </testelement2>
+        <div pm-elements-element-type="testElement2" has-errors="false">
+        <div pm-elements-field-name="testElement_field4"><p></p></div>
+        <div pm-elements-field-name="testElement_field5"></div>
+        </div2>
       `;
 
     const testElementTransformHTML = `
-      <testelementwithtransform type="testElementWithTransform" has-errors="false">
-      <element-testelementwithtransform-field1 class="ProsemirrorElement__testelementwithtransform-field1"><p></p></element-testelementwithtransform-field1>
-      </testelement2>
+      <div pm-elements-element-type="testElementWithTransform" has-errors="false">
+      <element-testelementwithtransform-field1 pm-elements-field-name="testElement_field1"><p></p></element-testelementwithtransform-field1>
+      </div2>
     `;
 
     const testElement = createNoopElement({
@@ -416,11 +414,11 @@ describe("buildElementPlugin", () => {
     describe("Element parsing", () => {
       it("should parse fields of all types, respecting values against defaults", () => {
         const elementHTML = `
-          <testelement type="testElement" has-errors="false">
-          <element-testelement-field1 class="ProsemirrorElement__testElement-field1"><p>Content</p></element-testelement-field1>
-          <element-testelement-field2 class="ProsemirrorElement__testElement-field2">Content</element-testelement-field2>
-          <element-testelement-field3 class="ProsemirrorElement__testElement-field3" fields="{&quot;value&quot;:true}"></element-testelement-field3>
-          </testelement>
+          <div pm-elements-element-type="testElement" has-errors="false">
+          <div pm-elements-field-name="testElement_field1"><p>Content</p></div>
+          <div pm-elements-field-name="testElement_field2">Content</div>
+          <div pm-elements-field-name="testElement_field3" fields="true"></div>
+          </div>
         `;
 
         const { getElementAsHTML } = createEditorWithElements(
@@ -433,11 +431,11 @@ describe("buildElementPlugin", () => {
 
       it("should parse fields of all types, handling empty content values correctly", () => {
         const elementHTML = `
-          <testelement type="testElement" has-errors="false">
-          <element-testelement-field1 class="ProsemirrorElement__testElement-field1"><p></p></element-testelement-field1>
-          <element-testelement-field2 class="ProsemirrorElement__testElement-field2"></element-testelement-field2>
-          <element-testelement-field3 class="ProsemirrorElement__testElement-field3" fields="{&quot;value&quot;:true}"></element-testelement-field3>
-          </testelement>
+          <div pm-elements-element-type="testElement" has-errors="false">
+          <div pm-elements-field-name="testElement_field1"><p></p></div>
+          <div pm-elements-field-name="testElement_field2"></div>
+          <div pm-elements-field-name="testElement_field3" fields="true"></div>
+          </div>
         `;
 
         const { getElementAsHTML } = createEditorWithElements(

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -208,9 +208,9 @@ describe("buildElementPlugin", () => {
       );
 
       const expected = trimHtml(`
-        <div pm-elements-element-type="testElement" has-errors="false">
-          <div pm-elements-field-name="testElement_field1" fields="false"></div>
-          <div pm-elements-field-name="testElement_field2"><p>Content</p></div>
+        <div pme-element-type="testElement" has-errors="false">
+          <div pme-field-name="testElement_field1" fields="false"></div>
+          <div pme-field-name="testElement_field2"><p>Content</p></div>
         </div>`);
       expect(getElementAsHTML()).toBe(expected);
     });
@@ -231,8 +231,8 @@ describe("buildElementPlugin", () => {
       })(view.state, view.dispatch);
 
       const expected = trimHtml(`
-        <div pm-elements-element-type="testElement" has-errors="false">
-          <div pm-elements-field-name="testElement_field1" fields="true"></div>
+        <div pme-element-type="testElement" has-errors="false">
+          <div pme-field-name="testElement_field1" fields="true"></div>
         </div>`);
       expect(getElementAsHTML()).toBe(expected);
     });
@@ -253,8 +253,8 @@ describe("buildElementPlugin", () => {
       })(view.state, view.dispatch);
 
       const expected = trimHtml(`
-        <div pm-elements-element-type="testElement" has-errors="false">
-          <div pm-elements-field-name="testElement_field1"><p>Content</p></div>
+        <div pme-element-type="testElement" has-errors="false">
+          <div pme-field-name="testElement_field1"><p>Content</p></div>
         </div>`);
       expect(getElementAsHTML()).toBe(expected);
     });
@@ -279,9 +279,9 @@ describe("buildElementPlugin", () => {
       })(view.state, view.dispatch);
 
       const expected = trimHtml(`
-        <div pm-elements-element-type="testElement" has-errors="false">
-          <div pm-elements-field-name="testElement_field1"><p>Content for field1</p></div>
-          <div pm-elements-field-name="testElement_field2"><p>Content for field2</p></div>
+        <div pme-element-type="testElement" has-errors="false">
+          <div pme-field-name="testElement_field1"><p>Content for field1</p></div>
+          <div pme-field-name="testElement_field2"><p>Content for field2</p></div>
         </div>`);
       expect(getElementAsHTML()).toBe(expected);
     });
@@ -305,8 +305,8 @@ describe("buildElementPlugin", () => {
       })(view.state, view.dispatch);
 
       const expected = trimHtml(`
-        <div pm-elements-element-type="testElement" has-errors="false">
-          <div pm-elements-field-name="testElement_field1" fields="{&quot;arbitraryValue&quot;:&quot;hai&quot;}"></div>
+        <div pme-element-type="testElement" has-errors="false">
+          <div pme-field-name="testElement_field1" fields="{&quot;arbitraryValue&quot;:&quot;hai&quot;}"></div>
         </div>`);
       expect(getElementAsHTML()).toBe(expected);
     });
@@ -314,23 +314,23 @@ describe("buildElementPlugin", () => {
 
   describe("Serialisation/deserialisation", () => {
     const testElementHTML = `
-          <div pm-elements-element-type="testElement" has-errors="false">
-          <div pm-elements-field-name="testElement_field1"><p></p></div>
-          <div pm-elements-field-name="testElement_field2"></div>
-          <div pm-elements-field-name="testElement_field3" fields="true"></div>
+          <div pme-element-type="testElement" has-errors="false">
+          <div pme-field-name="testElement_field1"><p></p></div>
+          <div pme-field-name="testElement_field2"></div>
+          <div pme-field-name="testElement_field3" fields="true"></div>
           </div>
         `;
 
     const testElement2HTML = `
-        <div pm-elements-element-type="testElement2" has-errors="false">
-        <div pm-elements-field-name="testElement_field4"><p></p></div>
-        <div pm-elements-field-name="testElement_field5"></div>
+        <div pme-element-type="testElement2" has-errors="false">
+        <div pme-field-name="testElement_field4"><p></p></div>
+        <div pme-field-name="testElement_field5"></div>
         </div2>
       `;
 
     const testElementTransformHTML = `
-      <div pm-elements-element-type="testElementWithTransform" has-errors="false">
-      <element-testelementwithtransform-field1 pm-elements-field-name="testElement_field1"><p></p></element-testelementwithtransform-field1>
+      <div pme-element-type="testElementWithTransform" has-errors="false">
+      <element-testelementwithtransform-field1 pme-field-name="testElement_field1"><p></p></element-testelementwithtransform-field1>
       </div2>
     `;
 
@@ -414,10 +414,10 @@ describe("buildElementPlugin", () => {
     describe("Element parsing", () => {
       it("should parse fields of all types, respecting values against defaults", () => {
         const elementHTML = `
-          <div pm-elements-element-type="testElement" has-errors="false">
-          <div pm-elements-field-name="testElement_field1"><p>Content</p></div>
-          <div pm-elements-field-name="testElement_field2">Content</div>
-          <div pm-elements-field-name="testElement_field3" fields="true"></div>
+          <div pme-element-type="testElement" has-errors="false">
+          <div pme-field-name="testElement_field1"><p>Content</p></div>
+          <div pme-field-name="testElement_field2">Content</div>
+          <div pme-field-name="testElement_field3" fields="true"></div>
           </div>
         `;
 
@@ -431,10 +431,10 @@ describe("buildElementPlugin", () => {
 
       it("should parse fields of all types, handling empty content values correctly", () => {
         const elementHTML = `
-          <div pm-elements-element-type="testElement" has-errors="false">
-          <div pm-elements-field-name="testElement_field1"><p></p></div>
-          <div pm-elements-field-name="testElement_field2"></div>
-          <div pm-elements-field-name="testElement_field3" fields="true"></div>
+          <div pme-element-type="testElement" has-errors="false">
+          <div pme-field-name="testElement_field1"><p></p></div>
+          <div pme-field-name="testElement_field2"></div>
+          <div pme-field-name="testElement_field3" fields="true"></div>
           </div>
         `;
 

--- a/src/plugin/__tests__/elementSpec.spec.ts
+++ b/src/plugin/__tests__/elementSpec.spec.ts
@@ -171,9 +171,10 @@ describe("mount", () => {
             getNodeNameFromField("field1", "testElement1")
           );
           expect(field1NodeSpec).toHaveProperty("content", "text*");
-          expect(field1NodeSpec).toHaveProperty("parseDOM", [
-            { tag: "element-testelement1-field1", preserveWhitespace: false },
-          ]);
+          expect(field1NodeSpec?.parseDOM?.[0]).toMatchObject({
+            tag: "div",
+            preserveWhitespace: false,
+          });
         });
       });
 

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -5,8 +5,8 @@ import type { FieldNameToValueMap } from "./fieldViews/helpers";
 import { fieldTypeToViewMap } from "./fieldViews/helpers";
 import type { FieldDescription, FieldDescriptions } from "./types/Element";
 
-export const elementTypeAttr = "pm-elements-element-type";
-export const fieldNameAttr = "pm-elements-field-name";
+export const elementTypeAttr = "pme-element-type";
+export const fieldNameAttr = "pme-field-name";
 
 export const getNodeSpecFromFieldDescriptions = <
   FDesc extends FieldDescriptions<string>

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -5,6 +5,9 @@ import type { FieldNameToValueMap } from "./fieldViews/helpers";
 import { fieldTypeToViewMap } from "./fieldViews/helpers";
 import type { FieldDescription, FieldDescriptions } from "./types/Element";
 
+export const elementTypeAttr = "pm-elements-element-type";
+export const fieldNameAttr = "pm-elements-field-name";
+
 export const getNodeSpecFromFieldDescriptions = <
   FDesc extends FieldDescriptions<string>
 >(
@@ -47,9 +50,9 @@ const getNodeSpecForElement = (
     },
     draggable: false,
     toDOM: (node: Node) => [
-      elementName,
+      "div",
       {
-        type: node.attrs.type as string,
+        [elementTypeAttr]: node.attrs.type as string,
         fields: JSON.stringify(node.attrs.fields),
         "has-errors": JSON.stringify(node.attrs.hasErrors),
       },
@@ -57,15 +60,17 @@ const getNodeSpecForElement = (
     ],
     parseDOM: [
       {
-        tag: elementName,
+        tag: "div",
         getAttrs: (dom: Element) => {
-          if (typeof dom === "string") {
-            return;
+          const domElementName = dom.getAttribute(elementTypeAttr);
+          if (domElementName !== elementName) {
+            return false;
           }
+
           const hasErrorAttr = dom.getAttribute("has-errors");
 
           return {
-            type: dom.getAttribute("type"),
+            type: elementName,
             fields: JSON.parse(dom.getAttribute("fields") ?? "{}") as unknown,
             hasErrors: hasErrorAttr && hasErrorAttr !== "false",
           };
@@ -89,7 +94,17 @@ export const getNodeSpecForField = (
           toDOM: getDefaultToDOMForContentNode(elementName, fieldName),
           parseDOM: [
             {
-              tag: getTagForNode(elementName, fieldName),
+              tag: "div",
+              getAttrs: (dom: Element) => {
+                const domFieldName = dom.getAttribute(fieldNameAttr);
+                if (
+                  domFieldName !== getNodeNameFromField(fieldName, elementName)
+                ) {
+                  return false;
+                }
+
+                return {};
+              },
               preserveWhitespace: field.isCode ? "full" : false,
             },
           ],
@@ -158,18 +173,19 @@ const getDefaultToDOMForContentNode = (
   fieldName: string
 ) => () =>
   [
-    getTagForNode(elementName, fieldName),
-    { class: getClassForNode(elementName, fieldName) },
+    "div",
+    {
+      [fieldNameAttr]: getNodeNameFromField(fieldName, elementName),
+    },
     0,
   ] as const;
 
 const getDefaultToDOMForLeafNode = (elementName: string, fieldName: string) => (
   node: Node
 ) => [
-  getTagForNode(elementName, fieldName),
+  "div",
   {
-    class: getClassForNode(elementName, fieldName),
-    type: node.attrs.type as string,
+    [fieldNameAttr]: getNodeNameFromField(fieldName, elementName),
     fields: JSON.stringify(node.attrs.fields),
     "has-errors": JSON.stringify(node.attrs.hasErrors),
   },
@@ -180,11 +196,13 @@ const getDefaultParseDOMForLeafNode = (
   fieldName: string
 ) => [
   {
-    tag: getTagForNode(elementName, fieldName),
+    tag: "div",
     getAttrs: (dom: Element) => {
-      if (typeof dom === "string") {
-        return;
+      const domFieldName = dom.getAttribute(fieldNameAttr);
+      if (domFieldName !== getNodeNameFromField(fieldName, elementName)) {
+        return false;
       }
+
       const attrs = {
         fields: JSON.parse(dom.getAttribute("fields") ?? "{}") as unknown,
       };
@@ -193,9 +211,6 @@ const getDefaultParseDOMForLeafNode = (
     },
   },
 ];
-
-const getClassForNode = (elementName: string, fieldName: string) =>
-  `ProsemirrorElement__${elementName}-${fieldName}`;
 
 const getTagForNode = (elementName: string, fieldName: string) =>
   `element-${elementName}-${fieldName}`.toLowerCase();


### PR DESCRIPTION
_co-authored-by: @rhystmills_

## What does this change?

Removes custom tags and classes from serialised elements, in favour of attributes prefixed by `pm-elements`.

Using custom tags isn't recommend by the [W3C spec](https://html.spec.whatwg.org/multipage/dom.html#elements), and has caused problems where element names have coincided with actual element names (e.g. `code`), causing odd behaviour. We could namespace element tags to solve the latter, but making them `divs` also solves the former.

## How to test

The tests have been modified to reflect the new HTML output, but this is a no-op – everything should work as before.