### PR TITLE
feat: Image size warning

### DIFF
--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -7,6 +7,7 @@ import {
   createValidator,
   htmlMaxLength,
   htmlRequired,
+  largestAssetMinDimension,
 } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { ImageElementForm } from "./ImageElementForm";
@@ -102,5 +103,6 @@ export const createImageElement = (
       altText: [htmlMaxLength(1000), htmlRequired()],
       source: [htmlMaxLength(250), htmlRequired()],
       photographer: [htmlMaxLength(250)],
+      mainImage: [largestAssetMinDimension(460)],
     })
   );

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
 import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
-import type { Validator } from "../../plugin/helpers/validation";
 import {
   createValidator,
   htmlMaxLength,
@@ -11,6 +10,7 @@ import {
 } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { ImageElementForm } from "./ImageElementForm";
+import { largestAssetMinDimension } from "./imageElementValidation";
 
 export type MediaPayload = {
   mediaId: string;
@@ -82,88 +82,6 @@ export const createImageFields = (
       { text: "immersive", value: "immersive" },
     ]),
   };
-};
-
-type ImageAsset = {
-  fields: {
-    width: number;
-    height: number;
-  };
-};
-
-const hasOwnProperty = <X extends Record<string, unknown>, Y extends string>(
-  obj: X,
-  prop: Y
-): obj is X & Record<Y, unknown> => {
-  return Object.hasOwnProperty.call(obj, prop);
-};
-
-const isRecord = (value: unknown): value is Record<string, unknown> => {
-  return typeof value === "object" && value !== null;
-};
-
-const isValidImageAsset = (
-  maybeImage: Record<string, unknown>
-): maybeImage is ImageAsset => {
-  return (
-    hasOwnProperty(maybeImage, "fields") &&
-    isRecord(maybeImage.fields) &&
-    hasOwnProperty(maybeImage.fields, "width") &&
-    hasOwnProperty(maybeImage.fields, "height") &&
-    typeof maybeImage.fields.width === "number" &&
-    typeof maybeImage.fields.height === "number"
-  );
-};
-
-const validateAssets = (maybeAssets: unknown[]) => {
-  const assets = maybeAssets.map((asset, i) => {
-    if (!isRecord(asset)) {
-      throw new Error(
-        `[largestAssetMinDimension]: asset ${i} passed to validator was not an object`
-      );
-    }
-    if (!isValidImageAsset(asset)) {
-      throw new Error(
-        `[largestAssetMinDimension]: asset ${i} does not have height and width props that are numbers`
-      );
-    }
-    return asset;
-  });
-  return assets;
-};
-
-export const largestAssetMinDimension = (minSize: number): Validator => (
-  value
-) => {
-  if (typeof value !== "object" || value === null) {
-    throw new Error(
-      `[largestAssetMinDimension]: overall value passed to validator is not an object`
-    );
-  }
-
-  if (isRecord(value) && value.assets && Array.isArray(value.assets)) {
-    const validatedAssets = validateAssets(value.assets);
-    const largestImageAsset = validatedAssets.sort(function (a, b) {
-      return b.fields.width - a.fields.width;
-    })[0];
-
-    const largestDimensionMin = minSize;
-
-    if (
-      largestImageAsset.fields.width < largestDimensionMin &&
-      largestImageAsset.fields.height < largestDimensionMin
-    ) {
-      return [
-        {
-          error: "Warning: Small image, only thumbnail available",
-          message:
-            "Image should be greater than 460 x 460px for uses other than a thumbnail.",
-        },
-      ];
-    }
-  }
-
-  return [];
 };
 
 export const createImageElement = (

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -3,6 +3,7 @@ import { Button } from "@guardian/src-button";
 import { SvgCamera } from "@guardian/src-icons";
 import { Column, Columns, Inline } from "@guardian/src-layout";
 import React from "react";
+import { Error } from "../../editorial-source-components/Error";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
 import type { FieldValidationErrors } from "../../plugin/elementSpec";
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
@@ -31,6 +32,7 @@ type Props = {
 
 type ImageViewProps = {
   onChange: SetMedia;
+  errors: string[];
   field: CustomField<MainImageData, MainImageProps>;
 };
 
@@ -56,6 +58,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
             fields.source.update(source);
             fields.photographer.update(photographer);
           }}
+          errors={errors.mainImage}
         />
         <CustomDropdownView
           field={fields.imageType}
@@ -114,7 +117,10 @@ const imageViewStysles = css`
   width: 100%;
 `;
 
-const ImageView = ({ field, onChange }: ImageViewProps) => {
+const Errors = ({ errors }: { errors: string[] }) =>
+  !errors.length ? null : <Error>{errors.join(", ")}</Error>;
+
+const ImageView = ({ field, onChange, errors }: ImageViewProps) => {
   const [imageFields, setImageFields] = useCustomFieldState(field);
   const setMedia = (mediaPayload: MediaPayload) => {
     const { mediaId, mediaApiUri, assets, suppliersReference } = mediaPayload;
@@ -139,12 +145,12 @@ const ImageView = ({ field, onChange }: ImageViewProps) => {
     const assets = imageFields.assets
       .filter((asset) => !asset.fields.isMaster)
       .sort(sortByWidthDifference);
-
     return assets.length > 0 ? assets[0].url : undefined;
   };
 
   return (
     <>
+      <Errors errors={errors} />
       <div>
         <img css={imageViewStysles} src={getImageSrc()} />
       </div>

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -153,7 +153,7 @@ const ImageView = ({ field, onChange, errors }: ImageViewProps) => {
 
   return (
     <>
-      <Errors errors={errors.map((error) => error.message)} />
+      <Errors errors={errors.map((e) => e.error)} />
       <div>
         <img css={imageViewStysles} src={getImageSrc()} />
       </div>

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -5,7 +5,10 @@ import { Column, Columns, Inline } from "@guardian/src-layout";
 import React from "react";
 import { Error } from "../../editorial-source-components/Error";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
-import type { FieldValidationErrors } from "../../plugin/elementSpec";
+import type {
+  FieldValidationErrors,
+  ValidationError,
+} from "../../plugin/elementSpec";
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
 import type { CustomField, FieldNameToField } from "../../plugin/types/Element";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
@@ -32,7 +35,7 @@ type Props = {
 
 type ImageViewProps = {
   onChange: SetMedia;
-  errors: string[];
+  errors: ValidationError[];
   field: CustomField<MainImageData, MainImageProps>;
 };
 
@@ -150,7 +153,7 @@ const ImageView = ({ field, onChange, errors }: ImageViewProps) => {
 
   return (
     <>
-      <Errors errors={errors} />
+      <Errors errors={errors.map((error) => error.message)} />
       <div>
         <img css={imageViewStysles} src={getImageSrc()} />
       </div>

--- a/src/elements/image/imageElementValidation.tsx
+++ b/src/elements/image/imageElementValidation.tsx
@@ -1,0 +1,75 @@
+import type { Validator } from "../../plugin/helpers/validation";
+import type { Asset } from "./ImageElement";
+
+const hasOwnProperty = <X extends Record<string, unknown>, Y extends string>(
+  obj: X,
+  prop: Y
+): obj is X & Record<Y, unknown> => {
+  return Object.hasOwnProperty.call(obj, prop);
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === "object" && value !== null;
+};
+
+const isValidImageAsset = (
+  maybeImage: Record<string, unknown>
+): maybeImage is Asset => {
+  return (
+    hasOwnProperty(maybeImage, "fields") &&
+    isRecord(maybeImage.fields) &&
+    hasOwnProperty(maybeImage.fields, "width") &&
+    hasOwnProperty(maybeImage.fields, "height") &&
+    typeof maybeImage.fields.width === "number" &&
+    typeof maybeImage.fields.height === "number"
+  );
+};
+
+const validateAssets = (maybeAssets: unknown[]) => {
+  const assets = maybeAssets.map((asset, i) => {
+    if (!isRecord(asset)) {
+      throw new Error(
+        `[largestAssetMinDimension]: asset ${i} passed to validator was not an object`
+      );
+    }
+    if (!isValidImageAsset(asset)) {
+      throw new Error(
+        `[largestAssetMinDimension]: asset ${i} does not have height and width props that are numbers`
+      );
+    }
+    return asset;
+  });
+  return assets;
+};
+
+export const largestAssetMinDimension = (minSize: number): Validator => (
+  value
+) => {
+  if (typeof value !== "object" || value === null) {
+    throw new Error(
+      `[largestAssetMinDimension]: overall value passed to validator is not an object`
+    );
+  }
+
+  if (isRecord(value) && value.assets && Array.isArray(value.assets)) {
+    const validatedAssets = validateAssets(value.assets);
+    const largestImageAsset = validatedAssets.sort(function (a, b) {
+      return b.fields.width - a.fields.width;
+    })[0];
+
+    if (
+      largestImageAsset.fields.width < minSize &&
+      largestImageAsset.fields.height < minSize
+    ) {
+      return [
+        {
+          error: "Warning: Small image, only thumbnail available",
+          message:
+            "Image should be greater than 460 x 460px for uses other than a thumbnail.",
+        },
+      ];
+    }
+  }
+
+  return [];
+};

--- a/src/elements/image/imageElementValidation.tsx
+++ b/src/elements/image/imageElementValidation.tsx
@@ -1,13 +1,6 @@
 import type { Validator } from "../../plugin/helpers/validation";
 import type { Asset } from "./ImageElement";
 
-const hasOwnProperty = <X extends Record<string, unknown>, Y extends string>(
-  obj: X,
-  prop: Y
-): obj is X & Record<Y, unknown> => {
-  return Object.hasOwnProperty.call(obj, prop);
-};
-
 const isRecord = (value: unknown): value is Record<string, unknown> => {
   return typeof value === "object" && value !== null;
 };
@@ -16,10 +9,10 @@ const isValidImageAsset = (
   maybeImage: Record<string, unknown>
 ): maybeImage is Asset => {
   return (
-    hasOwnProperty(maybeImage, "fields") &&
+    maybeImage.fields !== undefined &&
     isRecord(maybeImage.fields) &&
-    hasOwnProperty(maybeImage.fields, "width") &&
-    hasOwnProperty(maybeImage.fields, "height") &&
+    maybeImage.fields.width !== undefined &&
+    maybeImage.fields.height !== undefined &&
     typeof maybeImage.fields.width === "number" &&
     typeof maybeImage.fields.height === "number"
   );

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -22,6 +22,82 @@ export const createValidator = (
   return errors;
 };
 
+type ImageAsset = {
+  fields: {
+    width: number;
+    height: number;
+  };
+};
+
+function hasOwnProperty<X extends Record<string, unknown>, Y extends string>(
+  obj: X,
+  prop: Y
+): obj is X & Record<Y, unknown> {
+  return Object.hasOwnProperty.call(obj, prop);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isValidImageAsset(
+  maybeImage: Record<string, unknown>
+): maybeImage is ImageAsset {
+  return (
+    hasOwnProperty(maybeImage, "fields") &&
+    isRecord(maybeImage.fields) &&
+    hasOwnProperty(maybeImage.fields, "width") &&
+    hasOwnProperty(maybeImage.fields, "height") &&
+    typeof maybeImage.fields.width === "number" &&
+    typeof maybeImage.fields.height === "number"
+  );
+}
+
+function validateAssets(maybeAssets: unknown[]) {
+  const assets = maybeAssets.map((asset, i) => {
+    if (!isRecord(asset)) {
+      throw new Error(
+        `[largestAssetMinDimension]: asset ${i} passed to validator was not an object`
+      );
+    }
+    if (!isValidImageAsset(asset)) {
+      throw new Error(
+        `[largestAssetMinDimension]: asset ${i} does not have height and width props that are numbers`
+      );
+    }
+    return asset;
+  });
+  return assets;
+}
+
+export const largestAssetMinDimension = (minSize: number): Validator => (
+  value
+) => {
+  if (typeof value !== "object" || value === null) {
+    throw new Error(
+      `[largestAssetMinDimension]: overall value passed to validator is not an object`
+    );
+  }
+
+  if (isRecord(value) && value.assets && Array.isArray(value.assets)) {
+    const validatedAssets = validateAssets(value.assets);
+    const largestImageAsset = validatedAssets.sort(function (a, b) {
+      return b.fields.width - a.fields.width;
+    })[0];
+
+    const largestDimensionMin = minSize;
+
+    if (
+      largestImageAsset.fields.width < largestDimensionMin &&
+      largestImageAsset.fields.height < largestDimensionMin
+    ) {
+      return ["Warning: Small image, only thumbnail available"];
+    }
+  }
+
+  return [];
+};
+
 export const htmlMaxLength = (
   maxLength: number,
   customMessage: string | undefined = undefined

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -29,20 +29,20 @@ type ImageAsset = {
   };
 };
 
-function hasOwnProperty<X extends Record<string, unknown>, Y extends string>(
+const hasOwnProperty = <X extends Record<string, unknown>, Y extends string>(
   obj: X,
   prop: Y
-): obj is X & Record<Y, unknown> {
+): obj is X & Record<Y, unknown> => {
   return Object.hasOwnProperty.call(obj, prop);
-}
+};
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+const isRecord = (value: unknown): value is Record<string, unknown> => {
   return typeof value === "object" && value !== null;
-}
+};
 
-function isValidImageAsset(
+const isValidImageAsset = (
   maybeImage: Record<string, unknown>
-): maybeImage is ImageAsset {
+): maybeImage is ImageAsset => {
   return (
     hasOwnProperty(maybeImage, "fields") &&
     isRecord(maybeImage.fields) &&
@@ -51,9 +51,9 @@ function isValidImageAsset(
     typeof maybeImage.fields.width === "number" &&
     typeof maybeImage.fields.height === "number"
   );
-}
+};
 
-function validateAssets(maybeAssets: unknown[]) {
+const validateAssets = (maybeAssets: unknown[]) => {
   const assets = maybeAssets.map((asset, i) => {
     if (!isRecord(asset)) {
       throw new Error(
@@ -68,7 +68,7 @@ function validateAssets(maybeAssets: unknown[]) {
     return asset;
   });
   return assets;
-}
+};
 
 export const largestAssetMinDimension = (minSize: number): Validator => (
   value

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -2,7 +2,10 @@ import type { FieldValidationErrors, ValidationError } from "../elementSpec";
 import type { FieldNameToValueMap } from "../fieldViews/helpers";
 import type { FieldDescriptions } from "../types/Element";
 
-type Validator = (fieldValue: unknown, fieldName: string) => ValidationError[];
+export type Validator = (
+  fieldValue: unknown,
+  fieldName: string
+) => ValidationError[];
 
 export const createValidator = (
   fieldValidationMap: Record<string, Validator[]>
@@ -20,82 +23,6 @@ export const createValidator = (
     errors[fieldName] = fieldErrors;
   }
   return errors;
-};
-
-type ImageAsset = {
-  fields: {
-    width: number;
-    height: number;
-  };
-};
-
-const hasOwnProperty = <X extends Record<string, unknown>, Y extends string>(
-  obj: X,
-  prop: Y
-): obj is X & Record<Y, unknown> => {
-  return Object.hasOwnProperty.call(obj, prop);
-};
-
-const isRecord = (value: unknown): value is Record<string, unknown> => {
-  return typeof value === "object" && value !== null;
-};
-
-const isValidImageAsset = (
-  maybeImage: Record<string, unknown>
-): maybeImage is ImageAsset => {
-  return (
-    hasOwnProperty(maybeImage, "fields") &&
-    isRecord(maybeImage.fields) &&
-    hasOwnProperty(maybeImage.fields, "width") &&
-    hasOwnProperty(maybeImage.fields, "height") &&
-    typeof maybeImage.fields.width === "number" &&
-    typeof maybeImage.fields.height === "number"
-  );
-};
-
-const validateAssets = (maybeAssets: unknown[]) => {
-  const assets = maybeAssets.map((asset, i) => {
-    if (!isRecord(asset)) {
-      throw new Error(
-        `[largestAssetMinDimension]: asset ${i} passed to validator was not an object`
-      );
-    }
-    if (!isValidImageAsset(asset)) {
-      throw new Error(
-        `[largestAssetMinDimension]: asset ${i} does not have height and width props that are numbers`
-      );
-    }
-    return asset;
-  });
-  return assets;
-};
-
-export const largestAssetMinDimension = (minSize: number): Validator => (
-  value
-) => {
-  if (typeof value !== "object" || value === null) {
-    throw new Error(
-      `[largestAssetMinDimension]: overall value passed to validator is not an object`
-    );
-  }
-
-  if (isRecord(value) && value.assets && Array.isArray(value.assets)) {
-    const validatedAssets = validateAssets(value.assets);
-    const largestImageAsset = validatedAssets.sort(function (a, b) {
-      return b.fields.width - a.fields.width;
-    })[0];
-
-    const largestDimensionMin = minSize;
-
-    if (
-      largestImageAsset.fields.width < largestDimensionMin &&
-      largestImageAsset.fields.height < largestDimensionMin
-    ) {
-      return ["Warning: Small image, only thumbnail available"];
-    }
-  }
-
-  return [];
 };
 
 export const htmlMaxLength = (


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This replicates the image size warning for the Image element, which is present in the existing element in Composer. This warning occurs when the largest asset available has at least one dimension smaller than 460px.

There's quite a bit of code here to allow us remain type-safe while validating the image fields. Is this valuable enough to justify not simply asserting the type using `as`?

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run `yarn start` locally and try using a crop with a dimension smaller than 460px.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
| Too Small | Correct Size |
| --- | --- |
| ![2021-09-09 09 19 42](https://user-images.githubusercontent.com/34686302/132650222-fe422c21-d586-4fc3-b8f9-2374cae85ada.gif) | ![2021-09-09 09 20 06](https://user-images.githubusercontent.com/34686302/132650201-281b71aa-b357-4015-8a87-5bb58db1fafd.gif) |

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [X] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [X] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [X] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
