### PR TITLE
fix: Fixes validation error border on fields

### DIFF
--- a/src/editorial-source-components/Editor.ts
+++ b/src/editorial-source-components/Editor.ts
@@ -1,14 +1,16 @@
 import styled from "@emotion/styled";
-import { background } from "@guardian/src-foundations";
+import { background, border } from "@guardian/src-foundations";
 import { focusHalo } from "@guardian/src-foundations/accessibility";
 import { body } from "@guardian/src-foundations/typography";
 import { inputBorder } from "./inputBorder";
 
-export const Editor = styled.div`
+export const Editor = styled.div<{ hasValidationErrors: boolean }>`
   ${body.small()}
   .ProseMirror {
     background-color: ${background.primary};
     ${inputBorder}
+    ${({ hasValidationErrors }) =>
+      !!hasValidationErrors && `border-color: ${border.error};`}
     &:active {
       border: 1px solid ${background.inputChecked};
     }

--- a/src/editorial-source-components/FieldWrapper.tsx
+++ b/src/editorial-source-components/FieldWrapper.tsx
@@ -20,6 +20,6 @@ export const FieldWrapper = <F extends Field<TFieldView<unknown>>>({
 }: Props<F>) => (
   <InputGroup className={className}>
     <InputHeading label={label} errors={errors.map((e) => e.error)} />
-    <FieldView field={field} />
+    <FieldView field={field} hasValidationErrors={errors.length >= 1} />
   </InputGroup>
 );

--- a/src/renderers/react/FieldView.tsx
+++ b/src/renderers/react/FieldView.tsx
@@ -5,12 +5,14 @@ import type { Field } from "../../plugin/types/Element";
 
 type Props<F extends Field<unknown>> = {
   field: F;
+  hasValidationErrors: boolean;
 };
 
 export const getFieldViewTestId = (name: string) => `FieldView-${name}`;
 
 export const FieldView = <F extends Field<TFieldView<unknown>>>({
   field,
+  hasValidationErrors,
 }: Props<F>) => {
   const editorRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -21,6 +23,10 @@ export const FieldView = <F extends Field<TFieldView<unknown>>>({
   }, []);
 
   return (
-    <Editor data-cy={getFieldViewTestId(field.name)} ref={editorRef}></Editor>
+    <Editor
+      data-cy={getFieldViewTestId(field.name)}
+      hasValidationErrors={hasValidationErrors}
+      ref={editorRef}
+    ></Editor>
   );
 };


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR fixes a regression introduced by #111, which removed the red border from field when an error is found.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Add an element with validation, if the validation fails, does the field highlight red?

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
