### PR TITLE
feat: Support custom dropdown undefined values

### DIFF
--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -102,6 +102,7 @@ export const getSerialisedHtml = ({
   otherOptionValue = undefined,
   restrictedTextValue = "",
   customDropdownValue = "opt1",
+  otherCustomDropdwonValue = undefined,
   mainImageValue = {
     assets: "[]",
     mediaId: undefined,
@@ -117,6 +118,7 @@ export const getSerialisedHtml = ({
   otherOptionValue?: string;
   restrictedTextValue?: string;
   customDropdownValue?: string;
+  otherCustomDropdwonValue?: string;
   mainImageValue?: {
     assets: string;
     mediaId?: string;
@@ -139,6 +141,11 @@ export const getSerialisedHtml = ({
     <div pme-field-name="imageElement_mainImage" fields="{${mainImageFields}}"></div>
     <div pme-field-name="imageElement_optionDropdown"${
       optionValue ? ` fields="&quot;${optionValue}&quot;"` : ""
+    }></div>
+    <div pme-field-name="imageElement_otherCustomDropdown"${
+      otherCustomDropdwonValue
+        ? ` fields="&quot;${otherCustomDropdwonValue}&quot;"`
+        : ""
     }></div>
     <div pme-field-name="imageElement_otherOptionDropdown"${
       otherOptionValue ? ` fields="&quot;${otherOptionValue}&quot;"` : ""

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -322,6 +322,22 @@ describe("ImageElement", () => {
       });
     });
 
+    describe("CustomDropdown field (with undefined default)", () => {
+      it(`should have a default value when instantiated`, () => {
+        addImageElement();
+        assertDocHtml(getSerialisedHtml({}));
+        assertDocHtml(
+          getSerialisedHtml({ otherCustomDropdwonValue: undefined })
+        );
+      });
+
+      it(`should serialise state as field attributes on the appropriate node in the document when a new option is selected`, () => {
+        addImageElement();
+        getElementField("otherCustomDropdown").find("select").select("opt2");
+        assertDocHtml(getSerialisedHtml({ otherCustomDropdwonValue: "opt2" }));
+      });
+    });
+
     describe("Programmatically update fields", () => {
       it("should revert the alt text to 'Default alt text' when the button is clicked", () => {
         addImageElement();

--- a/src/editorial-source-components/CustomDropdown.tsx
+++ b/src/editorial-source-components/CustomDropdown.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import { space } from "@guardian/src-foundations";
 import { Option, Select } from "@guardian/src-select";
-import type { Option as OptionValue } from "../plugin/fieldViews/DropdownFieldView";
+import type { DropdownValue, Options } from "../plugin/fieldViews/DropdownFieldView";
 import { inputBorder } from "./inputBorder";
 import { labelStyles } from "./Label";
 
@@ -47,9 +47,9 @@ const selectStyles = css`
 `;
 
 type CustomDropdownProps = {
-  options: Array<OptionValue<string>>;
-  selected: string;
-  onChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
+  options: Options<DropdownValue>;
+  selected: DropdownValue;
+  onChange: (value: DropdownValue) => void;
   label: string;
   dataCy: string;
   error: string;
@@ -61,12 +61,14 @@ export const CustomDropdown = (props: CustomDropdownProps) => {
       <Select
         error={props.error}
         label={props.label}
-        onChange={props.onChange}
+        onChange={(event) => {
+          props.onChange(event.target.value ? event.target.value : undefined);
+        }}
         value={props.selected}
         css={selectStyles}
       >
         {props.options.map((option) => (
-          <Option value={option.value} key={option.value}>
+          <Option value={option.value ?? ""} key={option.value}>
             {option.text}
           </Option>
         ))}

--- a/src/editorial-source-components/CustomDropdown.tsx
+++ b/src/editorial-source-components/CustomDropdown.tsx
@@ -1,7 +1,10 @@
 import { css } from "@emotion/react";
 import { space } from "@guardian/src-foundations";
 import { Option, Select } from "@guardian/src-select";
-import type { DropdownValue, Options } from "../plugin/fieldViews/DropdownFieldView";
+import type {
+  DropdownValue,
+  Options,
+} from "../plugin/fieldViews/DropdownFieldView";
 import { inputBorder } from "./inputBorder";
 import { labelStyles } from "./Label";
 

--- a/src/elements/code/CodeElementSpec.tsx
+++ b/src/elements/code/CodeElementSpec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
+import { createCustomDropdownField } from "../../plugin/fieldViews/CustomFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { createValidator, required } from "../../plugin/helpers/validation";
 import { createGuElementSpec } from "../createGuElementSpec";
@@ -7,7 +7,7 @@ import { CodeElementForm } from "./CodeElementForm";
 
 export const codeFields = {
   html: createTextField({ isMultiline: true, rows: 11 }, true),
-  language: createCustomField("text", [
+  language: createCustomDropdownField("text", [
     { text: "Plain text", value: "text" },
     { text: "HTML", value: "html" },
     { text: "CSS", value: "css" },

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -1,8 +1,10 @@
 import { exampleSetup } from "prosemirror-example-setup";
 import React from "react";
 import { createCheckBox } from "../../plugin/fieldViews/CheckboxFieldView";
-import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
-import type { Option } from "../../plugin/fieldViews/DropdownFieldView";
+import {
+  createCustomDropdownField,
+  createCustomField,
+} from "../../plugin/fieldViews/CustomFieldView";
 import { createDropDownField } from "../../plugin/fieldViews/DropdownFieldView";
 import {
   createDefaultRichTextField,
@@ -74,8 +76,13 @@ export const createImageFields = (
       ],
       undefined
     ),
-    customDropdown: createCustomField<string, Array<Option<string>>>("opt1", [
+    customDropdown: createCustomDropdownField("opt1", [
       { text: "Option 1", value: "opt1" },
+      { text: "Option 2", value: "opt2" },
+      { text: "Option 3", value: "opt3" },
+    ]),
+    otherCustomDropdown: createCustomDropdownField(undefined, [
+      { text: "Option 1", value: undefined },
       { text: "Option 2", value: "opt2" },
       { text: "Option 3", value: "opt3" },
     ]),

--- a/src/elements/demo-image/DemoImageElementForm.tsx
+++ b/src/elements/demo-image/DemoImageElementForm.tsx
@@ -69,6 +69,10 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
       }}
     />
     <CustomDropdownView label="Options" field={fields.customDropdown} />
+    <CustomDropdownView
+      label="Other Options"
+      field={fields.otherCustomDropdown}
+    />
     <hr />
     <Label>Element errors</Label>
     <pre>{JSON.stringify(errors)}</pre>

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -1,5 +1,8 @@
 import React from "react";
-import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
+import {
+  createCustomDropdownField,
+  createCustomField,
+} from "../../plugin/fieldViews/CustomFieldView";
 import { createDefaultRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import {
@@ -12,7 +15,7 @@ import { createReactElementSpec } from "../../renderers/react/createReactElement
 import { EmbedElementForm } from "./EmbedForm";
 
 export const embedFields = {
-  weighting: createCustomField("inline", [
+  weighting: createCustomDropdownField("inline", [
     { text: "inline (default)", value: "inline" },
     { text: "supporting", value: "supporting" },
     { text: "showcase", value: "showcase" },

--- a/src/elements/pullquote/PullquoteSpec.tsx
+++ b/src/elements/pullquote/PullquoteSpec.tsx
@@ -1,5 +1,9 @@
 import React from "react";
 import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
+import type {
+  DropdownValue,
+  Options,
+} from "../../plugin/fieldViews/DropdownFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { createValidator, htmlRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
@@ -8,11 +12,14 @@ import { PullquoteElementForm } from "./PullquoteForm";
 export const pullquoteFields = {
   pullquote: createTextField({ isMultiline: true, rows: 4 }),
   attribution: createTextField(),
-  weighting: createCustomField("supporting", [
-    { text: "supporting (default)", value: "supporting" },
-    { text: "inline", value: "inline" },
-    { text: "showcase", value: "showcase" },
-  ]),
+  weighting: createCustomField<DropdownValue, Options<DropdownValue>>(
+    "supporting",
+    [
+      { text: "supporting (default)", value: "supporting" },
+      { text: "inline", value: "inline" },
+      { text: "showcase", value: "showcase" },
+    ]
+  ),
 };
 
 export const pullquoteElement = createReactElementSpec(

--- a/src/plugin/__tests__/elementSpec.spec.ts
+++ b/src/plugin/__tests__/elementSpec.spec.ts
@@ -220,9 +220,7 @@ describe("mount", () => {
             attrs: {
               fields: {
                 default: {
-                  value: {
-                    arbitraryField: "hai",
-                  },
+                  arbitraryField: "hai",
                 },
               },
             },

--- a/src/plugin/fieldViews/CustomFieldView.ts
+++ b/src/plugin/fieldViews/CustomFieldView.ts
@@ -1,5 +1,6 @@
 import type { Node } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
+import type { DropdownValue, Options } from "./DropdownFieldView";
 import type { BaseFieldDescription, FieldView } from "./FieldView";
 import { FieldType } from "./FieldView";
 
@@ -14,6 +15,15 @@ export const createCustomField = <Data, Props>(
   defaultValue: Data,
   props: Props
 ): CustomFieldDescription<Data, Props> => ({
+  type: "custom" as const,
+  defaultValue,
+  props,
+});
+
+export const createCustomDropdownField = (
+  defaultValue: DropdownValue,
+  props: Options<DropdownValue>
+): CustomFieldDescription<DropdownValue, Options<DropdownValue>> => ({
   type: "custom" as const,
   defaultValue,
   props,

--- a/src/plugin/fieldViews/DropdownFieldView.ts
+++ b/src/plugin/fieldViews/DropdownFieldView.ts
@@ -4,9 +4,9 @@ import { AttributeFieldView } from "./AttributeFieldView";
 import type { BaseFieldDescription } from "./FieldView";
 
 export type Option<Data> = { text: string; value: Data };
-type Options<Data> = ReadonlyArray<Option<Data>>;
+export type Options<Data> = ReadonlyArray<Option<Data>>;
 
-type DropdownValue = string | undefined;
+export type DropdownValue = string | undefined;
 
 export interface DropdownFieldDescription
   extends BaseFieldDescription<DropdownValue> {

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -161,7 +161,7 @@ export const getNodeSpecForField = (
           parseDOM: getDefaultParseDOMForLeafNode(elementName, fieldName),
           attrs: {
             fields: {
-              default: { value: field.defaultValue },
+              default: field.defaultValue,
             },
           },
         },

--- a/src/renderers/react/customFieldViewComponents/CustomDropdownView.tsx
+++ b/src/renderers/react/customFieldViewComponents/CustomDropdownView.tsx
@@ -1,12 +1,15 @@
 import { CustomDropdown } from "../../../editorial-source-components/CustomDropdown";
 import { InputGroup } from "../../../editorial-source-components/InputGroup";
-import type { Option } from "../../../plugin/fieldViews/DropdownFieldView";
+import type {
+  DropdownValue,
+  Options,
+} from "../../../plugin/fieldViews/DropdownFieldView";
 import type { CustomField } from "../../../plugin/types/Element";
 import { getFieldViewTestId } from "../FieldView";
 import { useCustomFieldState } from "../useCustomFieldViewState";
 
 type CustomDropdownViewProps = {
-  field: CustomField<string, Array<Option<string>>>;
+  field: CustomField<DropdownValue, Options<DropdownValue>>;
   errors?: string[];
   label: string;
 };
@@ -23,8 +26,8 @@ export const CustomDropdownView = ({
         options={field.description.props}
         selected={selectedElement}
         label={label}
-        onChange={(event) => {
-          setSelectedElement(event.target.value);
+        onChange={(value) => {
+          setSelectedElement(value);
         }}
         error={errors.join(", ")}
         dataCy={getFieldViewTestId(field.name)}


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR build on the work of #96  and adds support for undefined option values for custom dropdowns.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This PR adds a custom dropdown with a default value of undefined into the DemoImageElement, this can be tested using the Cypress tests or manually.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
We are able to support dropdowns with undefined values options as per our requirements in Composer.

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [x] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
