### PR TITLE
fix: Add aria-labels to move and delete element buttons

### DIFF
--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -140,7 +140,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
           data-cy={removeTestId}
           disabled={!remove(false)}
           onClick={() => remove(true)}
-          aria-label="Delete element."
+          aria-label="Delete element"
         >
           <SvgCross />
         </SeriousButton>
@@ -151,7 +151,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
           data-cy={moveTopTestId}
           disabled={!moveTop(false)}
           onClick={() => moveTop(true)}
-          aria-label="Move element to top."
+          aria-label="Move element to top"
         >
           <div
             css={css`
@@ -166,7 +166,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
           expanded
           disabled={!moveUp(false)}
           onClick={() => moveUp(true)}
-          aria-label="Move element up."
+          aria-label="Move element up"
         >
           <SvgArrowUpStraight />
         </Button>
@@ -175,7 +175,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
           expanded
           disabled={!moveDown(false)}
           onClick={() => moveDown(true)}
-          aria-label="Move element down."
+          aria-label="Move element down"
         >
           <SvgArrowDownStraight />
         </Button>
@@ -183,7 +183,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
           data-cy={moveBottomTestId}
           disabled={!moveBottom(false)}
           onClick={() => moveBottom(true)}
-          aria-label="Move element to bottom."
+          aria-label="Move element to bottom"
         >
           <div
             css={css`

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -140,6 +140,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
           data-cy={removeTestId}
           disabled={!remove(false)}
           onClick={() => remove(true)}
+          aria-label="Delete element."
         >
           <SvgCross />
         </SeriousButton>
@@ -150,6 +151,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
           data-cy={moveTopTestId}
           disabled={!moveTop(false)}
           onClick={() => moveTop(true)}
+          aria-label="Move element to top."
         >
           <div
             css={css`
@@ -164,6 +166,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
           expanded
           disabled={!moveUp(false)}
           onClick={() => moveUp(true)}
+          aria-label="Move element up."
         >
           <SvgArrowUpStraight />
         </Button>
@@ -172,6 +175,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
           expanded
           disabled={!moveDown(false)}
           onClick={() => moveDown(true)}
+          aria-label="Move element down."
         >
           <SvgArrowDownStraight />
         </Button>
@@ -179,6 +183,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
           data-cy={moveBottomTestId}
           disabled={!moveBottom(false)}
           onClick={() => moveBottom(true)}
+          aria-label="Move element to bottom."
         >
           <div
             css={css`


### PR DESCRIPTION
## What does this change?
This adds an `aria-label` attribute to our move and delete element buttons.

## Why?
The buttons do not contain text so currently their purpose is not clear when using a screen reader.

## How to test
Run `yarn start` and test via a screenreader, e.g. VoiceOver on Mac.

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [X] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [X] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [X] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [X] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
