### PR TITLE
refactor: Refactor dropdown types

### DIFF
--- a/src/editorial-source-components/CustomDropdown.tsx
+++ b/src/editorial-source-components/CustomDropdown.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { space } from "@guardian/src-foundations";
 import { Option, Select } from "@guardian/src-select";
-import type { Option as OptionValue } from "../plugin/fieldViews/DropdownFieldView";
+import type { Options } from "../plugin/fieldViews/DropdownFieldView";
 import { inputBorder } from "./inputBorder";
 import { labelStyles } from "./Label";
 
@@ -64,7 +64,7 @@ const selectStyles = css`
 `;
 
 type CustomDropdownProps = {
-  options: Array<OptionValue<string>>;
+  options: Options;
   selected: string;
   onChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
   label: string;

--- a/src/elements/code/CodeElementSpec.tsx
+++ b/src/elements/code/CodeElementSpec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
+import { createCustomDropdownField } from "../../plugin/fieldViews/CustomFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { createValidator, required } from "../../plugin/helpers/validation";
 import { createGuElementSpec } from "../createGuElementSpec";
@@ -7,7 +7,7 @@ import { CodeElementForm } from "./CodeElementForm";
 
 export const codeFields = {
   html: createTextField({ isMultiline: true, rows: 4 }, true),
-  language: createCustomField("text", [
+  language: createCustomDropdownField("text", [
     { text: "Plain text", value: "text" },
     { text: "HTML", value: "html" },
     { text: "CSS", value: "css" },

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -1,8 +1,10 @@
 import { exampleSetup } from "prosemirror-example-setup";
 import React from "react";
 import { createCheckBox } from "../../plugin/fieldViews/CheckboxFieldView";
-import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
-import type { Option } from "../../plugin/fieldViews/DropdownFieldView";
+import {
+  createCustomDropdownField,
+  createCustomField,
+} from "../../plugin/fieldViews/CustomFieldView";
 import { createDropDownField } from "../../plugin/fieldViews/DropdownFieldView";
 import {
   createDefaultRichTextField,
@@ -66,7 +68,7 @@ export const createImageFields = (
       ],
       "opt1"
     ),
-    customDropdown: createCustomField<string, Array<Option<string>>>("opt1", [
+    customDropdown: createCustomDropdownField("opt1", [
       { text: "Option 1", value: "opt1" },
       { text: "Option 2", value: "opt2" },
       { text: "Option 3", value: "opt3" },

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -1,5 +1,8 @@
 import React from "react";
-import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
+import {
+  createCustomDropdownField,
+  createCustomField,
+} from "../../plugin/fieldViews/CustomFieldView";
 import { createDefaultRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import {
@@ -12,7 +15,7 @@ import { createReactElementSpec } from "../../renderers/react/createReactElement
 import { EmbedElementForm } from "./EmbedForm";
 
 export const embedFields = {
-  weighting: createCustomField("inline", [
+  weighting: createCustomDropdownField("inline", [
     { text: "inline (default)", value: "inline" },
     { text: "supporting", value: "supporting" },
     { text: "showcase", value: "showcase" },

--- a/src/elements/pullquote/PullquoteSpec.tsx
+++ b/src/elements/pullquote/PullquoteSpec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
+import { createCustomDropdownField } from "../../plugin/fieldViews/CustomFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { createValidator, htmlRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
@@ -8,7 +8,7 @@ import { PullquoteElementForm } from "./PullquoteForm";
 export const pullquoteFields = {
   pullquote: createTextField({ isMultiline: true, rows: 4 }),
   attribution: createTextField(),
-  weighting: createCustomField("supporting", [
+  weighting: createCustomDropdownField("supporting", [
     { text: "supporting (default)", value: "supporting" },
     { text: "inline", value: "inline" },
     { text: "showcase", value: "showcase" },

--- a/src/plugin/fieldViews/CustomFieldView.ts
+++ b/src/plugin/fieldViews/CustomFieldView.ts
@@ -1,5 +1,6 @@
 import type { Node } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
+import type { Options } from "./DropdownFieldView";
 import type { BaseFieldDescription, FieldView } from "./FieldView";
 import { FieldType } from "./FieldView";
 
@@ -14,6 +15,15 @@ export const createCustomField = <Data, Props>(
   defaultValue: Data,
   props: Props
 ): CustomFieldDescription<Data, Props> => ({
+  type: "custom" as const,
+  defaultValue,
+  props,
+});
+
+export const createCustomDropdownField = (
+  defaultValue: string,
+  props: Options
+): CustomFieldDescription<string, Options> => ({
   type: "custom" as const,
   defaultValue,
   props,

--- a/src/plugin/fieldViews/DropdownFieldView.ts
+++ b/src/plugin/fieldViews/DropdownFieldView.ts
@@ -3,16 +3,16 @@ import type { EditorView } from "prosemirror-view";
 import { AttributeFieldView } from "./AttributeFieldView";
 import type { BaseFieldDescription } from "./FieldView";
 
-export type Option<Data> = { text: string; value: Data };
-type Options<Data> = ReadonlyArray<Option<Data>>;
+export type Option = { text: string; value: string };
+export type Options = readonly Option[];
 
 export interface DropdownFieldDescription extends BaseFieldDescription<string> {
   type: typeof DropdownFieldView.fieldName;
-  options: ReadonlyArray<Option<string>>;
+  options: Options;
 }
 
 export const createDropDownField = (
-  options: Options<string>,
+  options: Options,
   defaultValue: string
 ): DropdownFieldDescription => ({
   type: DropdownFieldView.fieldName,
@@ -37,7 +37,7 @@ export class DropdownFieldView extends AttributeFieldView<string> {
     // The offset of this node relative to its parent FieldView.
     offset: number,
     defaultFields: string,
-    private options: ReadonlyArray<Option<string>>
+    private options: Options
   ) {
     super(node, outerView, getPos, offset);
     this.createInnerView(node.attrs.fields || defaultFields);
@@ -76,7 +76,7 @@ export class DropdownFieldView extends AttributeFieldView<string> {
   }
 
   private optionToDOMnode(
-    option: Option<string>,
+    option: Option,
     chosenOption: string
   ): HTMLOptionElement {
     const domOption = document.createElement("option");

--- a/src/renderers/react/customFieldViewComponents/CustomDropdownView.tsx
+++ b/src/renderers/react/customFieldViewComponents/CustomDropdownView.tsx
@@ -1,12 +1,12 @@
 import { CustomDropdown } from "../../../editorial-source-components/CustomDropdown";
 import { InputGroup } from "../../../editorial-source-components/InputGroup";
-import type { Option } from "../../../plugin/fieldViews/DropdownFieldView";
+import type { Options } from "../../../plugin/fieldViews/DropdownFieldView";
 import type { CustomField } from "../../../plugin/types/Element";
 import { getFieldViewTestId } from "../FieldView";
 import { useCustomFieldState } from "../useCustomFieldViewState";
 
 type CustomDropdownViewProps = {
-  field: CustomField<string, Array<Option<string>>>;
+  field: CustomField<string, Options>;
   errors?: string[];
   label: string;
   display?: "inline" | "block";


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
After a discussion of how to handle undefined values in dropdown, this PR attempts to save some of the little tweaks that were made to enable it. #96 and #99 will be closed due to a concern about adding too much additional complexity to support non-serializable types i.e. undefined.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This change should be a no-op and all tests should pass as before.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
It's easier to work with custom dropdowns.

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [x] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
