### PR TITLE
feat: Support dropdown undefined values

### DIFF
--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -99,6 +99,7 @@ export const getSerialisedHtml = ({
   codeValue = "",
   useSrcValue = "false",
   optionValue = "opt1",
+  otherOptionValue = undefined,
   restrictedTextValue = "",
   customDropdownValue = "opt1",
   mainImageValue = {
@@ -113,6 +114,7 @@ export const getSerialisedHtml = ({
   codeValue?: string;
   useSrcValue?: string;
   optionValue?: string;
+  otherOptionValue?: string;
   restrictedTextValue?: string;
   customDropdownValue?: string;
   mainImageValue?: {
@@ -135,7 +137,12 @@ export const getSerialisedHtml = ({
     <div pme-field-name="imageElement_code">${codeValue}</div>
     <div pme-field-name="imageElement_customDropdown" fields="&quot;${customDropdownValue}&quot;"></div>
     <div pme-field-name="imageElement_mainImage" fields="{${mainImageFields}}"></div>
-    <div pme-field-name="imageElement_optionDropdown" fields="&quot;${optionValue}&quot;"></div>
+    <div pme-field-name="imageElement_optionDropdown"${
+      optionValue ? ` fields="&quot;${optionValue}&quot;"` : ""
+    }></div>
+    <div pme-field-name="imageElement_otherOptionDropdown"${
+      otherOptionValue ? ` fields="&quot;${otherOptionValue}&quot;"` : ""
+    }></div>
     <div pme-field-name="imageElement_restrictedTextField">${restrictedTextValue}</div>
     <div pme-field-name="imageElement_src">${srcValue}</div>
     <div pme-field-name="imageElement_useSrc" fields="${useSrcValue}"></div>

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -281,6 +281,33 @@ describe("ImageElement", () => {
       });
     });
 
+    describe("Dropdown field (with undefined default)", () => {
+      it(`should change the option selected in the document when a user selects a new option`, () => {
+        addImageElement();
+        getElementField("otherOptionDropdown")
+          .find("select")
+          .select(JSON.stringify("opt2"));
+        getElementField("otherOptionDropdown")
+          .find("select")
+          .children("option:selected")
+          .should("have.value", JSON.stringify("opt2"));
+      });
+
+      it(`should have a default value when instantiated`, () => {
+        addImageElement();
+        assertDocHtml(getSerialisedHtml({}));
+        assertDocHtml(getSerialisedHtml({ otherOptionValue: undefined }));
+      });
+
+      it(`should serialise state as field attributes on the appropriate node in the document when a new option is selected`, () => {
+        addImageElement();
+        getElementField("otherOptionDropdown")
+          .find("select")
+          .select(JSON.stringify("opt2"));
+        assertDocHtml(getSerialisedHtml({ otherOptionValue: "opt2" }));
+      });
+    });
+
     describe("CustomDropdown field", () => {
       it(`should have a default value when instantiated`, () => {
         addImageElement();

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -66,6 +66,14 @@ export const createImageFields = (
       ],
       "opt1"
     ),
+    otherOptionDropdown: createDropDownField(
+      [
+        { text: "Option 1", value: undefined },
+        { text: "Option 2", value: "opt2" },
+        { text: "Option 3", value: "opt3" },
+      ],
+      undefined
+    ),
     customDropdown: createCustomField<string, Array<Option<string>>>("opt1", [
       { text: "Option 1", value: "opt1" },
       { text: "Option 2", value: "opt2" },

--- a/src/elements/demo-image/DemoImageElementForm.tsx
+++ b/src/elements/demo-image/DemoImageElementForm.tsx
@@ -56,6 +56,11 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
       field={fields.optionDropdown}
       errors={errors.optionDropdown}
     />
+    <FieldWrapper
+      label="Other Options"
+      field={fields.otherOptionDropdown}
+      errors={errors.otherOptionDropdown}
+    />
     <ImageView
       field={fields.mainImage}
       onChange={(_, __, ___, description) => {

--- a/src/plugin/fieldViews/DropdownFieldView.ts
+++ b/src/plugin/fieldViews/DropdownFieldView.ts
@@ -39,8 +39,8 @@ export class DropdownFieldView extends AttributeFieldView<DropdownValue> {
     getPos: () => number,
     // The offset of this node relative to its parent FieldView.
     offset: number,
-    defaultFields: string | undefined,
-    private options: ReadonlyArray<Option<string | undefined>>
+    defaultFields: DropdownValue,
+    private options: ReadonlyArray<Option<DropdownValue>>
   ) {
     super(node, outerView, getPos, offset);
     this.createInnerView(node.attrs.fields || defaultFields);

--- a/src/plugin/fieldViews/DropdownFieldView.ts
+++ b/src/plugin/fieldViews/DropdownFieldView.ts
@@ -11,7 +11,7 @@ type DropdownValue = string | undefined;
 export interface DropdownFieldDescription
   extends BaseFieldDescription<DropdownValue> {
   type: typeof DropdownFieldView.fieldName;
-  options: ReadonlyArray<Option<DropdownValue>>;
+  options: Options<DropdownValue>;
 }
 
 export const createDropDownField = (
@@ -40,7 +40,7 @@ export class DropdownFieldView extends AttributeFieldView<DropdownValue> {
     // The offset of this node relative to its parent FieldView.
     offset: number,
     defaultFields: DropdownValue,
-    private options: ReadonlyArray<Option<DropdownValue>>
+    private options: Options<DropdownValue>
   ) {
     super(node, outerView, getPos, offset);
     this.createInnerView(node.attrs.fields || defaultFields);

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -148,7 +148,7 @@ export const getNodeSpecForField = (
           parseDOM: getDefaultParseDOMForLeafNode(elementName, fieldName),
           attrs: {
             fields: {
-              default: field.defaultValue,
+              default: undefined,
             },
           },
         },
@@ -204,8 +204,10 @@ const getDefaultParseDOMForLeafNode = (
         return false;
       }
 
+      const fields = dom.getAttribute("fields");
+
       const attrs = {
-        fields: JSON.parse(dom.getAttribute("fields") ?? "{}") as unknown,
+        fields: (fields ? JSON.parse(fields) : undefined) as unknown,
       };
 
       return attrs;

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -207,7 +207,7 @@ const getDefaultParseDOMForLeafNode = (
       const fields = dom.getAttribute("fields");
 
       const attrs = {
-        fields: (fields ? JSON.parse(fields) : undefined) as unknown,
+        fields: (fields !== null ? JSON.parse(fields) : undefined) as unknown,
       };
 
       return attrs;


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR adds the ability to have a dropdown field with an undefined value. This is necessary to support dropdowns of this nature in Composer.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This PR adds a dropdown with a default value of undefined into the `DemoImageElement`, this can be tested using the Cypress tests or manually.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
We are able to support dropdowns with undefined values options as per our requirements in Composer.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
This change effectively treats options with an empty string value as undefined. This may cause issues if consumers ever want an option to represent an empty string. The other way we might approach this issue is to add a custom ingress and egress rule which handles option values we know represent undefined. Interested to hear opinions on this.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![image](https://user-images.githubusercontent.com/4633246/131531486-a419a695-5102-4aa6-9122-68948b753a03.png)


## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [x] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
