### PR TITLE
feat: Add validation results to `getElementDataFromNode`

### DIFF
--- a/src/elements/__tests__/createGuElementSpec.spec.tsx
+++ b/src/elements/__tests__/createGuElementSpec.spec.tsx
@@ -6,7 +6,7 @@ import { createGuElementSpec } from "../createGuElementSpec";
 const guElement = createGuElementSpec(
   { exampleField: createTextField() },
   () => <p></p>,
-  () => null
+  () => undefined
 );
 
 describe("createGuElementSpec", () => {

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -355,6 +355,14 @@ describe("buildElementPlugin", () => {
       },
     });
 
+    const testElementWithValidation = createElementSpec(
+      {
+        field1: { type: "richText" },
+      },
+      () => undefined,
+      () => ({ field1: ["Some error"] })
+    );
+
     type ExternalData = { nestedElementValues: { field1: string } };
     type OtherExternalData = { otherValues: { field1: string } };
 
@@ -362,8 +370,8 @@ describe("buildElementPlugin", () => {
       {
         field1: { type: "richText" },
       },
-      () => null,
-      () => null,
+      () => undefined,
+      () => undefined,
       {
         transformElementDataIn: (external: ExternalData) => {
           return external.nestedElementValues;
@@ -380,8 +388,8 @@ describe("buildElementPlugin", () => {
       {
         field1: { type: "richText" },
       },
-      () => null,
-      () => null,
+      () => undefined,
+      () => undefined,
       {
         transformElementDataIn: (external: OtherExternalData) => {
           return external.otherValues;
@@ -396,6 +404,7 @@ describe("buildElementPlugin", () => {
 
     const testElementValues = {
       elementName: "testElement",
+      errors: undefined,
       values: {
         field1: "<p></p>",
         field2: "",
@@ -405,6 +414,7 @@ describe("buildElementPlugin", () => {
 
     const testElement2Values = {
       elementName: "testElement2",
+      errors: undefined,
       values: {
         field4: "<p></p>",
         field5: "",
@@ -644,6 +654,28 @@ describe("buildElementPlugin", () => {
             element.values.nestedElementValues;
           }
         });
+      });
+      it("should output any errors", () => {
+        const {
+          insertElement,
+          getElementDataFromNode,
+          view,
+          serializer,
+        } = createEditorWithElements({
+          testElementWithValidation,
+        });
+
+        insertElement({
+          elementName: "testElementWithValidation",
+          values: { field1: "Some text" },
+        })(view.state, view.dispatch);
+
+        const element = getElementDataFromNode(
+          view.state.doc.firstChild as Node,
+          serializer
+        );
+
+        expect(element?.errors).toEqual({ field1: ["Some error"] });
       });
     });
   });

--- a/src/plugin/__tests__/elementSpec.spec.ts
+++ b/src/plugin/__tests__/elementSpec.spec.ts
@@ -18,7 +18,7 @@ describe("mount", () => {
           // field1 is derived from the fieldDescriptions
           fieldViews.field1;
         },
-        () => null
+        () => undefined
       );
     });
 
@@ -35,7 +35,7 @@ describe("mount", () => {
           // as it is not defined in `fieldDescriptions` passed into `mount`
           fieldViews.field1;
         },
-        () => null
+        () => undefined
       );
     });
   });
@@ -59,7 +59,7 @@ describe("mount", () => {
           fields.field1.toString();
           // field2 is a boolean b/c it's a checkbox field
           fields.field2.valueOf();
-          return null;
+          return undefined;
         }
       );
     });
@@ -77,7 +77,7 @@ describe("mount", () => {
           // @ts-expect-error – field1 is not available on this object,
           // as it is not defined in `fieldDescriptions` passed into `mount`
           fields.doesNotExist;
-          return null;
+          return undefined;
         }
       );
     });

--- a/src/plugin/elementSpec.ts
+++ b/src/plugin/elementSpec.ts
@@ -62,6 +62,7 @@ export const createElementSpec = <
 ): ElementSpec<FDesc, ExternalData> => ({
   fieldDescriptions,
   transformers,
+  validate,
   createUpdator: (dom, fields, updateState, fieldValues, commands) => {
     const updater = createUpdater<FDesc>();
     render(

--- a/src/plugin/elementSpec.ts
+++ b/src/plugin/elementSpec.ts
@@ -31,7 +31,7 @@ const createUpdater = <
 
 export type Validator<FDesc extends FieldDescriptions<string>> = (
   fields: FieldNameToValueMap<FDesc>
-) => null | Record<string, string[]>;
+) => undefined | Record<string, string[]>;
 
 export type Renderer<FDesc extends FieldDescriptions<string>> = (
   validate: Validator<FDesc>,

--- a/src/plugin/helpers/element.ts
+++ b/src/plugin/helpers/element.ts
@@ -106,6 +106,7 @@ export const createGetElementDataFromNode = <
 
   return ({
     elementName,
+    errors: element.validate(values as ExtractFieldValues<typeof element>),
     values:
       element.transformers?.transformElementDataOut(
         values as ExtractFieldValues<typeof element>

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -35,9 +35,12 @@ type Predicate = (
 ) => boolean;
 type CommandDirection = "up" | "down" | "top" | "bottom";
 
-const defaultPredicate: Predicate = (node: Node, pos: number, parent: Node) =>
-  parent.type.name === "doc" &&
-  (node.type.name === "element" || !!node.textContent);
+const defaultPredicate: Predicate = (node: Node, pos: number, parent: Node) => {
+  return (
+    parent.type.name === "doc" &&
+    (node.type.name === "element" || node.type.name === "paragraph")
+  );
+};
 
 const findPredicate = (consumerPredicate: Predicate, currentPos: number) => ([
   candidateNode,

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -35,12 +35,9 @@ type Predicate = (
 ) => boolean;
 type CommandDirection = "up" | "down" | "top" | "bottom";
 
-const defaultPredicate: Predicate = (node: Node, pos: number, parent: Node) => {
-  return (
-    parent.type.name === "doc" &&
-    (node.type.name === "element" || node.type.name === "paragraph")
-  );
-};
+const defaultPredicate: Predicate = (node: Node, pos: number, parent: Node) =>
+  parent.type.name === "doc" &&
+  (node.type.name === "element" || !!node.textContent);
 
 const findPredicate = (consumerPredicate: Predicate, currentPos: number) => ([
   candidateNode,

--- a/src/plugin/helpers/test.ts
+++ b/src/plugin/helpers/test.ts
@@ -64,7 +64,7 @@ export const createNoopElement = <FDesc extends FieldDescriptions<string>>(
   createElementSpec(
     fieldDescriptions,
     () => null,
-    () => null
+    () => undefined
   );
 
 export const createEditorWithElements = <

--- a/src/plugin/types/Element.ts
+++ b/src/plugin/types/Element.ts
@@ -1,4 +1,5 @@
 import type { Schema } from "prosemirror-model";
+import type { Validator } from "../elementSpec";
 import type {
   CheckboxFieldDescription,
   CheckboxFieldView,
@@ -93,6 +94,7 @@ export type ElementSpec<
 > = {
   fieldDescriptions: FDesc;
   transformers?: Transformers<FDesc, ExternalData>;
+  validate: Validator<FDesc>;
   createUpdator: (
     dom: HTMLElement,
     fields: FieldNameToField<FDesc>,
@@ -137,6 +139,7 @@ export type ExtractDataTypeFromElementSpec<T, U> = U extends keyof T
       values: ExtractExternalData<T[U]> extends Record<string, unknown>
         ? ExtractExternalData<T[U]>
         : ExtractFieldValues<T[U]>;
+      errors: Record<string, string[]>;
     }
   : never;
 

--- a/src/renderers/react/ElementProvider.tsx
+++ b/src/renderers/react/ElementProvider.tsx
@@ -13,7 +13,7 @@ import { ElementWrapper } from "./ElementWrapper";
 
 const fieldErrors = <FDesc extends FieldDescriptions<string>>(
   fields: FieldNameToValueMap<FDesc>,
-  errors: Errors | null
+  errors: Errors | undefined
 ) =>
   Object.keys(fields).reduce(
     (acc, key) => ({


### PR DESCRIPTION
## What does this change?

Adds the validation results to the output of `getElementDataFromNode`. This makes it easy for consumers to get hold of results when they're processing the output of the plugin.

## How to test

The new automated test should pass, and it should be clear what it's doing.

## Dev notes

I've changed the output of the `Validator` function in this PR from `null` to `undefined` – we don't use `null` anywhere else in this library, and I'm not aware of a good reason to use it over `undefined` in this instance, but I'd be interested if there was a rationale!