### PR TITLE
fix: Image element layout changes

### DIFF
--- a/src/editorial-source-components/FieldWrapper.tsx
+++ b/src/editorial-source-components/FieldWrapper.tsx
@@ -8,7 +8,7 @@ import { InputHeading } from "./InputHeading";
 type Props<F> = {
   field: F;
   errors: ValidationError[];
-  label: string;
+  label: React.ReactNode;
   className?: string;
 };
 

--- a/src/editorial-source-components/InputHeading.tsx
+++ b/src/editorial-source-components/InputHeading.tsx
@@ -20,7 +20,7 @@ const Errors = ({ errors }: { errors: string[] }) =>
   !errors.length ? null : <Error>{errors.join(", ")}</Error>;
 
 type Props = {
-  label: string;
+  label: React.ReactNode;
   errors: string[];
 };
 

--- a/src/editorial-source-components/Label.tsx
+++ b/src/editorial-source-components/Label.tsx
@@ -6,6 +6,10 @@ export const labelStyles = css`
   ${textSans.small({ fontWeight: "bold", lineHeight: "loose" })}
   font-family: "Guardian Agate Sans";
   display: block;
+  // Ensure that the label pushes error messages to the rhs
+  // if they occupy the same line, to ensure the error message
+  // is right-aligned.
+  flex-grow: 1;
 `;
 
 export const Label = styled.label`

--- a/src/editorial-source-components/Label.tsx
+++ b/src/editorial-source-components/Label.tsx
@@ -6,10 +6,6 @@ export const labelStyles = css`
   ${textSans.small({ fontWeight: "bold", lineHeight: "loose" })}
   font-family: "Guardian Agate Sans";
   display: block;
-  // Ensure that the label pushes error messages to the rhs
-  // if they occupy the same line, to ensure the error message
-  // is right-aligned.
-  flex-grow: 1;
 `;
 
 export const Label = styled.label`

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -1,8 +1,10 @@
 import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+import { Button } from "@guardian/src-button";
+import { space } from "@guardian/src-foundations";
 import { SvgCamera } from "@guardian/src-icons";
 import { Column, Columns, Inline } from "@guardian/src-layout";
 import React from "react";
-import { Button } from "../../editorial-source-components/Button";
 import { Error } from "../../editorial-source-components/Error";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
 import type {
@@ -38,6 +40,10 @@ type ImageViewProps = {
   errors: ValidationError[];
   field: CustomField<MainImageData, MainImageProps>;
 };
+
+const AltText = styled.span`
+  margin-right: ${space[2]}px;
+`;
 
 export const ImageElementTestId = "ImageElement";
 
@@ -79,18 +85,20 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
           <FieldWrapper
             field={fields.altText}
             errors={errors.altText}
-            label="Alt text"
+            label={
+              <span>
+                <AltText>Alt text</AltText>
+                <Button
+                  priority="primary"
+                  size="xsmall"
+                  iconSide="left"
+                  onClick={() => fields.altText.update(fieldValues.caption)}
+                >
+                  Copy from caption
+                </Button>
+              </span>
+            }
           />
-        </span>
-        <span>
-          <Button
-            priority="primary"
-            size="xsmall"
-            iconSide="left"
-            onClick={() => fields.altText.update(fieldValues.caption)}
-          >
-            Copy from caption
-          </Button>
         </span>
         <Inline space={2}>
           <FieldWrapper

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -85,7 +85,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
               <span>
                 <AltText>Alt text</AltText>
                 <Button
-                  priority="primary"
+                  priority="secondary"
                   size="xsmall"
                   iconSide="left"
                   onClick={() => fields.altText.update(fieldValues.caption)}
@@ -164,7 +164,7 @@ const ImageView = ({ field, onChange, errors }: ImageViewProps) => {
         <img css={imageViewStysles} src={getImageSrc()} />
       </div>
       <Button
-        priority="primary"
+        priority="secondary"
         size="xsmall"
         icon={<SvgCamera />}
         iconSide="left"

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import { Button } from "@guardian/src-button";
 import { space } from "@guardian/src-foundations";
 import { SvgCamera } from "@guardian/src-icons";
-import { Column, Columns, Inline } from "@guardian/src-layout";
+import { Column, Columns } from "@guardian/src-layout";
 import React from "react";
 import { Error } from "../../editorial-source-components/Error";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
@@ -24,10 +24,6 @@ import type {
   MediaPayload,
   SetMedia,
 } from "./ImageElement";
-
-const inlineStyles = css`
-  width: 40%;
-`;
 
 type Props = {
   fieldValues: FieldNameToValueMap<ReturnType<typeof createImageFields>>;
@@ -100,20 +96,22 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
             }
           />
         </span>
-        <Inline space={2}>
-          <FieldWrapper
-            field={fields.photographer}
-            errors={errors.photographer}
-            label="Photographer"
-            css={inlineStyles}
-          />
-          <FieldWrapper
-            field={fields.source}
-            errors={errors.source}
-            label="Source"
-            css={inlineStyles}
-          />
-        </Inline>
+        <Columns>
+          <Column width={1 / 2}>
+            <FieldWrapper
+              field={fields.photographer}
+              errors={errors.photographer}
+              label="Photographer"
+            />
+          </Column>
+          <Column width={1 / 2}>
+            <FieldWrapper
+              field={fields.source}
+              errors={errors.source}
+              label="Source"
+            />
+          </Column>
+        </Columns>
         <CustomCheckboxView
           field={fields.displayCreditInformation}
           errors={errors.displayCreditInformation}

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -82,7 +82,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
             field={fields.altText}
             errors={errors.altText}
             label={
-              <span>
+              <>
                 <AltText>Alt text</AltText>
                 <Button
                   priority="secondary"
@@ -92,7 +92,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
                 >
                   Copy from caption
                 </Button>
-              </span>
+              </>
             }
           />
         </span>


### PR DESCRIPTION
## What does this change?

A few layout changes for the image element:

1) Moves the 'copy from altText' button inline with its label. 

To do this, I've changed the `label` prop to accept a`ReactNode`,  allowing us to pass arbitrary content in as a label. Because strings are `ReactNode`s, we can pass strings as usual.

2) Adjusts the photographer columns, which were not full width.

3) Changes buttons from 'primary' to 'secondary' to reflect [docs](https://theguardian.design/2a1e5182b/p/435225-button/b/86f344): 'use for actions that need to be clear, but aren’t the primary focus of a page.'

There are two more things that I think are worth changing:
- the 'weighting' field is not inline
- the spacing between 'alt text' and 'photographer' fields is not consistent (because flex/grid  elements [do not permit margin collapse](https://css-tricks.com/the-rules-of-margin-collapse/))

Both of these are difficult to solve without completely separating layout concerns from our elements (otherwise we're left struggling w/ 'first-child' style solutions, which don't play well w/ responsive layouts). This will be done in a separate PR, with an explanation.

Before:

<img width="1128" alt="Screenshot 2021-09-09 at 11 44 57" src="https://user-images.githubusercontent.com/7767575/132672685-7a8d0085-bd97-4ebd-b6e0-8db0df1d4f5e.png">

After:

<img width="967" alt="Screenshot 2021-09-09 at 12 07 41" src="https://user-images.githubusercontent.com/7767575/132675599-e465e559-3c75-4459-b3c1-d96d0270298f.png">

## How to test

Take a look at the layout. Does it reflect the screenshots above? Is there anything that's regressed in other elements?