### PR TITLE
feat: Click to confirm element close

### DIFF
--- a/cypress/tests/ElementWrapper.spec.ts
+++ b/cypress/tests/ElementWrapper.spec.ts
@@ -59,6 +59,7 @@ describe("ElementWrapper", () => {
     it("should remove an element", async () => {
       addImageElement();
       cy.get(selectDataCy(removeTestId)).click();
+      cy.get(selectDataCy(removeTestId)).click();
       const elementTypes = await getArrayOfBlockElementTypes();
       expect(elementTypes).to.deep.equal(["paragraph", "paragraph"]);
     });

--- a/src/editorial-source-components/SvgBin.tsx
+++ b/src/editorial-source-components/SvgBin.tsx
@@ -1,0 +1,14 @@
+export const SvgBin = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height="24px"
+      viewBox="0 0 24 24"
+      width="24px"
+      fill="#000000"
+    >
+      <path d="M0 0h24v24H0z" fill="none" />
+      <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z" />
+    </svg>
+  );
+};

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -87,14 +87,20 @@ const Button = styled("button")<{ expanded?: boolean }>`
   }
 `;
 
-const SeriousButton = styled(Button)`
+const SeriousButton = styled(Button)<{ activated?: boolean }>`
+  background-color: ${({ activated }) =>
+    activated ? border.error : neutral[93]};
   div {
     opacity: 0;
   }
+  svg {
+    fill: ${({ activated }) => (activated ? neutral[100] : neutral[20])};
+  }
   :hover {
-    background-color: ${border.error};
+    background-color: ${({ activated }) =>
+      activated ? neutral[0] : border.error};
     svg {
-      fill: #fff;
+      fill: ${neutral[100]};
     }
     div {
       opacity: 1;
@@ -119,12 +125,12 @@ const Tooltip = styled("div")`
   bottom: ${buttonWidth + 10}px;
   font-family: "Guardian Agate Sans";
   box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.5);
-  z-index: 5;
+  z-index: 1;
   width: 82px;
   padding: ${space[1]}px;
   pointer-events: none;
   transition: opacity 0.2s;
-  // Add a point to the bottom of the tooltip
+  /* Add a point to the bottom of the tooltip */
   ::after {
     content: " ";
     position: absolute;
@@ -176,15 +182,22 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
         <LeftActions className="actions">
           <SeriousButton
             type="button"
+            activated={closeClickedOnce}
             data-cy={removeTestId}
             disabled={!remove(false)}
             onClick={() => {
-              closeClickedOnce ? remove(true) : setCloseClickedOnce(true);
+              if (closeClickedOnce) remove(true);
+              else {
+                setCloseClickedOnce(true);
+                setTimeout(() => {
+                  setCloseClickedOnce(false);
+                }, 5000);
+              }
             }}
             aria-label="Delete element"
           >
             <SvgCross />
-            {clickedOnce && <Tooltip>Click again to confirm</Tooltip>}
+            {closeClickedOnce && <Tooltip>Click again to confirm</Tooltip>}
           </SeriousButton>
         </LeftActions>
         <Panel>{children}</Panel>

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { space } from "@guardian/src-foundations";
 import { focusHalo } from "@guardian/src-foundations/accessibility";
-import { border, neutral } from "@guardian/src-foundations/palette";
+import { border, neutral, news } from "@guardian/src-foundations/palette";
 import {
   SvgArrowDownStraight,
   SvgArrowUpStraight,
@@ -51,7 +51,7 @@ const Button = styled("button")<{ expanded?: boolean }>`
   cursor: pointer;
   flex-grow: ${({ expanded }) => (expanded ? "1" : "0")};
   ${({ expanded }) => !expanded && "height: 32px;"};
-  font-size: 16px;
+  font-size: 15px;
   line-height: 1;
   padding: ${space[1]}px;
   width: ${buttonWidth}px;
@@ -98,7 +98,7 @@ const SeriousButton = styled(Button)<{ activated?: boolean }>`
   }
   :hover {
     background-color: ${({ activated }) =>
-      activated ? neutral[0] : border.error};
+      activated ? news[200] : border.error};
     svg {
       fill: ${neutral[100]};
     }
@@ -118,16 +118,20 @@ const Actions = styled("div")`
 `;
 
 const Tooltip = styled("div")`
-  background-color: ${neutral[93]};
+  background-color: ${neutral[97]};
   color: ${neutral[0]};
   position: absolute;
+  left: 0px;
+  border-radius: 4px;
   line-height: 1.2rem;
   bottom: ${buttonWidth + 10}px;
   font-family: "Guardian Agate Sans";
-  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.5);
+  font-size: 15px;
+  filter: drop-shadow(0 2px 4px rgb(0 0 0 / 30%));
   z-index: 1;
   width: 82px;
   padding: ${space[1]}px;
+  padding-bottom: 5px;
   pointer-events: none;
   transition: opacity 0.2s;
   /* Add a point to the bottom of the tooltip */
@@ -139,7 +143,7 @@ const Tooltip = styled("div")`
     margin-left: -5px;
     border-width: 5px;
     border-style: solid;
-    border-color: ${neutral[93]} transparent transparent transparent;
+    border-color: ${neutral[97]} transparent transparent transparent;
   }
 `;
 

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -10,7 +10,7 @@ import {
   SvgCross,
 } from "@guardian/src-icons";
 import type { ReactElement } from "react";
-import React from "react";
+import React, { useState } from "react";
 import type { CommandCreator } from "../../plugin/types/Commands";
 
 const buttonWidth = 32;
@@ -88,10 +88,16 @@ const Button = styled("button")<{ expanded?: boolean }>`
 `;
 
 const SeriousButton = styled(Button)`
+  div {
+    opacity: 0;
+  }
   :hover {
     background-color: ${border.error};
     svg {
       fill: #fff;
+    }
+    div {
+      opacity: 1;
     }
   }
 `;
@@ -103,6 +109,32 @@ const Actions = styled("div")`
   flex-direction: column;
   opacity: 0;
   transition: opacity 0.2s;
+`;
+
+const Tooltip = styled("div")`
+  background-color: ${neutral[93]};
+  color: ${neutral[0]};
+  position: absolute;
+  line-height: 1.2rem;
+  bottom: ${buttonWidth + 10}px;
+  font-family: "Guardian Agate Sans";
+  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.5);
+  z-index: 5;
+  width: 82px;
+  padding: ${space[1]}px;
+  pointer-events: none;
+  transition: opacity 0.2s;
+  // Add a point to the bottom of the tooltip
+  ::after {
+    content: " ";
+    position: absolute;
+    top: 100%;
+    left: ${buttonWidth / 2}px;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: ${neutral[93]} transparent transparent transparent;
+  }
 `;
 
 const RightActions = styled(Actions)`
@@ -132,76 +164,83 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
   moveBottom,
   remove,
   children,
-}) => (
-  <Container
-    className="ProsemirrorElement__wrapper"
-    data-cy={elementWrapperTestId}
-  >
-    <Body>
-      <LeftActions className="actions">
-        <SeriousButton
-          type="button"
-          data-cy={removeTestId}
-          disabled={!remove(false)}
-          onClick={() => remove(true)}
-          aria-label="Delete element"
-        >
-          <SvgCross />
-        </SeriousButton>
-      </LeftActions>
-      <Panel>{children}</Panel>
-      <RightActions className="actions">
-        <Button
-          type="button"
-          data-cy={moveTopTestId}
-          disabled={!moveTop(false)}
-          onClick={() => moveTop(true)}
-          aria-label="Move element to top"
-        >
-          <div
-            css={css`
-              transform: rotate(270deg) translate(1px, 1px);
-            `}
+}) => {
+  const [closeClickedOnce, setCloseClickedOnce] = useState(false);
+
+  return (
+    <Container
+      className="ProsemirrorElement__wrapper"
+      data-cy={elementWrapperTestId}
+    >
+      <Body>
+        <LeftActions className="actions">
+          <SeriousButton
+            type="button"
+            data-cy={removeTestId}
+            disabled={!remove(false)}
+            onClick={() => {
+              closeClickedOnce ? remove(true) : setCloseClickedOnce(true);
+            }}
+            aria-label="Delete element"
           >
-            <SvgChevronRightDouble />
-          </div>
-        </Button>
-        <Button
-          type="button"
-          data-cy={moveUpTestId}
-          expanded
-          disabled={!moveUp(false)}
-          onClick={() => moveUp(true)}
-          aria-label="Move element up"
-        >
-          <SvgArrowUpStraight />
-        </Button>
-        <Button
-          type="button"
-          data-cy={moveDownTestId}
-          expanded
-          disabled={!moveDown(false)}
-          onClick={() => moveDown(true)}
-          aria-label="Move element down"
-        >
-          <SvgArrowDownStraight />
-        </Button>
-        <Button
-          type="button"
-          data-cy={moveBottomTestId}
-          disabled={!moveBottom(false)}
-          onClick={() => moveBottom(true)}
-          aria-label="Move element to bottom"
-        >
-          <div
-            css={css`
-              transform: rotate(90deg) translate(-2px, 2px);
-            `}
+            <SvgCross />
+            {clickedOnce && <Tooltip>Click again to confirm</Tooltip>}
+          </SeriousButton>
+        </LeftActions>
+        <Panel>{children}</Panel>
+        <RightActions className="actions">
+          <Button
+            type="button"
+            data-cy={moveTopTestId}
+            disabled={!moveTop(false)}
+            onClick={() => moveTop(true)}
+            aria-label="Move element to top"
           >
-            <SvgChevronRightDouble />
-          </div>
-        </Button>
-      </RightActions>
-    </Body>
-  </Container>
-);
+            <div
+              css={css`
+                transform: rotate(270deg) translate(1px, 1px);
+              `}
+            >
+              <SvgChevronRightDouble />
+            </div>
+          </Button>
+          <Button
+            type="button"
+            data-cy={moveUpTestId}
+            expanded
+            disabled={!moveUp(false)}
+            onClick={() => moveUp(true)}
+            aria-label="Move element up"
+          >
+            <SvgArrowUpStraight />
+          </Button>
+          <Button
+            type="button"
+            data-cy={moveDownTestId}
+            expanded
+            disabled={!moveDown(false)}
+            onClick={() => moveDown(true)}
+            aria-label="Move element down"
+          >
+            <SvgArrowDownStraight />
+          </Button>
+          <Button
+            type="button"
+            data-cy={moveBottomTestId}
+            disabled={!moveBottom(false)}
+            onClick={() => moveBottom(true)}
+            aria-label="Move element to bottom"
+          >
+            <div
+              css={css`
+                transform: rotate(90deg) translate(-2px, 2px);
+              `}
+            >
+              <SvgChevronRightDouble />
+            </div>
+          </Button>
+        </RightActions>
+      </Body>
+    </Container>
+  );
+};

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { space } from "@guardian/src-foundations";
 import { focusHalo } from "@guardian/src-foundations/accessibility";
-import { border, neutral, news } from "@guardian/src-foundations/palette";
+import { border, neutral } from "@guardian/src-foundations/palette";
 import {
   SvgArrowDownStraight,
   SvgArrowUpStraight,
@@ -98,9 +98,9 @@ const SeriousButton = styled(Button)<{ activated?: boolean }>`
   }
   :hover {
     background-color: ${({ activated }) =>
-      activated ? news[200] : border.error};
+      activated ? neutral[0] : neutral[86]};
     svg {
-      fill: ${neutral[100]};
+      fill: ${({ activated }) => (activated ? neutral[100] : neutral[20])};
     }
     div {
       opacity: 1;

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -7,10 +7,10 @@ import {
   SvgArrowDownStraight,
   SvgArrowUpStraight,
   SvgChevronRightDouble,
-  SvgCross,
 } from "@guardian/src-icons";
 import type { ReactElement } from "react";
 import React, { useState } from "react";
+import { SvgBin } from "../../editorial-source-components/SvgBin";
 import type { CommandCreator } from "../../plugin/types/Commands";
 
 const buttonWidth = 32;
@@ -194,9 +194,8 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
                 }, 5000);
               }
             }}
-            aria-label="Delete element"
           >
-            <SvgCross />
+            <SvgBin />
             {closeClickedOnce && <Tooltip>Click again to confirm</Tooltip>}
           </SeriousButton>
         </LeftActions>


### PR DESCRIPTION
## What does this change?
Elements in Composer ([flexible-content](https://github.com/guardian/flexible-content)) currently require two clicks to close, but the implementation is not working very well. 

In order to be consistent with this existing behaviour (especially during migration where some, but not all, elements may be migrated), this PR adds 'click to confirm close' behaviour to our ProseMirror Elements. However, we've tidied the implementation with a new hover tooltip. As before, there is only a limited timeframe in which a user can confirm the close, after which a timeout occurs, and the button returns to its initial state.

**Once all elements are migrated to ProseMirror, we can revisit whether we want this behaviour at all.**

(N.B - due to a lack of bin icon in Source, we've borrowed one from the material design icon set).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Run `yarn start` from the repository root and try closing an element.

## Images

| Close timeout | Close the element |
| --- | --- |
| ![2021-09-07 14 35 39](https://user-images.githubusercontent.com/34686302/132354077-7b2b947b-1b95-4ad1-a9de-9be61bc2bb7c.gif) | ![2021-09-07 14 09 50](https://user-images.githubusercontent.com/34686302/132353488-f5c658db-631a-428f-adb0-3f031283b509.gif) |



## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->


#### I've tested the 'close to confirm' behaviour via screenreader and the experience is not good, because there is no additional information given to the user after the first click. I'm not sure how best to convey additional information to the screen-reader on the first click - perhaps this is an argument against the double-click functionality in the long run.

#### It's also worth noting that introducing a timeout introduces additional WCAG criteria to consider, e.g. https://www.w3.org/TR/WCAG21/#timing-adjustable
- [X] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [X] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [X] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [X] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
