### PR TITLE
fix: Use createGuElementSpec for flexible-model elements

### DIFF
--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -10,7 +10,7 @@ import {
   htmlRequired,
   maxLength,
 } from "../../plugin/helpers/validation";
-import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+import { createGuElementSpec } from "../createGuElementSpec";
 import { EmbedElementForm } from "./EmbedForm";
 
 export const embedFields = {
@@ -36,7 +36,7 @@ export const embedFields = {
 };
 
 export const createEmbedElement = () =>
-  createReactElementSpec(embedFields, (fieldValues, errors, __, fields) => {
+  createGuElementSpec(embedFields, (fieldValues, errors, __, fields) => {
     return (
       <EmbedElementForm
         fields={fields}

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -4,7 +4,7 @@ import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
 import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
-import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+import { createGuElementSpec } from "../createGuElementSpec";
 import { ImageElementForm } from "./ImageElementForm";
 import { largestAssetMinDimension } from "./imageElementValidation";
 
@@ -90,7 +90,7 @@ export const createImageFields = (
 export const createImageElement = (
   openImageSelector: (setMedia: SetMedia, mediaId?: string) => void
 ) =>
-  createReactElementSpec(
+  createGuElementSpec(
     createImageFields(openImageSelector),
     (fieldValues, errors, __, fields) => {
       return (

--- a/src/elements/pullquote/PullquoteSpec.tsx
+++ b/src/elements/pullquote/PullquoteSpec.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { createCustomDropdownField } from "../../plugin/fieldViews/CustomFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { htmlRequired } from "../../plugin/helpers/validation";
-import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+import { createGuElementSpec } from "../createGuElementSpec";
 import { PullquoteElementForm } from "./PullquoteForm";
 
 export const pullquoteFields = {
@@ -18,7 +18,7 @@ export const pullquoteFields = {
   ]),
 };
 
-export const pullquoteElement = createReactElementSpec(
+export const pullquoteElement = createGuElementSpec(
   pullquoteFields,
   (_, errors, __, fields) => {
     return <PullquoteElementForm errors={errors} fields={fields} />;


### PR DESCRIPTION
## What does this change?

Use `createGuElementSpec` for all flexible-model elements. Previously, this was limited to just code – now we use that method for the lot, ensuring that our data is in the correct shape for flexible-conte.

## How to test

Use this library in flexible-content. Does it work as expected?