### PR TITLE
docs: Extended accessibility checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,9 +19,9 @@
 This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
 -->
 
-- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-- [ ] [Navigable with keyboard](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html)
-- [ ] [Colour contrast passed](https://webaim.org/resources/contrastchecker/)
-- [ ] [The change doesn't use only colour to convey meaning](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-without-color.html)
-- [ ] [Interactive elements show a focus ring when focused by keyboard](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html)
-- [ ] [Semantic elements have been used where possible](https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html)
+- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
+- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
+- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
+- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
+- [ ] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
+- [ ] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## What does this change?
+<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
+
+## How to test
+<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
+
+## How can we measure success?
+<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
+
+## Have we considered potential risks?
+<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
+
+## Images
+<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
+
+## Accessibility
+<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 
+
+This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
+-->
+
+- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
+- [ ] [Navigable with keyboard](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html)
+- [ ] [Colour contrast passed](https://webaim.org/resources/contrastchecker/)
+- [ ] [The change doesn't use only colour to convey meaning](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-without-color.html)
+- [ ] [Interactive elements show a focus ring when focused by keyboard](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html)
+- [ ] [No content flashes more than three times in any one second period](https://www.w3.org/WAI/WCAG21/Understanding/three-flashes-or-below-threshold.html)
+- [ ] [Semantic elements have been used where possible](https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,5 +24,4 @@ This repository follows the Editorial Tools accessibility guidelines: https://gi
 - [ ] [Colour contrast passed](https://webaim.org/resources/contrastchecker/)
 - [ ] [The change doesn't use only colour to convey meaning](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-without-color.html)
 - [ ] [Interactive elements show a focus ring when focused by keyboard](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html)
-- [ ] [No content flashes more than three times in any one second period](https://www.w3.org/WAI/WCAG21/Understanding/three-flashes-or-below-threshold.html)
 - [ ] [Semantic elements have been used where possible](https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html)

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -105,9 +105,6 @@ const SeriousButton = styled(Button)<{ activated?: boolean }>`
     div {
       opacity: 1;
     }
-    div {
-      opacity: 1;
-    }
   }
 `;
 

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -105,6 +105,9 @@ const SeriousButton = styled(Button)<{ activated?: boolean }>`
     div {
       opacity: 1;
     }
+    div {
+      opacity: 1;
+    }
   }
 `;
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR adds a PR template which extends our accessibility checklist to match the [Editorial Tools Accessibility guidelines](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md).

These will look like:
## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
- [ ] [Navigable with keyboard](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html)
- [ ] [Colour contrast passed](https://webaim.org/resources/contrastchecker/)
- [ ] [The change doesn't use only colour to convey meaning](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-without-color.html)
- [ ] [Interactive elements show a focus ring when focused by keyboard](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html)
- [ ] [Semantic elements have been used where possible](https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html)
<s>[No content flashes more than three times in any one second period](https://www.w3.org/WAI/WCAG21/Understanding/three-flashes-or-below-threshold.html)</s>
