### PR TITLE
fix: Prevents validators from throwing errors and allow undefined

### DIFF
--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -26,17 +26,25 @@ export const htmlMaxLength = (
   maxLength: number,
   customMessage: string | undefined = undefined
 ): Validator => (value, field) => {
-  if (typeof value !== "string") {
-    throw new Error(`[htmlMaxLength]: value is not of type string`);
-  }
-  const el = document.createElement("div");
-  el.innerHTML = value;
-  if (el.innerText.length > maxLength) {
+  if (typeof value !== "string" && value !== undefined) {
+    const typeError = `[htmlMaxLength]: value is not of type string`;
     return [
       {
-        error: `Too long: ${value.length}/${maxLength}`,
+        message: typeError,
+        error: typeError,
+      },
+    ];
+  }
+
+  const el = document.createElement("div");
+  el.innerHTML = value ?? "";
+  const length = el.innerText.length;
+  if (length > maxLength) {
+    return [
+      {
+        error: `Too long: ${length}/${maxLength}`,
         message:
-          customMessage ?? `${field} is too long: ${value.length}/${maxLength}`,
+          customMessage ?? `${field} is too long: ${length}/${maxLength}`,
       },
     ];
   }
@@ -47,15 +55,22 @@ export const maxLength = (
   maxLength: number,
   customMessage: string | undefined = undefined
 ): Validator => (value, field) => {
-  if (typeof value !== "string") {
-    throw new Error(`[maxLength]: value is not of type string`);
-  }
-  if (value.length > maxLength) {
+  if (typeof value !== "string" && value !== undefined) {
+    const typeError = `[maxLength]: value is not of type string`;
     return [
       {
-        error: `Too long: ${value.length}/${maxLength}`,
+        message: typeError,
+        error: typeError,
+      },
+    ];
+  }
+  const length = (value ?? "").length;
+  if (length > maxLength) {
+    return [
+      {
+        error: `Too long: ${length}/${maxLength}`,
         message:
-          customMessage ?? `${field} is too long: ${value.length}/${maxLength}`,
+          customMessage ?? `${field} is too long: ${length}/${maxLength}`,
       },
     ];
   }
@@ -65,11 +80,17 @@ export const maxLength = (
 export const htmlRequired = (
   customMessage: string | undefined = undefined
 ): Validator => (value, field) => {
-  if (typeof value !== "string") {
-    throw new Error(`[maxLength]: value is not of type string`);
+  if (typeof value !== "string" && value !== undefined) {
+    const typeError = `[maxLength]: value is not of type string`;
+    return [
+      {
+        message: typeError,
+        error: typeError,
+      },
+    ];
   }
   const el = document.createElement("div");
-  el.innerHTML = value;
+  el.innerHTML = value ?? "";
   if (!el.innerText.length) {
     return [
       { error: "Required", message: customMessage ?? `${field} is required` },
@@ -81,10 +102,17 @@ export const htmlRequired = (
 export const required = (
   customMessage: string | undefined = undefined
 ): Validator => (value, field) => {
-  if (typeof value !== "string") {
-    throw new Error(`[maxLength]: value is not of type string`);
+  if (typeof value !== "string" && value !== undefined) {
+    const typeError = `[maxLength]: value is not of type string`;
+    return [
+      {
+        message: typeError,
+        error: typeError,
+      },
+    ];
   }
-  if (!value.length) {
+  const length = (value ?? "").length;
+  if (!length) {
     return [
       { error: "Required", message: customMessage ?? `${field} is required` },
     ];

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -27,7 +27,7 @@ export const htmlMaxLength = (
   customMessage: string | undefined = undefined
 ): Validator => (value, field) => {
   if (typeof value !== "string" && value !== undefined) {
-    const typeError = `[htmlMaxLength]: value is not of type string`;
+    const typeError = `html max length check: ${field} value is incorrect`;
     return [
       {
         message: typeError,
@@ -56,7 +56,7 @@ export const maxLength = (
   customMessage: string | undefined = undefined
 ): Validator => (value, field) => {
   if (typeof value !== "string" && value !== undefined) {
-    const typeError = `[maxLength]: value is not of type string`;
+    const typeError = `max length check: ${field} value is incorrect`;
     return [
       {
         message: typeError,
@@ -81,7 +81,7 @@ export const htmlRequired = (
   customMessage: string | undefined = undefined
 ): Validator => (value, field) => {
   if (typeof value !== "string" && value !== undefined) {
-    const typeError = `[maxLength]: value is not of type string`;
+    const typeError = `required check: ${field} value is incorrect`;
     return [
       {
         message: typeError,
@@ -103,7 +103,7 @@ export const required = (
   customMessage: string | undefined = undefined
 ): Validator => (value, field) => {
   if (typeof value !== "string" && value !== undefined) {
-    const typeError = `[maxLength]: value is not of type string`;
+    const typeError = `required check: ${field} value is incorrect`;
     return [
       {
         message: typeError,


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR makes the validators more tolerant of different types and changes the paradigm to not throw exceptions of the types don't match what's expected. 

This should make the validators easier to work with in Composer where the shape of elements may differ slightly from PME spec.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This should be a no-op functionally but make the validators easier to work with in Composer.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Validators accept shapes which don't entirely match but still produce useful errors.

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [x] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
