### PR TITLE
feat: Button font update for image elelemt

### DIFF
--- a/src/editorial-source-components/Button.tsx
+++ b/src/editorial-source-components/Button.tsx
@@ -1,0 +1,36 @@
+import { css } from "@emotion/react";
+import { Button as SourceButton } from "@guardian/src-button";
+import type { ReactElement } from "react";
+import React from "react";
+
+export const buttonStyles = css`
+  font-family: "Guardian Agate Sans";
+`;
+
+type Size = "default" | "small" | "xsmall";
+type ButtonPriority = "primary" | "secondary" | "tertiary" | "subdued";
+type IconSide = "left" | "right";
+
+type Props = {
+  iconSide?: IconSide;
+  priority?: ButtonPriority;
+  size?: Size;
+  icon?: ReactElement;
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+};
+
+export const Button: React.FunctionComponent<Props> = ({
+  children,
+  size,
+  ...props
+}) => {
+  return (
+    <SourceButton
+      size={size ? size : "xsmall"}
+      cssOverrides={buttonStyles}
+      {...props}
+    >
+      {children}
+    </SourceButton>
+  );
+};

--- a/src/editorial-source-components/Button.tsx
+++ b/src/editorial-source-components/Button.tsx
@@ -1,25 +1,13 @@
 import { css } from "@emotion/react";
+import type { ButtonProps } from "@guardian/src-button";
 import { Button as SourceButton } from "@guardian/src-button";
-import type { ReactElement } from "react";
 import React from "react";
 
 export const buttonStyles = css`
   font-family: "Guardian Agate Sans";
 `;
 
-type Size = "default" | "small" | "xsmall";
-type ButtonPriority = "primary" | "secondary" | "tertiary" | "subdued";
-type IconSide = "left" | "right";
-
-type Props = {
-  iconSide?: IconSide;
-  priority?: ButtonPriority;
-  size?: Size;
-  icon?: ReactElement;
-  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
-};
-
-export const Button: React.FunctionComponent<Props> = ({
+export const Button: React.FunctionComponent<ButtonProps> = ({
   children,
   size,
   ...props

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -1,8 +1,8 @@
 import { css } from "@emotion/react";
-import { Button } from "@guardian/src-button";
 import { SvgCamera } from "@guardian/src-icons";
 import { Column, Columns, Inline } from "@guardian/src-layout";
 import React from "react";
+import { Button } from "../../editorial-source-components/Button";
 import { Error } from "../../editorial-source-components/Error";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
 import type {


### PR DESCRIPTION
co-authored @rhystmills 

## What does this change?
We are currently using Source button for the `copy from caption` and `re crop image` on the image element.
In order to keep the styling in line with the rest of Composer we would like the font for the text to be Agate Sans.

This PR aims to amend the default font for the source button to Agate Sans.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run `yarn start` from the repository root and try closing an element.
Also using dev tools; inspect the font source (as screenshots below)

## Additional information
In order to implement this the following additions were made to this feature:
* New Button component created in its own file
* The button component is based off of Source button
* Additional styling added through props to override the default font
* Re factor the default props for Source button to allow for our custom button

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
| Before: Default font   | Styling |
| --- | --- |
| <img width="600" alt="image" src="https://user-images.githubusercontent.com/49187886/132350976-3d886e23-12f3-4fc2-9450-f304d696536d.png">) |<img width="300" alt="image" src="https://user-images.githubusercontent.com/49187886/132350740-0b53b4aa-6d82-489b-b41a-4d6179cf8a76.png"> |

| After: Customised font  | Styling |
| --- | --- |
| <img width="600" alt="image" src="https://user-images.githubusercontent.com/49187886/132349305-45e8e30b-24b3-45a8-b335-ddf094276d7b.png">|<img width="300" alt="image" src="https://user-images.githubusercontent.com/49187886/132351349-fcb8cbff-0d02-4c96-a424-413f8764d0a1.png"> |

