### PR TITLE
feat: refactor validation api

### DIFF
--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -665,6 +665,50 @@ describe("buildElementPlugin", () => {
 
         describe("validateElementData", () => {
           it("should output found errors", () => {
+            const { validateElementData } = createEditorWithElements({
+              testElementWithValidation,
+              testElementWithDifferentValidation,
+            });
+
+            const errors = validateElementData("testElementWithValidation", {
+              field1: "Some text",
+            });
+
+            expect(errors).toEqual({ field1: ["Some error"] });
+
+            const otherErrors = validateElementData(
+              "testElementWithDifferentValidation",
+              { checkbox: true }
+            );
+
+            expect(otherErrors).toEqual({ checkbox: ["Some other error"] });
+          });
+
+          it("should output undefined if there are no errors", () => {
+            const { validateElementData } = createEditorWithElements({
+              testElement,
+            });
+
+            const errors = validateElementData(
+              "testElement",
+              testElementValues.values
+            );
+
+            expect(errors).toEqual(undefined);
+          });
+
+          it("should not allow non-existent elements", () => {
+            const { validateElementData } = createEditorWithElements({
+              testElement,
+            });
+            validateElementData(
+              // @ts-expect-error -- we should not be able to check a non-existent element
+              "non-existing-element",
+              testElementValues.values
+            );
+          });
+
+          it("should accept the getElementDataFromNode output", () => {
             const {
               insertElement,
               getElementDataFromNode,
@@ -676,91 +720,22 @@ describe("buildElementPlugin", () => {
               testElementWithDifferentValidation,
             });
 
+            const elementName = "testElementWithValidation";
+
             insertElement({
-              elementName: "testElementWithValidation",
+              elementName,
               values: { field1: "Some text" },
             })(view.state, view.dispatch);
 
-            const element = getElementDataFromNode(
-              view.state.doc.firstChild as Node,
-              serializer
-            );
-
             const errors = validateElementData(
-              "testElementWithValidation",
-              element?.values
+              elementName,
+              getElementDataFromNode(
+                view.state.doc.firstChild as Node,
+                serializer
+              )?.values
             );
 
             expect(errors).toEqual({ field1: ["Some error"] });
-
-            insertElement({
-              elementName: "testElementWithDifferentValidation",
-              values: { checkbox: true },
-            })(view.state, view.dispatch);
-
-            const otherElement = getElementDataFromNode(
-              view.state.doc.firstChild as Node,
-              serializer
-            );
-
-            const otherErrors = validateElementData(
-              "testElementWithDifferentValidation",
-              otherElement?.values
-            );
-
-            expect(otherErrors).toEqual({ checkbox: ["Some other error"] });
-          });
-
-          it("should output undefined if there are no errors", () => {
-            const {
-              insertElement,
-              getElementDataFromNode,
-              validateElementData,
-              view,
-              serializer,
-            } = createEditorWithElements({
-              testElement,
-            });
-
-            insertElement({
-              elementName: "testElement",
-              values: testElementValues.values,
-            })(view.state, view.dispatch);
-
-            const element = getElementDataFromNode(
-              view.state.doc.firstChild as Node,
-              serializer
-            );
-
-            const errors = validateElementData("testElement", element?.values);
-
-            expect(errors).toEqual(undefined);
-          });
-          it("should not allow non-existent elements", () => {
-            const {
-              insertElement,
-              getElementDataFromNode,
-              validateElementData,
-              view,
-              serializer,
-            } = createEditorWithElements({
-              testElement,
-            });
-
-            insertElement({
-              elementName: "testElement",
-              values: testElementValues.values,
-            })(view.state, view.dispatch);
-
-            const element = getElementDataFromNode(
-              view.state.doc.firstChild as Node,
-              serializer
-            );
-
-            expect(
-              // @ts-expect-error -- we should not be able to check a non-existent element
-              validateElementData("non-existing-element", element?.values)
-            ).toEqual(undefined);
           });
         });
       });

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -670,16 +670,19 @@ describe("buildElementPlugin", () => {
               testElementWithDifferentValidation,
             });
 
-            const errors = validateElementData("testElementWithValidation", {
-              field1: "Some text",
+            const errors = validateElementData({
+              elementName: "testElementWithValidation",
+              values: {
+                field1: "Some text",
+              },
             });
 
             expect(errors).toEqual({ field1: ["Some error"] });
 
-            const otherErrors = validateElementData(
-              "testElementWithDifferentValidation",
-              { checkbox: true }
-            );
+            const otherErrors = validateElementData({
+              elementName: "testElementWithDifferentValidation",
+              values: { checkbox: true },
+            });
 
             expect(otherErrors).toEqual({ checkbox: ["Some other error"] });
           });
@@ -689,10 +692,21 @@ describe("buildElementPlugin", () => {
               testElement,
             });
 
-            const errors = validateElementData(
-              "testElement",
-              testElementValues.values
-            );
+            const errors = validateElementData({
+              elementName: "testElement",
+              values: testElementValues.values,
+            });
+
+            expect(errors).toEqual(undefined);
+          });
+
+          it("should output undefined if there are no errors", () => {
+            const { validateElementData } = createEditorWithElements({
+              testElement,
+            });
+
+            // @ts-expect-error -- values need to match the expected shape
+            const errors = validateElementData("testElement", { a: 123 });
 
             expect(errors).toEqual(undefined);
           });
@@ -701,11 +715,11 @@ describe("buildElementPlugin", () => {
             const { validateElementData } = createEditorWithElements({
               testElement,
             });
-            validateElementData(
+            validateElementData({
               // @ts-expect-error -- we should not be able to check a non-existent element
-              "non-existing-element",
-              testElementValues.values
-            );
+              elementName: "non-existing-element",
+              values: testElementValues.values,
+            });
           });
 
           it("should accept the getElementDataFromNode output", () => {
@@ -728,11 +742,11 @@ describe("buildElementPlugin", () => {
             })(view.state, view.dispatch);
 
             const errors = validateElementData(
-              elementName,
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion  -- We know this exists for the purposes of the test
               getElementDataFromNode(
                 view.state.doc.firstChild as Node,
                 serializer
-              )?.values
+              )!
             );
 
             expect(errors).toEqual({ field1: ["Some error"] });

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -655,28 +655,6 @@ describe("buildElementPlugin", () => {
           }
         });
       });
-      it("should output any errors", () => {
-        const {
-          insertElement,
-          getElementDataFromNode,
-          view,
-          serializer,
-        } = createEditorWithElements({
-          testElementWithValidation,
-        });
-
-        insertElement({
-          elementName: "testElementWithValidation",
-          values: { field1: "Some text" },
-        })(view.state, view.dispatch);
-
-        const element = getElementDataFromNode(
-          view.state.doc.firstChild as Node,
-          serializer
-        );
-
-        expect(element?.errors).toEqual({ field1: ["Some error"] });
-      });
     });
   });
 });

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -700,7 +700,7 @@ describe("buildElementPlugin", () => {
             expect(errors).toEqual(undefined);
           });
 
-          it("should output undefined if there are no errors", () => {
+          it("should not allow values which don't match the element", () => {
             const { validateElementData } = createEditorWithElements({
               testElement,
             });

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -663,12 +663,12 @@ describe("buildElementPlugin", () => {
           }
         });
 
-        describe("elementValidator", () => {
+        describe("validateElementData", () => {
           it("should output found errors", () => {
             const {
               insertElement,
               getElementDataFromNode,
-              elementValidator,
+              validateElementData,
               view,
               serializer,
             } = createEditorWithElements({
@@ -686,7 +686,7 @@ describe("buildElementPlugin", () => {
               serializer
             );
 
-            const errors = elementValidator(
+            const errors = validateElementData(
               "testElementWithValidation",
               element?.values
             );
@@ -703,7 +703,7 @@ describe("buildElementPlugin", () => {
               serializer
             );
 
-            const otherErrors = elementValidator(
+            const otherErrors = validateElementData(
               "testElementWithDifferentValidation",
               otherElement?.values
             );
@@ -715,7 +715,7 @@ describe("buildElementPlugin", () => {
             const {
               insertElement,
               getElementDataFromNode,
-              elementValidator,
+              validateElementData,
               view,
               serializer,
             } = createEditorWithElements({
@@ -732,7 +732,7 @@ describe("buildElementPlugin", () => {
               serializer
             );
 
-            const errors = elementValidator("testElement", element?.values);
+            const errors = validateElementData("testElement", element?.values);
 
             expect(errors).toEqual(undefined);
           });
@@ -740,7 +740,7 @@ describe("buildElementPlugin", () => {
             const {
               insertElement,
               getElementDataFromNode,
-              elementValidator,
+              validateElementData,
               view,
               serializer,
             } = createEditorWithElements({
@@ -759,7 +759,7 @@ describe("buildElementPlugin", () => {
 
             expect(
               // @ts-expect-error -- we should not be able to check a non-existent element
-              elementValidator("non-existing-element", element?.values)
+              validateElementData("non-existing-element", element?.values)
             ).toEqual(undefined);
           });
         });

--- a/src/plugin/element.ts
+++ b/src/plugin/element.ts
@@ -2,7 +2,7 @@ import OrderedMap from "orderedmap";
 import type { NodeSpec, Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
 import {
-  createElementValidator,
+  createElementDataValidator,
   createGetElementDataFromNode,
   createGetNodeFromElementData,
 } from "./helpers/element";
@@ -31,7 +31,7 @@ export const buildElementPlugin = <
 ) => {
   const getNodeFromElementData = createGetNodeFromElementData(elementSpecs);
   const getElementDataFromNode = createGetElementDataFromNode(elementSpecs);
-  const elementValidator = createElementValidator(elementSpecs);
+  const validateElementData = createElementDataValidator(elementSpecs);
 
   const insertElement = (
     elementData: ExtractPartialDataTypeFromElementSpec<ESpecMap, ElementNames>
@@ -69,6 +69,6 @@ export const buildElementPlugin = <
     nodeSpec,
     getElementDataFromNode,
     getNodeFromElementData,
-    elementValidator,
+    validateElementData,
   };
 };

--- a/src/plugin/element.ts
+++ b/src/plugin/element.ts
@@ -2,6 +2,7 @@ import OrderedMap from "orderedmap";
 import type { NodeSpec, Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
 import {
+  createElementValidator,
   createGetElementDataFromNode,
   createGetNodeFromElementData,
 } from "./helpers/element";
@@ -30,6 +31,7 @@ export const buildElementPlugin = <
 ) => {
   const getNodeFromElementData = createGetNodeFromElementData(elementSpecs);
   const getElementDataFromNode = createGetElementDataFromNode(elementSpecs);
+  const elementValidator = createElementValidator(elementSpecs);
 
   const insertElement = (
     elementData: ExtractPartialDataTypeFromElementSpec<ESpecMap, ElementNames>
@@ -67,5 +69,6 @@ export const buildElementPlugin = <
     nodeSpec,
     getElementDataFromNode,
     getNodeFromElementData,
+    elementValidator,
   };
 };

--- a/src/plugin/helpers/element.ts
+++ b/src/plugin/helpers/element.ts
@@ -121,3 +121,26 @@ const getValuesFromContentNode = (node: Node, serializer: DOMSerializer) => {
   e.appendChild(dom);
   return e.innerHTML;
 };
+
+export const createElementValidator = <
+  FDesc extends FieldDescriptions<keyof FDesc>,
+  ElementNames extends keyof ESpecMap,
+  ExternalData,
+  ESpecMap extends ElementSpecMap<FDesc, ElementNames, ExternalData>
+>(
+  elementTypeMap: ESpecMap
+) => (
+  elementName: string,
+  values: unknown
+): Record<string, string[]> | undefined => {
+  const element = elementTypeMap[elementName as keyof ESpecMap];
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- this may be falsy.
+  if (!element) {
+    return undefined;
+  }
+
+  const errors = element.validate(values as FieldNameToValueMap<FDesc>);
+
+  return errors;
+};

--- a/src/plugin/helpers/element.ts
+++ b/src/plugin/helpers/element.ts
@@ -122,7 +122,7 @@ const getValuesFromContentNode = (node: Node, serializer: DOMSerializer) => {
   return e.innerHTML;
 };
 
-export const createElementValidator = <
+export const createElementDataValidator = <
   FDesc extends FieldDescriptions<keyof FDesc>,
   ElementNames extends keyof ESpecMap,
   ExternalData,

--- a/src/plugin/helpers/element.ts
+++ b/src/plugin/helpers/element.ts
@@ -106,7 +106,6 @@ export const createGetElementDataFromNode = <
 
   return ({
     elementName,
-    errors: element.validate(values as ExtractFieldValues<typeof element>),
     values:
       element.transformers?.transformElementDataOut(
         values as ExtractFieldValues<typeof element>

--- a/src/plugin/helpers/element.ts
+++ b/src/plugin/helpers/element.ts
@@ -130,17 +130,15 @@ export const createElementValidator = <
 >(
   elementTypeMap: ESpecMap
 ) => (
-  elementName: string,
+  elementName: keyof ESpecMap,
   values: unknown
 ): Record<string, string[]> | undefined => {
-  const element = elementTypeMap[elementName as keyof ESpecMap];
+  const element = elementTypeMap[elementName];
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- this may be falsy.
   if (!element) {
     return undefined;
   }
 
-  const errors = element.validate(values as FieldNameToValueMap<FDesc>);
-
-  return errors;
+  return element.validate(values as FieldNameToValueMap<FDesc>);
 };

--- a/src/plugin/helpers/test.ts
+++ b/src/plugin/helpers/test.ts
@@ -81,6 +81,7 @@ export const createEditorWithElements = <
     nodeSpec,
     getNodeFromElementData,
     getElementDataFromNode,
+    elementValidator,
   } = buildElementPlugin(elements);
   const editorElement = document.createElement("div");
   const docElement = document.createElement("div");
@@ -113,5 +114,6 @@ export const createEditorWithElements = <
     getNodeFromElementData,
     getElementDataFromNode,
     serializer,
+    elementValidator,
   };
 };

--- a/src/plugin/helpers/test.ts
+++ b/src/plugin/helpers/test.ts
@@ -81,7 +81,7 @@ export const createEditorWithElements = <
     nodeSpec,
     getNodeFromElementData,
     getElementDataFromNode,
-    elementValidator,
+    validateElementData,
   } = buildElementPlugin(elements);
   const editorElement = document.createElement("div");
   const docElement = document.createElement("div");
@@ -114,6 +114,6 @@ export const createEditorWithElements = <
     getNodeFromElementData,
     getElementDataFromNode,
     serializer,
-    elementValidator,
+    validateElementData,
   };
 };

--- a/src/plugin/types/Element.ts
+++ b/src/plugin/types/Element.ts
@@ -139,7 +139,6 @@ export type ExtractDataTypeFromElementSpec<T, U> = U extends keyof T
       values: ExtractExternalData<T[U]> extends Record<string, unknown>
         ? ExtractExternalData<T[U]>
         : ExtractFieldValues<T[U]>;
-      errors: Record<string, string[]>;
     }
   : never;
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR changes how the validation logic is surfaced to the consumer. With this PR it is no longer returned from`getElementFromNode` but instead a function is provided called `elementDataValidator` which can be used to validate element values.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
I have added some additional unit tests to ensure the functionality is working correctly, but should be a no-op for the demo.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Consumers have an easy way of validating element values, whilst validation logic is nicely encapsulated within the element spec.

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [x] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
