### PR TITLE
refactor: Removes the hasErrors function and state as it's no longer needed

### DIFF
--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -138,7 +138,7 @@ export const getSerialisedHtml = ({
           mainImageValue.mediaApiUri ?? "undefined"
         }&quot;,&quot;assets&quot;${mainImageValue.assets}`
       : `&quot;assets&quot;:[]`;
-  return trimHtml(`<div pme-element-type="demoImageElement" has-errors="false">
+  return trimHtml(`<div pme-element-type="demoImageElement">
     <div pme-field-name="demoImageElement_altText">${altTextValue}</div>
     <div pme-field-name="demoImageElement_caption">${captionValue}</div>
     <div pme-field-name="demoImageElement_code">${codeValue}</div>

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -43,12 +43,7 @@ type Name =
   | typeof codeElementName
   | typeof pullquoteElementName;
 
-const {
-  plugin: elementPlugin,
-  insertElement,
-  hasErrors,
-  nodeSpec,
-} = buildElementPlugin({
+const { plugin: elementPlugin, insertElement, nodeSpec } = buildElementPlugin({
   demoImageElement: createDemoImageElement(onSelectImage, onDemoCropImage),
   imageElement: createImageElement(onCropImage),
   embedElement: createEmbedElement(),
@@ -75,12 +70,6 @@ const editorsContainer = document.querySelector("#editor-container");
 if (!editorsContainer) {
   throw new Error("No #editor element present in DOM");
 }
-
-const highlightErrors = (state: EditorState) => {
-  document.body.style.backgroundColor = hasErrors(state)
-    ? "red"
-    : "transparent";
-};
 
 const get = () => {
   const state = window.localStorage.getItem("pm");
@@ -136,8 +125,6 @@ const createEditor = (server: CollabServer) => {
   if (!isFirstEditor) {
     firstEditor = view;
   }
-
-  highlightErrors(view.state);
 
   const createElementButton = (
     buttonText: string,
@@ -216,7 +203,6 @@ const createEditor = (server: CollabServer) => {
   );
 
   new EditorConnection(view, server, clientID, `User ${clientID}`, (state) => {
-    highlightErrors(state);
     if (isFirstEditor) {
       set(state.doc);
     }

--- a/src/editorial-source-components/Editor.ts
+++ b/src/editorial-source-components/Editor.ts
@@ -1,15 +1,14 @@
 import styled from "@emotion/styled";
-import { background, border } from "@guardian/src-foundations";
+import { background } from "@guardian/src-foundations";
 import { focusHalo } from "@guardian/src-foundations/accessibility";
 import { body } from "@guardian/src-foundations/typography";
 import { inputBorder } from "./inputBorder";
 
-export const Editor = styled.div<{ hasErrors: boolean }>`
+export const Editor = styled.div`
   ${body.small()}
   .ProseMirror {
     background-color: ${background.primary};
     ${inputBorder}
-    ${({ hasErrors }) => !!hasErrors && `border-color: ${border.error};`}
     &:active {
       border: 1px solid ${background.inputChecked};
     }

--- a/src/editorial-source-components/FieldWrapper.tsx
+++ b/src/editorial-source-components/FieldWrapper.tsx
@@ -20,6 +20,6 @@ export const FieldWrapper = <F extends Field<TFieldView<unknown>>>({
 }: Props<F>) => (
   <InputGroup className={className}>
     <InputHeading label={label} errors={errors.map((e) => e.error)} />
-    <FieldView field={field} hasErrors={!!errors.length} />
+    <FieldView field={field} />
   </InputGroup>
 );

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -208,7 +208,7 @@ describe("buildElementPlugin", () => {
       );
 
       const expected = trimHtml(`
-        <div pme-element-type="testElement" has-errors="false">
+        <div pme-element-type="testElement">
           <div pme-field-name="testElement_field1" fields="false"></div>
           <div pme-field-name="testElement_field2"><p>Content</p></div>
         </div>`);
@@ -231,7 +231,7 @@ describe("buildElementPlugin", () => {
       })(view.state, view.dispatch);
 
       const expected = trimHtml(`
-        <div pme-element-type="testElement" has-errors="false">
+        <div pme-element-type="testElement">
           <div pme-field-name="testElement_field1" fields="true"></div>
         </div>`);
       expect(getElementAsHTML()).toBe(expected);
@@ -253,7 +253,7 @@ describe("buildElementPlugin", () => {
       })(view.state, view.dispatch);
 
       const expected = trimHtml(`
-        <div pme-element-type="testElement" has-errors="false">
+        <div pme-element-type="testElement">
           <div pme-field-name="testElement_field1"><p>Content</p></div>
         </div>`);
       expect(getElementAsHTML()).toBe(expected);
@@ -279,7 +279,7 @@ describe("buildElementPlugin", () => {
       })(view.state, view.dispatch);
 
       const expected = trimHtml(`
-        <div pme-element-type="testElement" has-errors="false">
+        <div pme-element-type="testElement">
           <div pme-field-name="testElement_field1"><p>Content for field1</p></div>
           <div pme-field-name="testElement_field2"><p>Content for field2</p></div>
         </div>`);
@@ -305,7 +305,7 @@ describe("buildElementPlugin", () => {
       })(view.state, view.dispatch);
 
       const expected = trimHtml(`
-        <div pme-element-type="testElement" has-errors="false">
+        <div pme-element-type="testElement">
           <div pme-field-name="testElement_field1" fields="{&quot;arbitraryValue&quot;:&quot;hai&quot;}"></div>
         </div>`);
       expect(getElementAsHTML()).toBe(expected);
@@ -314,7 +314,7 @@ describe("buildElementPlugin", () => {
 
   describe("Serialisation/deserialisation", () => {
     const testElementHTML = `
-          <div pme-element-type="testElement" has-errors="false">
+          <div pme-element-type="testElement">
           <div pme-field-name="testElement_field1"><p></p></div>
           <div pme-field-name="testElement_field2"></div>
           <div pme-field-name="testElement_field3" fields="true"></div>
@@ -322,14 +322,14 @@ describe("buildElementPlugin", () => {
         `;
 
     const testElement2HTML = `
-        <div pme-element-type="testElement2" has-errors="false">
+        <div pme-element-type="testElement2">
         <div pme-field-name="testElement_field4"><p></p></div>
         <div pme-field-name="testElement_field5"></div>
         </div2>
       `;
 
     const testElementTransformHTML = `
-      <div pme-element-type="testElementWithTransform" has-errors="false">
+      <div pme-element-type="testElementWithTransform">
       <element-testelementwithtransform-field1 pme-field-name="testElement_field1"><p></p></element-testelementwithtransform-field1>
       </div2>
     `;
@@ -436,7 +436,7 @@ describe("buildElementPlugin", () => {
     describe("Element parsing", () => {
       it("should parse fields of all types, respecting values against defaults", () => {
         const elementHTML = `
-          <div pme-element-type="testElement" has-errors="false">
+          <div pme-element-type="testElement">
           <div pme-field-name="testElement_field1"><p>Content</p></div>
           <div pme-field-name="testElement_field2">Content</div>
           <div pme-field-name="testElement_field3" fields="true"></div>
@@ -453,7 +453,7 @@ describe("buildElementPlugin", () => {
 
       it("should parse fields of all types, handling empty content values correctly", () => {
         const elementHTML = `
-          <div pme-element-type="testElement" has-errors="false">
+          <div pme-element-type="testElement">
           <div pme-field-name="testElement_field1"><p></p></div>
           <div pme-field-name="testElement_field2"></div>
           <div pme-field-name="testElement_field3" fields="true"></div>

--- a/src/plugin/element.ts
+++ b/src/plugin/element.ts
@@ -64,7 +64,6 @@ export const buildElementPlugin = <
 
   return {
     insertElement,
-    hasErrors: (state: EditorState) => plugin.getState(state).hasErrors,
     plugin,
     nodeSpec,
     getElementDataFromNode,

--- a/src/plugin/elementSpec.ts
+++ b/src/plugin/elementSpec.ts
@@ -75,7 +75,7 @@ export const createElementSpec = <
       validate,
       dom,
       fields,
-      (fields) => updateState(fields, !!validate(fields)),
+      (fields) => updateState(fields),
       fieldValues,
       commands,
       updater.subscribe

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -44,9 +44,6 @@ const getNodeSpecForElement = (
       addUpdateDecoration: {
         default: true,
       },
-      hasErrors: {
-        default: false,
-      },
     },
     draggable: false,
     toDOM: (node: Node) => [
@@ -54,7 +51,6 @@ const getNodeSpecForElement = (
       {
         [elementTypeAttr]: node.attrs.type as string,
         fields: JSON.stringify(node.attrs.fields),
-        "has-errors": JSON.stringify(node.attrs.hasErrors),
       },
       0,
     ],
@@ -67,12 +63,9 @@ const getNodeSpecForElement = (
             return false;
           }
 
-          const hasErrorAttr = dom.getAttribute("has-errors");
-
           return {
             type: elementName,
             fields: JSON.parse(dom.getAttribute("fields") ?? "{}") as unknown,
-            hasErrors: hasErrorAttr && hasErrorAttr !== "false",
           };
         },
       },
@@ -187,7 +180,6 @@ const getDefaultToDOMForLeafNode = (nodeName: string) => (node: Node) => [
   {
     [fieldNameAttr]: nodeName,
     fields: JSON.stringify(node.attrs.fields),
-    "has-errors": JSON.stringify(node.attrs.hasErrors),
   },
 ];
 

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -16,7 +16,7 @@ import { getFieldNameFromNode } from "./nodeSpec";
 const decorations = createUpdateDecorations();
 const pluginKey = new PluginKey("prosemirror_elements");
 
-export type PluginState = { hasErrors: boolean };
+export type PluginState = unknown;
 
 export const createPlugin = <
   ElementNames extends string,
@@ -28,32 +28,8 @@ export const createPlugin = <
   },
   commands: Commands
 ): Plugin<PluginState, Schema> => {
-  type ElementNode = Node<Schema>;
-
-  const hasErrors = (doc: Node) => {
-    let foundError = false;
-    doc.descendants((node: ElementNode) => {
-      if (!foundError) {
-        if (node.type.name === "element") {
-          foundError = node.attrs.hasErrors as boolean;
-        }
-      } else {
-        return false;
-      }
-    });
-    return foundError;
-  };
-
   return new Plugin<PluginState, Schema>({
     key: pluginKey,
-    state: {
-      init: (_, state) => ({
-        hasErrors: hasErrors(state.doc),
-      }),
-      apply: (_tr, _value, _oldState, state) => ({
-        hasErrors: hasErrors(state.doc),
-      }),
-    },
     props: {
       decorations,
       nodeViews: createNodeViews(
@@ -162,12 +138,11 @@ const createNodeView = <
   const update = element.createUpdator(
     dom,
     fields,
-    (fields, hasErrors) => {
+    (fields) => {
       view.dispatch(
         view.state.tr.setNodeMarkup(getPos(), undefined, {
           ...initNode.attrs,
           fields,
-          hasErrors,
         })
       );
     },

--- a/src/plugin/types/Element.ts
+++ b/src/plugin/types/Element.ts
@@ -98,10 +98,7 @@ export type ElementSpec<
   createUpdator: (
     dom: HTMLElement,
     fields: FieldNameToField<FDesc>,
-    updateState: (
-      fields: FieldNameToValueMap<FDesc>,
-      hasErrors: boolean
-    ) => void,
+    updateState: (fields: FieldNameToValueMap<FDesc>) => void,
     initFields: FieldNameToValueMap<FDesc>,
     commands: ReturnType<CommandCreator>
   ) => (

--- a/src/renderers/react/FieldView.tsx
+++ b/src/renderers/react/FieldView.tsx
@@ -5,14 +5,12 @@ import type { Field } from "../../plugin/types/Element";
 
 type Props<F extends Field<unknown>> = {
   field: F;
-  hasErrors?: boolean;
 };
 
 export const getFieldViewTestId = (name: string) => `FieldView-${name}`;
 
 export const FieldView = <F extends Field<TFieldView<unknown>>>({
   field,
-  hasErrors = false,
 }: Props<F>) => {
   const editorRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -23,10 +21,6 @@ export const FieldView = <F extends Field<TFieldView<unknown>>>({
   }, []);
 
   return (
-    <Editor
-      hasErrors={hasErrors}
-      data-cy={getFieldViewTestId(field.name)}
-      ref={editorRef}
-    ></Editor>
+    <Editor data-cy={getFieldViewTestId(field.name)} ref={editorRef}></Editor>
   );
 };


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR removes the `hasErrors` state and function as it has now been usurped by the validator function.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This should be a no-op but make the code cleaner by removing redundant code.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
The code is easier to work with, in accordance with our vision document.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Is there any chance we may need this?

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [x] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
