### PR TITLE
fix: Update property names to match interface expected by Composer (again)

### DIFF
--- a/src/elements/pullquote/PullquoteForm.tsx
+++ b/src/elements/pullquote/PullquoteForm.tsx
@@ -22,8 +22,8 @@ export const PullquoteElementForm: React.FunctionComponent<Props> = ({
       <Column width={2 / 3}>
         <FieldWrapper
           label="Pullquote"
-          field={fields.pullquote}
-          errors={errors.pullquote}
+          field={fields.html}
+          errors={errors.html}
         />
       </Column>
       <Column width={1 / 3}>
@@ -32,7 +32,7 @@ export const PullquoteElementForm: React.FunctionComponent<Props> = ({
           field={fields.attribution}
           errors={errors.attribution}
         />
-        <CustomDropdownView label="Weighting" field={fields.weighting} />
+        <CustomDropdownView label="Weighting" field={fields.role} />
       </Column>
     </Columns>
   </div>

--- a/src/elements/pullquote/PullquoteSpec.tsx
+++ b/src/elements/pullquote/PullquoteSpec.tsx
@@ -6,9 +6,9 @@ import { createReactElementSpec } from "../../renderers/react/createReactElement
 import { PullquoteElementForm } from "./PullquoteForm";
 
 export const pullquoteFields = {
-  pullquote: createTextField({ isMultiline: true, rows: 4 }),
+  html: createTextField({ isMultiline: true, rows: 4 }),
   attribution: createTextField(),
-  weighting: createCustomDropdownField("supporting", [
+  role: createCustomDropdownField("supporting", [
     { text: "supporting (default)", value: "supporting" },
     { text: "inline", value: "inline" },
     { text: "showcase", value: "showcase" },


### PR DESCRIPTION
Repeating as first change did not give semantic commit message.

Co-authored by @dskamiotis 

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Update's the Pullquote element's property names to match those expected by Composer.

This should be a no-op in Prosemirror-Elements, but will allow the element to function properly in Composer.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run `yarn start` from the repository root.