### PR TITLE
fix: Minor changes to HTML

### DIFF
--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -61,7 +61,7 @@ const Button = styled("button")<{ expanded?: boolean }>`
     z-index: 1;
   }
 
-  :first-child {
+  :first-of-type {
     border: none;
   }
 
@@ -133,7 +133,10 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
   remove,
   children,
 }) => (
-  <Container data-cy={elementWrapperTestId}>
+  <Container
+    className="ProsemirrorElement__wrapper"
+    data-cy={elementWrapperTestId}
+  >
     <Body>
       <LeftActions className="actions">
         <SeriousButton

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -140,6 +140,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
     <Body>
       <LeftActions className="actions">
         <SeriousButton
+          type="button"
           data-cy={removeTestId}
           disabled={!remove(false)}
           onClick={() => remove(true)}
@@ -150,6 +151,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
       <Panel>{children}</Panel>
       <RightActions className="actions">
         <Button
+          type="button"
           data-cy={moveTopTestId}
           disabled={!moveTop(false)}
           onClick={() => moveTop(true)}
@@ -163,6 +165,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
           </div>
         </Button>
         <Button
+          type="button"
           data-cy={moveUpTestId}
           expanded
           disabled={!moveUp(false)}
@@ -171,6 +174,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
           <SvgArrowUpStraight />
         </Button>
         <Button
+          type="button"
           data-cy={moveDownTestId}
           expanded
           disabled={!moveDown(false)}
@@ -179,6 +183,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
           <SvgArrowDownStraight />
         </Button>
         <Button
+          type="button"
           data-cy={moveBottomTestId}
           disabled={!moveBottom(false)}
           onClick={() => moveBottom(true)}


### PR DESCRIPTION
## What does this change?

Changes a `first-child` selector to a `first-of-type` selector to avoid red in produced by Emotion, and adds `type='button'` attributes to our buttons to prevent them from submitting forms unintentionally.

## How to test

The changes above should be reflected in the markup.