### PR TITLE
fix: Add FieldVerticalLayout component and remove margins from inputs/labels

### DIFF
--- a/src/editorial-source-components/CustomCheckbox.tsx
+++ b/src/editorial-source-components/CustomCheckbox.tsx
@@ -10,8 +10,9 @@ const parentStyles = css`
   white-space: nowrap;
   div {
     ${labelStyles}
-    margin-top: ${space[2]}px;
-    margin-bottom: ${space[2]}px;
+  }
+  label {
+    min-height: initial;
   }
   // Re-order the checkbox field and error message
   fieldset {

--- a/src/editorial-source-components/CustomCheckbox.tsx
+++ b/src/editorial-source-components/CustomCheckbox.tsx
@@ -29,6 +29,7 @@ const checkboxGroupStyles = css`
   span {
     font-size: 0.9375rem;
     transform: scale(${scaleFactor}) rotate(45);
+    top: 5px;
     svg {
       height: ${space[6]}px;
       margin-top: 2px;

--- a/src/editorial-source-components/CustomDropdown.tsx
+++ b/src/editorial-source-components/CustomDropdown.tsx
@@ -16,8 +16,7 @@ const SelectWrapper = styled.div<{ display: "block" | "inline" }>`
     display: flex;
     :first-of-type {
       ${labelStyles}
-      margin-top: ${space[2]}px;
-      margin-bottom: ${space[2]}px;
+      ${({ display }) => display === "block" && `margin-bottom: ${space[2]}px;`}
     }
     svg {
       height: ${space[5]}px;
@@ -45,12 +44,6 @@ const SelectWrapper = styled.div<{ display: "block" | "inline" }>`
       >div:first-child {
         margin-right: ${space[3]}px;
       }
-      /*
-       * This resolves some margin problems introduced by
-       * restyling the Source Select component to be inline with its
-       * label
-       */
-      margin: -${space[2]}px 0;
     }`}
 `;
 

--- a/src/editorial-source-components/FieldWrapper.tsx
+++ b/src/editorial-source-components/FieldWrapper.tsx
@@ -2,7 +2,6 @@ import type { ValidationError } from "../plugin/elementSpec";
 import type { FieldView as TFieldView } from "../plugin/fieldViews/FieldView";
 import type { Field } from "../plugin/types/Element";
 import { FieldView } from "../renderers/react/FieldView";
-import { InputGroup } from "./InputGroup";
 import { InputHeading } from "./InputHeading";
 
 type Props<F> = {
@@ -18,8 +17,8 @@ export const FieldWrapper = <F extends Field<TFieldView<unknown>>>({
   label,
   className,
 }: Props<F>) => (
-  <InputGroup className={className}>
+  <div className={className}>
     <InputHeading label={label} errors={errors.map((e) => e.error)} />
-    <FieldView field={field} hasValidationErrors={errors.length >= 1} />
-  </InputGroup>
+    <FieldView field={field} hasValidationErrors={!!errors.length} />
+  </div>
 );

--- a/src/editorial-source-components/InputGroup.tsx
+++ b/src/editorial-source-components/InputGroup.tsx
@@ -1,6 +1,0 @@
-import styled from "@emotion/styled";
-import { space } from "@guardian/src-foundations";
-
-export const InputGroup = styled.div`
-  margin-bottom: ${space[3]}px;
-`;

--- a/src/editorial-source-components/InputHeading.tsx
+++ b/src/editorial-source-components/InputHeading.tsx
@@ -6,7 +6,6 @@ import { Label } from "./Label";
 const InputHeadingContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
-  margin-top: ${space[2]}px;
   margin-bottom: ${space[2]}px;
   label {
     // Ensure that the label pushes error messages to the rhs

--- a/src/editorial-source-components/Label.tsx
+++ b/src/editorial-source-components/Label.tsx
@@ -6,6 +6,10 @@ export const labelStyles = css`
   ${textSans.small({ fontWeight: "bold", lineHeight: "loose" })}
   font-family: "Guardian Agate Sans";
   display: block;
+  // Ensure that the label pushes error messages to the rhs
+  // if they occupy the same line, to ensure the error message
+  // is right-aligned.
+  flex-grow: 1;
 `;
 
 export const Label = styled.label`

--- a/src/editorial-source-components/Label.tsx
+++ b/src/editorial-source-components/Label.tsx
@@ -6,10 +6,6 @@ export const labelStyles = css`
   ${textSans.small({ fontWeight: "bold", lineHeight: "loose" })}
   font-family: "Guardian Agate Sans";
   display: block;
-  // Ensure that the label pushes error messages to the rhs
-  // if they occupy the same line, to ensure the error message
-  // is right-aligned.
-  flex-grow: 1;
 `;
 
 export const Label = styled.label`

--- a/src/editorial-source-components/VerticalFieldLayout.tsx
+++ b/src/editorial-source-components/VerticalFieldLayout.tsx
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+import { space } from "@guardian/src-foundations";
+
+export const FieldLayoutVertical = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${space[3]}px;
+`;

--- a/src/elements/code/CodeElementForm.tsx
+++ b/src/elements/code/CodeElementForm.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
 import type { FieldValidationErrors } from "../../plugin/elementSpec";
 import type { FieldNameToField } from "../../plugin/types/Element";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
@@ -16,12 +17,12 @@ export const CodeElementForm: React.FunctionComponent<Props> = ({
   errors,
   fields,
 }) => (
-  <div data-cy={CodeElementTestId}>
+  <FieldLayoutVertical data-cy={CodeElementTestId}>
     <FieldWrapper label="Code" field={fields.html} errors={errors.html} />
     <CustomDropdownView
       label="Language"
       field={fields.language}
       display="inline"
     />
-  </div>
+  </FieldLayoutVertical>
 );

--- a/src/elements/demo-image/DemoImageElementForm.tsx
+++ b/src/elements/demo-image/DemoImageElementForm.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
 import { Label } from "../../editorial-source-components/Label";
+import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
 import type { FieldValidationErrors } from "../../plugin/elementSpec";
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
 import type { CustomField, FieldNameToField } from "../../plugin/types/Element";
@@ -23,7 +24,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
   errors,
   fieldValues,
 }) => (
-  <div data-cy={ImageElementTestId}>
+  <FieldLayoutVertical data-cy={ImageElementTestId}>
     <FieldWrapper
       label="Caption"
       field={fields.caption}
@@ -71,7 +72,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
     <hr />
     <Label>Element values</Label>
     <pre>{JSON.stringify(fieldValues)}</pre>
-  </div>
+  </FieldLayoutVertical>
 );
 
 type ImageViewProps = {

--- a/src/elements/embed/EmbedForm.tsx
+++ b/src/elements/embed/EmbedForm.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
 import type { FieldValidationErrors } from "../../plugin/elementSpec";
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
 import type { FieldNameToField } from "../../plugin/types/Element";
@@ -19,7 +20,7 @@ export const EmbedElementForm: React.FunctionComponent<Props> = ({
   errors,
   fields,
 }) => (
-  <div data-cy={EmbedElementTestId}>
+  <FieldLayoutVertical data-cy={EmbedElementTestId}>
     <CustomDropdownView
       field={fields.weighting}
       label="Weighting"
@@ -50,5 +51,5 @@ export const EmbedElementForm: React.FunctionComponent<Props> = ({
       errors={errors.required}
       label="This element is required for publication"
     />
-  </div>
+  </FieldLayoutVertical>
 );

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -7,6 +7,7 @@ import { Column, Columns } from "@guardian/src-layout";
 import React from "react";
 import { Error } from "../../editorial-source-components/Error";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
 import type {
   FieldValidationErrors,
   ValidationError,
@@ -51,33 +52,35 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
   <div data-cy={ImageElementTestId}>
     <Columns>
       <Column width={2 / 5}>
-        <CustomDropdownView
-          field={fields.weighting}
-          label="Weighting"
-          errors={errors.weighting}
-        />
-        <ImageView
-          field={fields.mainImage}
-          onChange={({ caption, source, photographer }) => {
-            fields.caption.update(caption);
-            fields.source.update(source);
-            fields.photographer.update(photographer);
-          }}
-          errors={errors.mainImage}
-        />
-        <CustomDropdownView
-          field={fields.imageType}
-          label={"Image type"}
-          errors={errors.imageType}
-        />
+        <FieldLayoutVertical>
+          <CustomDropdownView
+            field={fields.weighting}
+            label="Weighting"
+            errors={errors.weighting}
+          />
+          <ImageView
+            field={fields.mainImage}
+            onChange={({ caption, source, photographer }) => {
+              fields.caption.update(caption);
+              fields.source.update(source);
+              fields.photographer.update(photographer);
+            }}
+            errors={errors.mainImage}
+          />
+          <CustomDropdownView
+            field={fields.imageType}
+            label={"Image type"}
+            errors={errors.imageType}
+          />
+        </FieldLayoutVertical>
       </Column>
       <Column width={3 / 5}>
-        <FieldWrapper
-          field={fields.caption}
-          errors={errors.caption}
-          label="Caption"
-        />
-        <span>
+        <FieldLayoutVertical>
+          <FieldWrapper
+            field={fields.caption}
+            errors={errors.caption}
+            label="Caption"
+          />
           <FieldWrapper
             field={fields.altText}
             errors={errors.altText}
@@ -85,7 +88,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
               <>
                 <AltText>Alt text</AltText>
                 <Button
-                  priority="primary"
+                  priority="secondary"
                   size="xsmall"
                   iconSide="left"
                   onClick={() => fields.altText.update(fieldValues.caption)}
@@ -95,28 +98,28 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
               </>
             }
           />
-        </span>
-        <Columns>
-          <Column width={1 / 2}>
-            <FieldWrapper
-              field={fields.photographer}
-              errors={errors.photographer}
-              label="Photographer"
-            />
-          </Column>
-          <Column width={1 / 2}>
-            <FieldWrapper
-              field={fields.source}
-              errors={errors.source}
-              label="Source"
-            />
-          </Column>
-        </Columns>
-        <CustomCheckboxView
-          field={fields.displayCreditInformation}
-          errors={errors.displayCreditInformation}
-          label="Display credit information"
-        />
+          <Columns>
+            <Column width={1 / 2}>
+              <FieldWrapper
+                field={fields.photographer}
+                errors={errors.photographer}
+                label="Photographer"
+              />
+            </Column>
+            <Column width={1 / 2}>
+              <FieldWrapper
+                field={fields.source}
+                errors={errors.source}
+                label="Source"
+              />
+            </Column>
+          </Columns>
+          <CustomCheckboxView
+            field={fields.displayCreditInformation}
+            errors={errors.displayCreditInformation}
+            label="Display credit information"
+          />
+        </FieldLayoutVertical>
       </Column>
     </Columns>
   </div>
@@ -158,7 +161,7 @@ const ImageView = ({ field, onChange, errors }: ImageViewProps) => {
   };
 
   return (
-    <>
+    <div>
       <Errors errors={errors.map((e) => e.error)} />
       <div>
         <img css={imageViewStysles} src={getImageSrc()} />
@@ -177,6 +180,6 @@ const ImageView = ({ field, onChange, errors }: ImageViewProps) => {
       >
         Re-crop image
       </Button>
-    </>
+    </div>
   );
 };

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -85,7 +85,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
               <>
                 <AltText>Alt text</AltText>
                 <Button
-                  priority="secondary"
+                  priority="primary"
                   size="xsmall"
                   iconSide="left"
                   onClick={() => fields.altText.update(fieldValues.caption)}

--- a/src/elements/pullquote/PullquoteForm.tsx
+++ b/src/elements/pullquote/PullquoteForm.tsx
@@ -1,6 +1,7 @@
 import { Column, Columns } from "@guardian/src-layout";
 import React from "react";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
 import type { FieldValidationErrors } from "../../plugin/elementSpec";
 import type { FieldNameToField } from "../../plugin/types/Element";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
@@ -27,12 +28,14 @@ export const PullquoteElementForm: React.FunctionComponent<Props> = ({
         />
       </Column>
       <Column width={1 / 3}>
-        <FieldWrapper
-          label="Attribution"
-          field={fields.attribution}
-          errors={errors.attribution}
-        />
-        <CustomDropdownView label="Weighting" field={fields.role} />
+        <FieldLayoutVertical>
+          <FieldWrapper
+            label="Attribution"
+            field={fields.attribution}
+            errors={errors.attribution}
+          />
+          <CustomDropdownView label="Weighting" field={fields.role} />
+        </FieldLayoutVertical>
       </Column>
     </Columns>
   </div>

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -38,8 +38,7 @@ const Panel = styled("div")`
   background: ${neutral[97]};
   flex-grow: 1;
   overflow: hidden;
-  padding-left: ${space[3]}px;
-  padding-right: ${space[3]}px;
+  padding: ${space[3]}px;
 `;
 
 const Button = styled("button")<{ expanded?: boolean }>`

--- a/src/renderers/react/customFieldViewComponents/CustomDropdownView.tsx
+++ b/src/renderers/react/customFieldViewComponents/CustomDropdownView.tsx
@@ -1,5 +1,4 @@
 import { CustomDropdown } from "../../../editorial-source-components/CustomDropdown";
-import { InputGroup } from "../../../editorial-source-components/InputGroup";
 import type { ValidationError } from "../../../plugin/elementSpec";
 import type { Options } from "../../../plugin/fieldViews/DropdownFieldView";
 import type { CustomField } from "../../../plugin/types/Element";
@@ -21,18 +20,16 @@ export const CustomDropdownView = ({
 }: CustomDropdownViewProps) => {
   const [selectedElement, setSelectedElement] = useCustomFieldState(field);
   return (
-    <InputGroup>
-      <CustomDropdown
-        display={display}
-        options={field.description.props}
-        selected={selectedElement}
-        label={label}
-        onChange={(event) => {
-          setSelectedElement(event.target.value);
-        }}
-        error={errors.map((e) => e.error).join(", ")}
-        dataCy={getFieldViewTestId(field.name)}
-      />
-    </InputGroup>
+    <CustomDropdown
+      display={display}
+      options={field.description.props}
+      selected={selectedElement}
+      label={label}
+      onChange={(event) => {
+        setSelectedElement(event.target.value);
+      }}
+      error={errors.map((e) => e.error).join(", ")}
+      dataCy={getFieldViewTestId(field.name)}
+    />
   );
 };


### PR DESCRIPTION
## What does this change?

Adds a layout component to take care of spacing our fields vertically.

This was previously done with margins, which mostly worked – but because `flex` doesn't permit [margin-collapse](https://css-tricks.com/the-rules-of-margin-collapse/), we had a problem with fields meeting flex containers.

A single component in charge of vertical spacing makes easier to make global adjustments to layout.

Here's a fun spot-the-difference that I've ruined for everyone! 

Before:

<img width="967" alt="Screenshot 2021-09-09 at 12 07 41" src="https://user-images.githubusercontent.com/7767575/132681310-b2a506a1-61fa-4e93-ae79-87dd1ba99e08.png">

After: 

<img width="1193" alt="Screenshot 2021-09-09 at 12 46 16" src="https://user-images.githubusercontent.com/7767575/132681135-6b9f2134-2b0e-499e-b469-8ae2dca43e79.png">


## How to test

Besides the small change in the before/after, this should be a no-op. Do all the elements look as they should?

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [x] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
