### PR TITLE
fix: Allow error messages to wrap beneath labels 

### DIFF
--- a/src/editorial-source-components/CustomCheckbox.tsx
+++ b/src/editorial-source-components/CustomCheckbox.tsx
@@ -10,10 +10,8 @@ const parentStyles = css`
   white-space: nowrap;
   div {
     ${labelStyles}
-  }
-  label {
-    margin-top: -6px;
-    margin-bottom: -6px;
+    margin-top: ${space[2]}px;
+    margin-bottom: ${space[2]}px;
   }
   // Re-order the checkbox field and error message
   fieldset {

--- a/src/editorial-source-components/CustomDropdown.tsx
+++ b/src/editorial-source-components/CustomDropdown.tsx
@@ -16,6 +16,8 @@ const SelectWrapper = styled.div<{ display: "block" | "inline" }>`
     display: flex;
     :first-of-type {
       ${labelStyles}
+      margin-top: ${space[2]}px;
+      margin-bottom: ${space[2]}px;
     }
     svg {
       height: ${space[5]}px;
@@ -37,14 +39,14 @@ const SelectWrapper = styled.div<{ display: "block" | "inline" }>`
   ${({ display }) =>
     display === "inline" &&
     `
-    label { 
-      display: flex; 
-      align-items: center; 
+    label {
+      display: flex;
+      align-items: center;
       >div:first-child {
         margin-right: ${space[3]}px;
       }
-      /* 
-       * This resolves some margin problems introduced by 
+      /*
+       * This resolves some margin problems introduced by
        * restyling the Source Select component to be inline with its
        * label
        */

--- a/src/editorial-source-components/Error.tsx
+++ b/src/editorial-source-components/Error.tsx
@@ -1,15 +1,12 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { space, text } from "@guardian/src-foundations";
+import { text } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
 
 export const errorStyles = css`
   ${textSans.small({ lineHeight: "loose" })}
   font-family: "Guardian Agate Sans";
-  margin-top: ${space[2]}px;
-  margin-bottom: ${space[2]}px;
   display: block;
-  margin-left: auto;
   color: ${text.error};
 `;
 

--- a/src/editorial-source-components/InputHeading.tsx
+++ b/src/editorial-source-components/InputHeading.tsx
@@ -1,9 +1,19 @@
 import styled from "@emotion/styled";
+import { space } from "@guardian/src-foundations";
 import { Error } from "./Error";
 import { Label } from "./Label";
 
 const InputHeadingContainer = styled.div`
   display: flex;
+  flex-wrap: wrap;
+  margin-top: ${space[2]}px;
+  margin-bottom: ${space[2]}px;
+  label {
+    // Ensure that the label pushes error messages to the rhs
+    // if they occupy the same line, to ensure the error message
+    // is right-aligned.
+    flex-grow: 1;
+  }
 `;
 
 const Errors = ({ errors }: { errors: string[] }) =>

--- a/src/editorial-source-components/Label.tsx
+++ b/src/editorial-source-components/Label.tsx
@@ -1,13 +1,10 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { space } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
 
 export const labelStyles = css`
   ${textSans.small({ fontWeight: "bold", lineHeight: "loose" })}
   font-family: "Guardian Agate Sans";
-  margin-top: ${space[2]}px;
-  margin-bottom: ${space[2]}px;
   display: block;
 `;
 


### PR DESCRIPTION


## What does this change?

Allows error messages to wrap beneath labels when they exceed a single line.

Before:

<img width="443" alt="Screenshot 2021-09-09 at 11 18 24" src="https://user-images.githubusercontent.com/7767575/132668616-4e830d7e-3e7f-455d-a77a-25eb74a0238c.png">

After:

<img width="443" alt="Screenshot 2021-09-09 at 11 18 51" src="https://user-images.githubusercontent.com/7767575/132668628-1a5ac402-5690-4ded-b3fb-abd7bf303e64.png">

## How to test

Have a play with our elements. Do our error messages behave as expected? Is everything else as it should be?

## Dev notes

It'd be nice to specify elements programmatically (`${label} {` rather than `label {` in InputHeading), but we can't do that without adding a babel plugin. That's probably another PR.