### PR TITLE
fix: Alter fields of code element to correspond with flexible-content

### DIFF
--- a/src/elements/__tests__/createGuElementSpec.spec.tsx
+++ b/src/elements/__tests__/createGuElementSpec.spec.tsx
@@ -3,14 +3,15 @@ import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { createEditorWithElements } from "../../plugin/helpers/test";
 import { createGuElementSpec } from "../createGuElementSpec";
 
-const guElement = createGuElementSpec(
-  { exampleField: createTextField() },
-  () => <p></p>,
-  () => undefined
-);
-
 describe("createGuElementSpec", () => {
   it("should transform data with the provided transformer", () => {
+    const guElement = createGuElementSpec(
+      { exampleField: createTextField() },
+      () => <p></p>,
+      () => undefined,
+      true
+    );
+
     const {
       getElementDataFromNode,
       serializer,
@@ -32,6 +33,43 @@ describe("createGuElementSpec", () => {
     })(view.state, view.dispatch);
 
     // ... and getElementDataFromNode transforms on the way out.
+    const elementDataFromNode = getElementDataFromNode(
+      view.state.doc.content.firstChild as Node,
+      serializer
+    );
+
+    expect(elementDataFromNode).toEqual({
+      elementName: "guElement",
+      values: elementData,
+    });
+  });
+
+  it("should not add an isMandatory property if not specified", () => {
+    const guElement = createGuElementSpec(
+      { exampleField: createTextField() },
+      () => <p></p>,
+      () => undefined
+    );
+
+    const {
+      getElementDataFromNode,
+      serializer,
+      view,
+      insertElement,
+    } = createEditorWithElements({
+      guElement,
+    });
+
+    const elementData = {
+      assets: [],
+      fields: { exampleField: "" },
+    };
+
+    insertElement({
+      elementName: "guElement",
+      values: elementData,
+    })(view.state, view.dispatch);
+
     const elementDataFromNode = getElementDataFromNode(
       view.state.doc.content.firstChild as Node,
       serializer

--- a/src/elements/code/CodeElementForm.tsx
+++ b/src/elements/code/CodeElementForm.tsx
@@ -16,11 +16,7 @@ export const CodeElementForm: React.FunctionComponent<Props> = ({
   fields,
 }) => (
   <div data-cy={CodeElementTestId}>
-    <FieldWrapper
-      label="Code"
-      field={fields.codeText}
-      errors={errors.codeText}
-    />
+    <FieldWrapper label="Code" field={fields.html} errors={errors.html} />
     <CustomDropdownView label="Language" field={fields.language} />
   </div>
 );

--- a/src/elements/code/CodeElementSpec.tsx
+++ b/src/elements/code/CodeElementSpec.tsx
@@ -6,7 +6,7 @@ import { createGuElementSpec } from "../createGuElementSpec";
 import { CodeElementForm } from "./CodeElementForm";
 
 export const codeFields = {
-  codeText: createTextField({ isMultiline: true, rows: 11 }, true),
+  html: createTextField({ isMultiline: true, rows: 11 }, true),
   language: createCustomField("text", [
     { text: "Plain text", value: "text" },
     { text: "HTML", value: "html" },
@@ -24,5 +24,5 @@ export const codeElement = createGuElementSpec(
   (_, errors, __, fields) => {
     return <CodeElementForm errors={errors} fields={fields} />;
   },
-  createValidator({ codeText: [required()] })
+  createValidator({ html: [required()] })
 );

--- a/src/elements/createGuElementSpec.ts
+++ b/src/elements/createGuElementSpec.ts
@@ -6,7 +6,9 @@ import type { FieldDescriptions } from "../plugin/types/Element";
 import { createReactElementSpec } from "../renderers/react/createReactElementSpec";
 
 type FlexibleModelElement<FDesc extends FieldDescriptions<string>> = {
-  fields: Omit<FieldNameToValueMap<FDesc>, "assets"> & { isMandatory: boolean };
+  fields: Omit<FieldNameToValueMap<FDesc>, "assets"> & {
+    isMandatory?: boolean;
+  };
   assets: string[];
 };
 
@@ -19,7 +21,7 @@ export const createGuElementSpec = <FDesc extends FieldDescriptions<string>>(
   FieldDescriptions: FDesc,
   consumer: Consumer<ReactElement, FDesc>,
   validate: Validator<FDesc>,
-  isMandatory = true
+  isMandatory?: boolean
 ) => {
   return createReactElementSpec(FieldDescriptions, consumer, validate, {
     transformElementDataIn: ({
@@ -32,10 +34,19 @@ export const createGuElementSpec = <FDesc extends FieldDescriptions<string>>(
       assets,
       ...fields
     }: FieldNameToValueMap<FDesc>) => {
-      return {
+      const baseFields = {
         assets: assets || [],
-        fields: { ...fields, isMandatory },
+        fields: { ...fields },
       } as FlexibleModelElement<FDesc>;
+
+      if (isMandatory === undefined) {
+        return baseFields;
+      }
+
+      return {
+        ...baseFields,
+        fields: { ...fields, isMandatory },
+      };
     },
   });
 };


### PR DESCRIPTION
## What does this change?

Alter the field names of code element to correspond with flexible-content. In doing this, we also need to strip `isMandatory` from elements that don't explicitly need it – `isMandatory` is ... not required.

## How to test

- The automated tests should pass.
- The fields for the Code element should be `html` and `language` in the prosemirror dev tools.

Tested locally in Composer via `yarn link`.