### PR TITLE
feat: Move validation into field descriptions

### DIFF
--- a/src/elements/code/CodeElementSpec.tsx
+++ b/src/elements/code/CodeElementSpec.tsx
@@ -1,12 +1,16 @@
 import React from "react";
 import { createCustomDropdownField } from "../../plugin/fieldViews/CustomFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
-import { createValidator, required } from "../../plugin/helpers/validation";
+import { required } from "../../plugin/helpers/validation";
 import { createGuElementSpec } from "../createGuElementSpec";
 import { CodeElementForm } from "./CodeElementForm";
 
 export const codeFields = {
-  html: createTextField({ isMultiline: true, rows: 4 }, true),
+  html: createTextField({
+    multilineOptions: { isMultiline: true, rows: 4 },
+    isCode: true,
+    validators: [required("empty code field")],
+  }),
   language: createCustomDropdownField("text", [
     { text: "Plain text", value: "text" },
     { text: "HTML", value: "html" },
@@ -23,6 +27,5 @@ export const codeElement = createGuElementSpec(
   codeFields,
   (_, errors, __, fields) => {
     return <CodeElementForm errors={errors} fields={fields} />;
-  },
-  createValidator({ html: [required("empty code field")] })
+  }
 );

--- a/src/elements/createGuElementSpec.ts
+++ b/src/elements/createGuElementSpec.ts
@@ -20,7 +20,7 @@ type FlexibleModelElement<FDesc extends FieldDescriptions<string>> = {
 export const createGuElementSpec = <FDesc extends FieldDescriptions<string>>(
   FieldDescriptions: FDesc,
   consumer: Consumer<ReactElement, FDesc>,
-  validate: Validator<FDesc>,
+  validate: Validator<FDesc> | undefined = undefined,
   isMandatory?: boolean
 ) => {
   return createReactElementSpec(FieldDescriptions, consumer, validate, {

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -49,9 +49,14 @@ export const createImageFields = (
         marks: "em",
       },
     }),
-    altText: createTextField({ isMultiline: true, rows: 2 }),
+    altText: createTextField({
+      multilineOptions: { isMultiline: true, rows: 2 },
+    }),
     src: createTextField(),
-    code: createTextField({ isMultiline: true, rows: 4 }, true),
+    code: createTextField({
+      multilineOptions: { isMultiline: true, rows: 4 },
+      isCode: true,
+    }),
     mainImage: createCustomField<ImageField, ImageProps>(
       { mediaId: undefined, mediaApiUri: undefined, assets: [] },
       {

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -11,11 +11,7 @@ import {
   createFlatRichTextField,
 } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
-import {
-  createValidator,
-  htmlMaxLength,
-  htmlRequired,
-} from "../../plugin/helpers/validation";
+import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { ImageElementForm } from "./DemoImageElementForm";
 
@@ -42,7 +38,7 @@ export const createImageFields = (
   onCropImage: (mediaId: string, setMedia: DemoSetMedia) => void
 ) => {
   return {
-    caption: createDefaultRichTextField(),
+    caption: createDefaultRichTextField([htmlRequired()]),
     restrictedTextField: createFlatRichTextField({
       createPlugins: (schema) => exampleSetup({ schema }),
       nodeSpec: {
@@ -51,6 +47,7 @@ export const createImageFields = (
     }),
     altText: createTextField({
       multilineOptions: { isMultiline: true, rows: 2 },
+      validators: [htmlMaxLength(100), htmlRequired()],
     }),
     src: createTextField(),
     code: createTextField({
@@ -95,9 +92,5 @@ export const createDemoImageElement = (
           fieldValues={fieldValues}
         />
       );
-    },
-    createValidator({
-      altText: [htmlMaxLength(100), htmlRequired()],
-      caption: [htmlRequired()],
-    })
+    }
   );

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -6,7 +6,6 @@ import {
 import { createDefaultRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import {
-  createValidator,
   htmlMaxLength,
   htmlRequired,
   maxLength,
@@ -28,7 +27,7 @@ export const embedFields = {
     isCode: true,
     validators: [htmlRequired()],
   }),
-  caption: createDefaultRichTextField(),
+  caption: createDefaultRichTextField([maxLength(1000)]),
   altText: createTextField({
     multilineOptions: { isMultiline: true, rows: 2 },
     validators: [htmlMaxLength(1000), htmlRequired()],
@@ -37,18 +36,12 @@ export const embedFields = {
 };
 
 export const createEmbedElement = () =>
-  createReactElementSpec(
-    embedFields,
-    (fieldValues, errors, __, fields) => {
-      return (
-        <EmbedElementForm
-          fields={fields}
-          errors={errors}
-          fieldValues={fieldValues}
-        />
-      );
-    },
-    createValidator({
-      caption: [maxLength(1000)],
-    })
-  );
+  createReactElementSpec(embedFields, (fieldValues, errors, __, fields) => {
+    return (
+      <EmbedElementForm
+        fields={fields}
+        errors={errors}
+        fieldValues={fieldValues}
+      />
+    );
+  });

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -23,9 +23,16 @@ export const embedFields = {
     { text: "immersive", value: "immersive" },
   ]),
   sourceUrl: createTextField(),
-  embedCode: createTextField({ isMultiline: true, rows: 2 }, true),
+  embedCode: createTextField({
+    multilineOptions: { isMultiline: true, rows: 2 },
+    isCode: true,
+    validators: [htmlRequired()],
+  }),
   caption: createDefaultRichTextField(),
-  altText: createTextField({ isMultiline: true, rows: 2 }),
+  altText: createTextField({
+    multilineOptions: { isMultiline: true, rows: 2 },
+    validators: [htmlMaxLength(1000), htmlRequired()],
+  }),
   required: createCustomField(true, true),
 };
 
@@ -42,8 +49,6 @@ export const createEmbedElement = () =>
       );
     },
     createValidator({
-      altText: [htmlMaxLength(1000), htmlRequired()],
-      embedCode: [htmlRequired()],
       caption: [maxLength(1000)],
     })
   );

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -52,12 +52,14 @@ export const createImageFields = (
   return {
     altText: createTextField({
       multilineOptions: { isMultiline: true, rows: 2 },
+      validators: [htmlMaxLength(1000), htmlRequired()],
     }),
     caption: createFlatRichTextField({
       createPlugins: (schema) => exampleSetup({ schema }),
       nodeSpec: {
         marks: "em strong link strike",
       },
+      validators: [htmlMaxLength(600)],
     }),
     displayCreditInformation: createCustomField(true, true),
     imageType: createCustomField("Photograph", [
@@ -65,7 +67,7 @@ export const createImageFields = (
       { text: "Illustration", value: "Illustration" },
       { text: "Composite", value: "Composite" },
     ]),
-    photographer: createTextField(),
+    photographer: createTextField({ validators: [htmlMaxLength(250)] }),
     mainImage: createCustomField<MainImageData, MainImageProps>(
       {
         mediaId: undefined,
@@ -75,7 +77,9 @@ export const createImageFields = (
       },
       { openImageSelector }
     ),
-    source: createTextField(),
+    source: createTextField({
+      validators: [htmlMaxLength(250), htmlRequired()],
+    }),
     weighting: createCustomField("none-selected", [
       { text: "inline (default)", value: "none-selected" },
       { text: "supporting", value: "supporting" },
@@ -101,10 +105,6 @@ export const createImageElement = (
       );
     },
     createValidator({
-      caption: [htmlMaxLength(600)],
-      altText: [htmlMaxLength(1000), htmlRequired()],
-      source: [htmlMaxLength(250), htmlRequired()],
-      photographer: [htmlMaxLength(250)],
       mainImage: [largestAssetMinDimension(460)],
     })
   );

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -3,11 +3,7 @@ import React from "react";
 import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
 import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
-import {
-  createValidator,
-  htmlMaxLength,
-  htmlRequired,
-} from "../../plugin/helpers/validation";
+import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { ImageElementForm } from "./ImageElementForm";
 import { largestAssetMinDimension } from "./imageElementValidation";
@@ -75,7 +71,8 @@ export const createImageFields = (
         assets: [],
         suppliersReference: "",
       },
-      { openImageSelector }
+      { openImageSelector },
+      [largestAssetMinDimension(460)]
     ),
     source: createTextField({
       validators: [htmlMaxLength(250), htmlRequired()],
@@ -103,8 +100,5 @@ export const createImageElement = (
           fields={fields}
         />
       );
-    },
-    createValidator({
-      mainImage: [largestAssetMinDimension(460)],
-    })
+    }
   );

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -50,7 +50,9 @@ export const createImageFields = (
   openImageSelector: (setMedia: SetMedia, mediaId?: string) => void
 ) => {
   return {
-    altText: createTextField({ isMultiline: true, rows: 2 }),
+    altText: createTextField({
+      multilineOptions: { isMultiline: true, rows: 2 },
+    }),
     caption: createFlatRichTextField({
       createPlugins: (schema) => exampleSetup({ schema }),
       nodeSpec: {

--- a/src/elements/image/imageElementValidation.tsx
+++ b/src/elements/image/imageElementValidation.tsx
@@ -1,4 +1,4 @@
-import type { Validator } from "../../plugin/helpers/validation";
+import type { FieldValidator } from "../../plugin/elementSpec";
 import type { Asset } from "./ImageElement";
 
 const isRecord = (value: unknown): value is Record<string, unknown> => {
@@ -26,7 +26,7 @@ const hasAssets = (maybeData: unknown): maybeData is { assets: Asset[] } => {
   );
 };
 
-export const largestAssetMinDimension = (minSize: number): Validator => (
+export const largestAssetMinDimension = (minSize: number): FieldValidator => (
   value
 ) => {
   if (hasAssets(value)) {

--- a/src/elements/pullquote/PullquoteSpec.tsx
+++ b/src/elements/pullquote/PullquoteSpec.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { createCustomDropdownField } from "../../plugin/fieldViews/CustomFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
-import { createValidator, htmlRequired } from "../../plugin/helpers/validation";
+import { htmlRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { PullquoteElementForm } from "./PullquoteForm";
 
 export const pullquoteFields = {
-  html: createTextField({ isMultiline: true, rows: 4 }),
+  html: createTextField({ isMultiline: true, rows: 4 }, false, [
+    htmlRequired(),
+  ]),
   attribution: createTextField(),
   role: createCustomDropdownField("supporting", [
     { text: "supporting (default)", value: "supporting" },
@@ -19,6 +21,5 @@ export const pullquoteElement = createReactElementSpec(
   pullquoteFields,
   (_, errors, __, fields) => {
     return <PullquoteElementForm errors={errors} fields={fields} />;
-  },
-  createValidator({ pullquote: [htmlRequired()] })
+  }
 );

--- a/src/elements/pullquote/PullquoteSpec.tsx
+++ b/src/elements/pullquote/PullquoteSpec.tsx
@@ -6,9 +6,10 @@ import { createReactElementSpec } from "../../renderers/react/createReactElement
 import { PullquoteElementForm } from "./PullquoteForm";
 
 export const pullquoteFields = {
-  html: createTextField({ isMultiline: true, rows: 4 }, false, [
-    htmlRequired(),
-  ]),
+  html: createTextField({
+    multilineOptions: { isMultiline: true, rows: 4 },
+    validators: [htmlRequired()],
+  }),
   attribution: createTextField(),
   role: createCustomDropdownField("supporting", [
     { text: "supporting (default)", value: "supporting" },

--- a/src/plugin/fieldViews/CheckboxFieldView.ts
+++ b/src/plugin/fieldViews/CheckboxFieldView.ts
@@ -1,5 +1,6 @@
 import type { Node } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
+import type { FieldValidator } from "../elementSpec";
 import { AttributeFieldView } from "./AttributeFieldView";
 import type { BaseFieldDescription } from "./FieldView";
 
@@ -11,10 +12,12 @@ export interface CheckboxFieldDescription
 }
 
 export const createCheckBox = (
-  defaultValue: boolean
+  defaultValue: boolean,
+  validators?: FieldValidator[]
 ): CheckboxFieldDescription => ({
   type: CheckboxFieldView.fieldName,
   defaultValue,
+  validators,
 });
 
 export class CheckboxFieldView extends AttributeFieldView<CheckboxValue> {

--- a/src/plugin/fieldViews/CustomFieldView.ts
+++ b/src/plugin/fieldViews/CustomFieldView.ts
@@ -1,5 +1,6 @@
 import type { Node } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
+import type { FieldValidator } from "../elementSpec";
 import type { Options } from "./DropdownFieldView";
 import type { BaseFieldDescription, FieldView } from "./FieldView";
 import { FieldType } from "./FieldView";
@@ -13,20 +14,24 @@ export interface CustomFieldDescription<Data = unknown, Props = unknown>
 
 export const createCustomField = <Data, Props>(
   defaultValue: Data,
-  props: Props
+  props: Props,
+  validators?: FieldValidator[]
 ): CustomFieldDescription<Data, Props> => ({
   type: "custom" as const,
   defaultValue,
   props,
+  validators,
 });
 
 export const createCustomDropdownField = (
   defaultValue: string,
-  props: Options
+  props: Options,
+  validators?: FieldValidator[]
 ): CustomFieldDescription<string, Options> => ({
   type: "custom" as const,
   defaultValue,
   props,
+  validators,
 });
 
 type Subscriber<Fields extends unknown> = (fields: Fields) => void;

--- a/src/plugin/fieldViews/DropdownFieldView.ts
+++ b/src/plugin/fieldViews/DropdownFieldView.ts
@@ -1,5 +1,6 @@
 import type { Node } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
+import type { FieldValidator } from "../elementSpec";
 import { AttributeFieldView } from "./AttributeFieldView";
 import type { BaseFieldDescription } from "./FieldView";
 
@@ -13,11 +14,13 @@ export interface DropdownFieldDescription extends BaseFieldDescription<string> {
 
 export const createDropDownField = (
   options: Options,
-  defaultValue: string
+  defaultValue: string,
+  validators?: FieldValidator[]
 ): DropdownFieldDescription => ({
   type: DropdownFieldView.fieldName,
   options,
   defaultValue,
+  validators,
 });
 
 export type DropdownFields = string;

--- a/src/plugin/fieldViews/FieldView.ts
+++ b/src/plugin/fieldViews/FieldView.ts
@@ -1,5 +1,6 @@
 import type { Node } from "prosemirror-model";
 import type { Decoration, DecorationSet } from "prosemirror-view";
+import type { FieldValidator } from "../elementSpec";
 
 /**
  * The specification for an element field, to be modelled as a Node in Prosemirror.
@@ -8,6 +9,7 @@ export interface BaseFieldDescription<DefaultValue extends unknown> {
   // The data type of the field.
   type: string;
   defaultValue?: DefaultValue;
+  validators?: FieldValidator[];
 }
 
 export enum FieldType {

--- a/src/plugin/fieldViews/RichTextFieldView.ts
+++ b/src/plugin/fieldViews/RichTextFieldView.ts
@@ -4,6 +4,7 @@ import { keymap } from "prosemirror-keymap";
 import type { Node, NodeSpec, Schema } from "prosemirror-model";
 import type { EditorState, Plugin, Transaction } from "prosemirror-state";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
+import type { FieldValidator } from "../elementSpec";
 import type { BaseFieldDescription } from "./FieldView";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
 
@@ -16,19 +17,23 @@ export interface RichTextFieldDescription extends BaseFieldDescription<string> {
 type RichTextOptions = {
   createPlugins?: (schema: Schema) => Plugin[];
   nodeSpec?: Partial<NodeSpec>;
+  validators?: FieldValidator[];
 };
 
 export const createRichTextField = ({
   createPlugins,
   nodeSpec,
+  validators,
 }: RichTextOptions): RichTextFieldDescription => ({
   type: RichTextFieldView.fieldName,
   createPlugins,
   nodeSpec,
+  validators,
 });
 
 type FlatRichTextOptions = RichTextOptions & {
   nodeSpec?: Partial<Omit<NodeSpec, "content">>;
+  validators?: FieldValidator[];
 };
 
 /**
@@ -38,6 +43,7 @@ type FlatRichTextOptions = RichTextOptions & {
 export const createFlatRichTextField = ({
   createPlugins,
   nodeSpec,
+  validators,
 }: FlatRichTextOptions): RichTextFieldDescription =>
   createRichTextField({
     createPlugins: (schema) => {
@@ -65,14 +71,20 @@ export const createFlatRichTextField = ({
       ...nodeSpec,
       content: "(text|hard_break)*",
     },
+    validators,
   });
 
 /**
  * Create a rich text field with a default setup. Largely for demonstrative
  * purposes, as library users are likely to want different defaults.
  */
-export const createDefaultRichTextField = (): RichTextFieldDescription =>
-  createRichTextField({ createPlugins: (schema) => exampleSetup({ schema }) });
+export const createDefaultRichTextField = (
+  validators?: FieldValidator[]
+): RichTextFieldDescription =>
+  createRichTextField({
+    createPlugins: (schema) => exampleSetup({ schema }),
+    validators,
+  });
 
 export class RichTextFieldView extends ProseMirrorFieldView {
   public static fieldName = "richText" as const;

--- a/src/plugin/fieldViews/TextFieldView.ts
+++ b/src/plugin/fieldViews/TextFieldView.ts
@@ -23,29 +23,29 @@ export interface TextFieldDescription extends BaseFieldDescription<string> {
 
 type MultilineOptions = {
   isMultiline: boolean;
-  rows?: number;
+  rows: number;
 };
 
 type TextFieldOptions = {
-  multilineOptions?: MultilineOptions | undefined;
+  multilineOptions?: MultilineOptions;
   isCode?: boolean;
   validators?: FieldValidator[];
 };
 
 export const createTextField = (
   {
-    multilineOptions,
+    multilineOptions = { isMultiline: false, rows: 1 },
     isCode = false,
     validators = [],
   }: TextFieldOptions | undefined = {
-    multilineOptions: undefined,
+    multilineOptions: { isMultiline: false, rows: 1 },
     isCode: false,
     validators: [],
   }
 ): TextFieldDescription => ({
   type: TextFieldView.fieldName,
-  isMultiline: multilineOptions?.isMultiline ?? false,
-  rows: multilineOptions?.rows ?? 0,
+  isMultiline: multilineOptions.isMultiline,
+  rows: multilineOptions.rows,
   isCode,
   validators,
 });

--- a/src/plugin/fieldViews/TextFieldView.ts
+++ b/src/plugin/fieldViews/TextFieldView.ts
@@ -5,6 +5,7 @@ import { keymap } from "prosemirror-keymap";
 import type { Node, Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
+import type { FieldValidator } from "../elementSpec";
 import type { BaseFieldDescription } from "./FieldView";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
 
@@ -24,17 +25,20 @@ type MultilineOptions = {
   isMultiline: boolean;
   rows?: number;
 };
+
 export const createTextField = (
   { isMultiline = false, rows = 1 }: MultilineOptions = {
     isMultiline: false,
     rows: 1,
   },
-  isCode = false
+  isCode = false,
+  validators: FieldValidator[] = []
 ): TextFieldDescription => ({
   type: TextFieldView.fieldName,
   isMultiline,
   rows,
   isCode,
+  validators,
 });
 
 export class TextFieldView extends ProseMirrorFieldView {

--- a/src/plugin/fieldViews/TextFieldView.ts
+++ b/src/plugin/fieldViews/TextFieldView.ts
@@ -26,17 +26,26 @@ type MultilineOptions = {
   rows?: number;
 };
 
+type TextFieldOptions = {
+  multilineOptions?: MultilineOptions | undefined;
+  isCode?: boolean;
+  validators?: FieldValidator[];
+};
+
 export const createTextField = (
-  { isMultiline = false, rows = 1 }: MultilineOptions = {
-    isMultiline: false,
-    rows: 1,
-  },
-  isCode = false,
-  validators: FieldValidator[] = []
+  {
+    multilineOptions,
+    isCode = false,
+    validators = [],
+  }: TextFieldOptions | undefined = {
+    multilineOptions: undefined,
+    isCode: false,
+    validators: [],
+  }
 ): TextFieldDescription => ({
   type: TextFieldView.fieldName,
-  isMultiline,
-  rows,
+  isMultiline: multilineOptions?.isMultiline ?? false,
+  rows: multilineOptions?.rows ?? 0,
   isCode,
   validators,
 });

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -1,14 +1,9 @@
-import type { FieldValidationErrors, ValidationError } from "../elementSpec";
+import type { FieldValidationErrors, FieldValidator } from "../elementSpec";
 import type { FieldNameToValueMap } from "../fieldViews/helpers";
 import type { FieldDescriptions } from "../types/Element";
 
-export type Validator = (
-  fieldValue: unknown,
-  fieldName: string
-) => ValidationError[];
-
 export const createValidator = (
-  fieldValidationMap: Record<string, Validator[]>
+  fieldValidationMap: Record<string, FieldValidator[]>
 ) => <FDesc extends FieldDescriptions<string>>(
   fieldValues: FieldNameToValueMap<FDesc>
 ): FieldValidationErrors => {
@@ -28,7 +23,7 @@ export const createValidator = (
 export const htmlMaxLength = (
   maxLength: number,
   customMessage: string | undefined = undefined
-): Validator => (value, field) => {
+): FieldValidator => (value, field) => {
   if (typeof value !== "string" && value !== undefined) {
     const typeError = `html max length check: ${field} value is incorrect`;
     return [
@@ -57,7 +52,7 @@ export const htmlMaxLength = (
 export const maxLength = (
   maxLength: number,
   customMessage: string | undefined = undefined
-): Validator => (value, field) => {
+): FieldValidator => (value, field) => {
   if (typeof value !== "string" && value !== undefined) {
     const typeError = `max length check: ${field} value is incorrect`;
     return [
@@ -82,7 +77,7 @@ export const maxLength = (
 
 export const htmlRequired = (
   customMessage: string | undefined = undefined
-): Validator => (value, field) => {
+): FieldValidator => (value, field) => {
   if (typeof value !== "string" && value !== undefined) {
     const typeError = `required check: ${field} value is incorrect`;
     return [
@@ -104,7 +99,7 @@ export const htmlRequired = (
 
 export const required = (
   customMessage: string | undefined = undefined
-): Validator => (value, field) => {
+): FieldValidator => (value, field) => {
   if (typeof value !== "string" && value !== undefined) {
     const typeError = `required check: ${field} value is incorrect`;
     return [

--- a/src/renderers/react/createReactElementSpec.tsx
+++ b/src/renderers/react/createReactElementSpec.tsx
@@ -14,10 +14,10 @@ export const createReactElementSpec = <
   FDesc extends FieldDescriptions<string>,
   ExternalData
 >(
-  FieldDescriptions: FDesc,
+  fieldDescriptions: FDesc,
   consumer: Consumer<ReactElement, FDesc>,
-  validate: Validator<FDesc>,
-  transformers?: Transformers<FDesc, ExternalData>
+  validate: Validator<FDesc> | undefined = undefined,
+  transformers: Transformers<FDesc, ExternalData> | undefined = undefined
 ) => {
   const renderer: Renderer<FDesc> = (
     validate,
@@ -41,5 +41,5 @@ export const createReactElementSpec = <
       dom
     );
 
-  return createElementSpec(FieldDescriptions, renderer, validate, transformers);
+  return createElementSpec(fieldDescriptions, renderer, validate, transformers);
 };


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR changes the field description API to allow the possibility of colocating the validation with the field. This should make the API easier to work with in line with our vision document goals.

Before:

```javascript
export const pullquoteFields = {
  html: createTextField({ isMultiline: true, rows: 4 }),
};

export const pullquoteElement = createReactElementSpec(
  pullquoteFields,
  (_, errors, __, fields) => {
    return <PullquoteElementForm errors={errors} fields={fields} />;
  },
  createValidator({ pullquote: [htmlRequired()] })
);
```
After: 

```javascript 
export const pullquoteFields = {
  html: createTextField({
    multilineOptions: { isMultiline: true, rows: 4 },
    validators: [htmlRequired()],
  })
};

export const pullquoteElement = createReactElementSpec(
  pullquoteFields,
  (_, errors, __, fields) => {
    return <PullquoteElementForm errors={errors} fields={fields} />;
  }
);
```

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This should be a no-op from a functional perspective but make the API easier to work with. 

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Creating new elements and updating existing ones is intuitive and easy.

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [x] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
