### PR TITLE
fix: Restrict marks in text elements

### DIFF
--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -141,3 +141,21 @@ export const getSerialisedHtml = ({
     <element-imageelement-usesrc class="ProsemirrorElement__imageElement-useSrc" fields="${useSrcValue}"></element-imageelement-usesrc>
   </imageelement><p>First paragraph</p><p>Second paragraph</p>`);
 };
+
+export const boldShortcut = () => {
+  switch (Cypress.platform) {
+    case "darwin":
+      return "{meta+b}";
+    default:
+      return "{ctrl+b}";
+  }
+};
+
+export const italicShortcut = () => {
+  switch (Cypress.platform) {
+    case "darwin":
+      return "{meta+i}";
+    default:
+      return "{ctrl+i}";
+  }
+};

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -29,6 +29,16 @@ describe("ImageElement", () => {
         getElementRichTextField("caption").should("have.text", text);
       });
 
+      it(`caption – should allow mark shortcuts in an element`, () => {
+        addImageElement();
+        const text = `{meta+b}bold caption text`;
+        typeIntoElementField("caption", text);
+        getElementRichTextField("caption").should(
+          "have.html",
+          "<p><strong>bold caption text</strong></p>"
+        );
+      });
+
       it(`caption – should create hard breaks on shift-enter`, () => {
         addImageElement();
         const text = `caption{shift+enter}text`;
@@ -139,6 +149,16 @@ describe("ImageElement", () => {
         const text = `Src text`;
         typeIntoElementField("src", text);
         getElementRichTextField("src").should("have.text", text);
+      });
+
+      it(`should ignore mark shortcuts`, () => {
+        addImageElement();
+        const text = `{meta+b}{meta+i}bold text {meta+b}{meta+i}italic text`;
+        typeIntoElementField("src", text);
+        getElementRichTextField("src").should(
+          "have.html",
+          "bold text italic text"
+        );
       });
 
       it("should serialise content as HTML within the appropriate nodes in the document", () => {

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -161,6 +161,16 @@ describe("ImageElement", () => {
         );
       });
 
+      it(`should remove marks when content is created with them`, () => {
+        addImageElement({
+          src: "<strong>bold text</strong> <em>italic text</em>",
+        });
+        getElementRichTextField("src").should(
+          "have.html",
+          "bold text italic text"
+        );
+      });
+
       it("should serialise content as HTML within the appropriate nodes in the document", () => {
         addImageElement();
         typeIntoElementField("src", "Src text");

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -2,11 +2,13 @@ import { UpdateAltTextButtonId } from "../../src/elements/demo-image/DemoImageEl
 import {
   addImageElement,
   assertDocHtml,
+  boldShortcut,
   changeTestDecoString,
   getElementField,
   getElementMenuButton,
   getElementRichTextField,
   getSerialisedHtml,
+  italicShortcut,
   selectDataCy,
   typeIntoElementField,
   visitRoot,
@@ -31,11 +33,11 @@ describe("ImageElement", () => {
 
       it(`caption – should allow mark shortcuts in an element`, () => {
         addImageElement();
-        const text = `{meta+b}bold caption text`;
+        const text = `${boldShortcut()}bold caption text${boldShortcut()}${italicShortcut()}italic caption text`;
         typeIntoElementField("caption", text);
         getElementRichTextField("caption").should(
           "have.html",
-          "<p><strong>bold caption text</strong></p>"
+          "<p><strong>bold caption text</strong><em>italic caption text</em></p>"
         );
       });
 
@@ -153,7 +155,8 @@ describe("ImageElement", () => {
 
       it(`should ignore mark shortcuts`, () => {
         addImageElement();
-        const text = `{meta+b}{meta+i}bold text {meta+b}{meta+i}italic text`;
+
+        const text = `${boldShortcut()}bold text ${boldShortcut()}${italicShortcut()}italic text`;
         typeIntoElementField("src", text);
         getElementRichTextField("src").should(
           "have.html",

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -94,6 +94,7 @@ export const getNodeSpecForField = (
             },
           ],
           code: field.isCode,
+          marks: "",
         },
       };
     case "richText": {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR restrict all marks in text fields to prevent them from being added by other means i.e. copy and paste.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Trying copying some text from an RTE field with marks into a text field. 
There is currently no Cypress test that checks this path, but I  have added some shortcut tests for good measure.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Text fields never contain marks.

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [x] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
