### PR TITLE
fix: Add FieldVerticalLayout component and remove margins from inputs/labels

### DIFF
--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -138,7 +138,7 @@ export const getSerialisedHtml = ({
           mainImageValue.mediaApiUri ?? "undefined"
         }&quot;,&quot;assets&quot;${mainImageValue.assets}`
       : `&quot;assets&quot;:[]`;
-  return trimHtml(`<div pme-element-type="demoImageElement" has-errors="false">
+  return trimHtml(`<div pme-element-type="demoImageElement">
     <div pme-field-name="demoImageElement_altText">${altTextValue}</div>
     <div pme-field-name="demoImageElement_caption">${captionValue}</div>
     <div pme-field-name="demoImageElement_code">${codeValue}</div>

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -43,12 +43,7 @@ type Name =
   | typeof codeElementName
   | typeof pullquoteElementName;
 
-const {
-  plugin: elementPlugin,
-  insertElement,
-  hasErrors,
-  nodeSpec,
-} = buildElementPlugin({
+const { plugin: elementPlugin, insertElement, nodeSpec } = buildElementPlugin({
   demoImageElement: createDemoImageElement(onSelectImage, onDemoCropImage),
   imageElement: createImageElement(onCropImage),
   embedElement: createEmbedElement(),
@@ -75,12 +70,6 @@ const editorsContainer = document.querySelector("#editor-container");
 if (!editorsContainer) {
   throw new Error("No #editor element present in DOM");
 }
-
-const highlightErrors = (state: EditorState) => {
-  document.body.style.backgroundColor = hasErrors(state)
-    ? "red"
-    : "transparent";
-};
 
 const get = () => {
   const state = window.localStorage.getItem("pm");
@@ -136,8 +125,6 @@ const createEditor = (server: CollabServer) => {
   if (!isFirstEditor) {
     firstEditor = view;
   }
-
-  highlightErrors(view.state);
 
   const createElementButton = (
     buttonText: string,
@@ -216,7 +203,6 @@ const createEditor = (server: CollabServer) => {
   );
 
   new EditorConnection(view, server, clientID, `User ${clientID}`, (state) => {
-    highlightErrors(state);
     if (isFirstEditor) {
       set(state.doc);
     }

--- a/src/editorial-source-components/Button.tsx
+++ b/src/editorial-source-components/Button.tsx
@@ -1,0 +1,24 @@
+import { css } from "@emotion/react";
+import type { ButtonProps } from "@guardian/src-button";
+import { Button as SourceButton } from "@guardian/src-button";
+import React from "react";
+
+export const buttonStyles = css`
+  font-family: "Guardian Agate Sans";
+`;
+
+export const Button: React.FunctionComponent<ButtonProps> = ({
+  children,
+  size,
+  ...props
+}) => {
+  return (
+    <SourceButton
+      size={size ? size : "xsmall"}
+      cssOverrides={buttonStyles}
+      {...props}
+    >
+      {children}
+    </SourceButton>
+  );
+};

--- a/src/editorial-source-components/CustomCheckbox.tsx
+++ b/src/editorial-source-components/CustomCheckbox.tsx
@@ -10,10 +10,8 @@ const parentStyles = css`
   white-space: nowrap;
   div {
     ${labelStyles}
-  }
-  label {
-    margin-top: -6px;
-    margin-bottom: -6px;
+    margin-top: ${space[2]}px;
+    margin-bottom: ${space[2]}px;
   }
   // Re-order the checkbox field and error message
   fieldset {

--- a/src/editorial-source-components/CustomCheckbox.tsx
+++ b/src/editorial-source-components/CustomCheckbox.tsx
@@ -10,8 +10,9 @@ const parentStyles = css`
   white-space: nowrap;
   div {
     ${labelStyles}
-    margin-top: ${space[2]}px;
-    margin-bottom: ${space[2]}px;
+  }
+  label {
+    min-height: initial;
   }
   // Re-order the checkbox field and error message
   fieldset {

--- a/src/editorial-source-components/CustomDropdown.tsx
+++ b/src/editorial-source-components/CustomDropdown.tsx
@@ -16,6 +16,8 @@ const SelectWrapper = styled.div<{ display: "block" | "inline" }>`
     display: flex;
     :first-of-type {
       ${labelStyles}
+      margin-top: ${space[2]}px;
+      margin-bottom: ${space[2]}px;
     }
     svg {
       height: ${space[5]}px;
@@ -37,14 +39,14 @@ const SelectWrapper = styled.div<{ display: "block" | "inline" }>`
   ${({ display }) =>
     display === "inline" &&
     `
-    label { 
-      display: flex; 
-      align-items: center; 
+    label {
+      display: flex;
+      align-items: center;
       >div:first-child {
         margin-right: ${space[3]}px;
       }
-      /* 
-       * This resolves some margin problems introduced by 
+      /*
+       * This resolves some margin problems introduced by
        * restyling the Source Select component to be inline with its
        * label
        */

--- a/src/editorial-source-components/CustomDropdown.tsx
+++ b/src/editorial-source-components/CustomDropdown.tsx
@@ -16,8 +16,7 @@ const SelectWrapper = styled.div<{ display: "block" | "inline" }>`
     display: flex;
     :first-of-type {
       ${labelStyles}
-      margin-top: ${space[2]}px;
-      margin-bottom: ${space[2]}px;
+      ${({ display }) => display === "block" && `margin-bottom: ${space[2]}px;`}
     }
     svg {
       height: ${space[5]}px;
@@ -45,12 +44,6 @@ const SelectWrapper = styled.div<{ display: "block" | "inline" }>`
       >div:first-child {
         margin-right: ${space[3]}px;
       }
-      /*
-       * This resolves some margin problems introduced by
-       * restyling the Source Select component to be inline with its
-       * label
-       */
-      margin: -${space[2]}px 0;
     }`}
 `;
 

--- a/src/editorial-source-components/Editor.ts
+++ b/src/editorial-source-components/Editor.ts
@@ -1,14 +1,16 @@
 import styled from "@emotion/styled";
-import { background } from "@guardian/src-foundations";
+import { background, border } from "@guardian/src-foundations";
 import { focusHalo } from "@guardian/src-foundations/accessibility";
 import { body } from "@guardian/src-foundations/typography";
 import { inputBorder } from "./inputBorder";
 
-export const Editor = styled.div`
+export const Editor = styled.div<{ hasValidationErrors: boolean }>`
   ${body.small()}
   .ProseMirror {
     background-color: ${background.primary};
     ${inputBorder}
+    ${({ hasValidationErrors }) =>
+      !!hasValidationErrors && `border-color: ${border.error};`}
     &:active {
       border: 1px solid ${background.inputChecked};
     }

--- a/src/editorial-source-components/Editor.ts
+++ b/src/editorial-source-components/Editor.ts
@@ -1,15 +1,14 @@
 import styled from "@emotion/styled";
-import { background, border } from "@guardian/src-foundations";
+import { background } from "@guardian/src-foundations";
 import { focusHalo } from "@guardian/src-foundations/accessibility";
 import { body } from "@guardian/src-foundations/typography";
 import { inputBorder } from "./inputBorder";
 
-export const Editor = styled.div<{ hasErrors: boolean }>`
+export const Editor = styled.div`
   ${body.small()}
   .ProseMirror {
     background-color: ${background.primary};
     ${inputBorder}
-    ${({ hasErrors }) => !!hasErrors && `border-color: ${border.error};`}
     &:active {
       border: 1px solid ${background.inputChecked};
     }

--- a/src/editorial-source-components/Error.tsx
+++ b/src/editorial-source-components/Error.tsx
@@ -1,15 +1,12 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { space, text } from "@guardian/src-foundations";
+import { text } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
 
 export const errorStyles = css`
   ${textSans.small({ lineHeight: "loose" })}
   font-family: "Guardian Agate Sans";
-  margin-top: ${space[2]}px;
-  margin-bottom: ${space[2]}px;
   display: block;
-  margin-left: auto;
   color: ${text.error};
 `;
 

--- a/src/editorial-source-components/FieldWrapper.tsx
+++ b/src/editorial-source-components/FieldWrapper.tsx
@@ -8,7 +8,7 @@ import { InputHeading } from "./InputHeading";
 type Props<F> = {
   field: F;
   errors: ValidationError[];
-  label: string;
+  label: React.ReactNode;
   className?: string;
 };
 

--- a/src/editorial-source-components/FieldWrapper.tsx
+++ b/src/editorial-source-components/FieldWrapper.tsx
@@ -2,7 +2,6 @@ import type { ValidationError } from "../plugin/elementSpec";
 import type { FieldView as TFieldView } from "../plugin/fieldViews/FieldView";
 import type { Field } from "../plugin/types/Element";
 import { FieldView } from "../renderers/react/FieldView";
-import { InputGroup } from "./InputGroup";
 import { InputHeading } from "./InputHeading";
 
 type Props<F> = {
@@ -18,8 +17,8 @@ export const FieldWrapper = <F extends Field<TFieldView<unknown>>>({
   label,
   className,
 }: Props<F>) => (
-  <InputGroup className={className}>
-    <InputHeading label={label} errors={errors.map((e) => e.error)} />
-    <FieldView field={field} hasValidationErrors={errors.length >= 1} />
-  </InputGroup>
+  <div className={className}>
+    <InputHeading label={label} errors={errors} />
+    <FieldView field={field} hasValidationErrors={!!errors.length} />
+  </div>
 );

--- a/src/editorial-source-components/FieldWrapper.tsx
+++ b/src/editorial-source-components/FieldWrapper.tsx
@@ -20,6 +20,6 @@ export const FieldWrapper = <F extends Field<TFieldView<unknown>>>({
 }: Props<F>) => (
   <InputGroup className={className}>
     <InputHeading label={label} errors={errors.map((e) => e.error)} />
-    <FieldView field={field} />
+    <FieldView field={field} hasValidationErrors={errors.length >= 1} />
   </InputGroup>
 );

--- a/src/editorial-source-components/FieldWrapper.tsx
+++ b/src/editorial-source-components/FieldWrapper.tsx
@@ -20,6 +20,6 @@ export const FieldWrapper = <F extends Field<TFieldView<unknown>>>({
 }: Props<F>) => (
   <InputGroup className={className}>
     <InputHeading label={label} errors={errors.map((e) => e.error)} />
-    <FieldView field={field} hasErrors={!!errors.length} />
+    <FieldView field={field} />
   </InputGroup>
 );

--- a/src/editorial-source-components/FieldWrapper.tsx
+++ b/src/editorial-source-components/FieldWrapper.tsx
@@ -1,3 +1,4 @@
+import type { ValidationError } from "../plugin/elementSpec";
 import type { FieldView as TFieldView } from "../plugin/fieldViews/FieldView";
 import type { Field } from "../plugin/types/Element";
 import { FieldView } from "../renderers/react/FieldView";
@@ -6,7 +7,7 @@ import { InputHeading } from "./InputHeading";
 
 type Props<F> = {
   field: F;
-  errors: string[];
+  errors: ValidationError[];
   label: string;
   className?: string;
 };
@@ -18,7 +19,7 @@ export const FieldWrapper = <F extends Field<TFieldView<unknown>>>({
   className,
 }: Props<F>) => (
   <InputGroup className={className}>
-    <InputHeading label={label} errors={errors} />
+    <InputHeading label={label} errors={errors.map((e) => e.error)} />
     <FieldView field={field} hasErrors={!!errors.length} />
   </InputGroup>
 );

--- a/src/editorial-source-components/InputGroup.tsx
+++ b/src/editorial-source-components/InputGroup.tsx
@@ -1,6 +1,0 @@
-import styled from "@emotion/styled";
-import { space } from "@guardian/src-foundations";
-
-export const InputGroup = styled.div`
-  margin-bottom: ${space[3]}px;
-`;

--- a/src/editorial-source-components/InputHeading.tsx
+++ b/src/editorial-source-components/InputHeading.tsx
@@ -1,9 +1,19 @@
 import styled from "@emotion/styled";
+import { space } from "@guardian/src-foundations";
 import { Error } from "./Error";
 import { Label } from "./Label";
 
 const InputHeadingContainer = styled.div`
   display: flex;
+  flex-wrap: wrap;
+  margin-top: ${space[2]}px;
+  margin-bottom: ${space[2]}px;
+  label {
+    // Ensure that the label pushes error messages to the rhs
+    // if they occupy the same line, to ensure the error message
+    // is right-aligned.
+    flex-grow: 1;
+  }
 `;
 
 const Errors = ({ errors }: { errors: string[] }) =>

--- a/src/editorial-source-components/InputHeading.tsx
+++ b/src/editorial-source-components/InputHeading.tsx
@@ -6,7 +6,6 @@ import { Label } from "./Label";
 const InputHeadingContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
-  margin-top: ${space[2]}px;
   margin-bottom: ${space[2]}px;
   label {
     // Ensure that the label pushes error messages to the rhs

--- a/src/editorial-source-components/InputHeading.tsx
+++ b/src/editorial-source-components/InputHeading.tsx
@@ -20,7 +20,7 @@ const Errors = ({ errors }: { errors: string[] }) =>
   !errors.length ? null : <Error>{errors.join(", ")}</Error>;
 
 type Props = {
-  label: string;
+  label: React.ReactNode;
   errors: string[];
 };
 

--- a/src/editorial-source-components/Label.tsx
+++ b/src/editorial-source-components/Label.tsx
@@ -6,6 +6,10 @@ export const labelStyles = css`
   ${textSans.small({ fontWeight: "bold", lineHeight: "loose" })}
   font-family: "Guardian Agate Sans";
   display: block;
+  // Ensure that the label pushes error messages to the rhs
+  // if they occupy the same line, to ensure the error message
+  // is right-aligned.
+  flex-grow: 1;
 `;
 
 export const Label = styled.label`

--- a/src/editorial-source-components/Label.tsx
+++ b/src/editorial-source-components/Label.tsx
@@ -1,13 +1,10 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { space } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
 
 export const labelStyles = css`
   ${textSans.small({ fontWeight: "bold", lineHeight: "loose" })}
   font-family: "Guardian Agate Sans";
-  margin-top: ${space[2]}px;
-  margin-bottom: ${space[2]}px;
   display: block;
 `;
 

--- a/src/editorial-source-components/Label.tsx
+++ b/src/editorial-source-components/Label.tsx
@@ -6,10 +6,6 @@ export const labelStyles = css`
   ${textSans.small({ fontWeight: "bold", lineHeight: "loose" })}
   font-family: "Guardian Agate Sans";
   display: block;
-  // Ensure that the label pushes error messages to the rhs
-  // if they occupy the same line, to ensure the error message
-  // is right-aligned.
-  flex-grow: 1;
 `;
 
 export const Label = styled.label`

--- a/src/editorial-source-components/VerticalFieldLayout.tsx
+++ b/src/editorial-source-components/VerticalFieldLayout.tsx
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+import { space } from "@guardian/src-foundations";
+
+export const FieldLayoutVertical = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${space[3]}px;
+`;

--- a/src/elements/code/CodeElementForm.tsx
+++ b/src/elements/code/CodeElementForm.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import type { FieldValidationErrors } from "../../plugin/elementSpec";
 import type { FieldNameToField } from "../../plugin/types/Element";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import type { codeFields } from "./CodeElementSpec";
 
 type Props = {
-  errors: Record<string, string[]>;
+  errors: FieldValidationErrors;
   fields: FieldNameToField<typeof codeFields>;
 };
 

--- a/src/elements/code/CodeElementForm.tsx
+++ b/src/elements/code/CodeElementForm.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
 import type { FieldValidationErrors } from "../../plugin/elementSpec";
 import type { FieldNameToField } from "../../plugin/types/Element";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
@@ -16,12 +17,12 @@ export const CodeElementForm: React.FunctionComponent<Props> = ({
   errors,
   fields,
 }) => (
-  <div data-cy={CodeElementTestId}>
+  <FieldLayoutVertical data-cy={CodeElementTestId}>
     <FieldWrapper label="Code" field={fields.html} errors={errors.html} />
     <CustomDropdownView
       label="Language"
       field={fields.language}
       display="inline"
     />
-  </div>
+  </FieldLayoutVertical>
 );

--- a/src/elements/code/CodeElementSpec.tsx
+++ b/src/elements/code/CodeElementSpec.tsx
@@ -24,5 +24,5 @@ export const codeElement = createGuElementSpec(
   (_, errors, __, fields) => {
     return <CodeElementForm errors={errors} fields={fields} />;
   },
-  createValidator({ html: [required()] })
+  createValidator({ html: [required("empty code field")] })
 );

--- a/src/elements/code/CodeElementSpec.tsx
+++ b/src/elements/code/CodeElementSpec.tsx
@@ -1,12 +1,16 @@
 import React from "react";
 import { createCustomDropdownField } from "../../plugin/fieldViews/CustomFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
-import { createValidator, required } from "../../plugin/helpers/validation";
+import { required } from "../../plugin/helpers/validation";
 import { createGuElementSpec } from "../createGuElementSpec";
 import { CodeElementForm } from "./CodeElementForm";
 
 export const codeFields = {
-  html: createTextField({ isMultiline: true, rows: 4 }, true),
+  html: createTextField({
+    multilineOptions: { isMultiline: true, rows: 4 },
+    isCode: true,
+    validators: [required("empty code field")],
+  }),
   language: createCustomDropdownField("text", [
     { text: "Plain text", value: "text" },
     { text: "HTML", value: "html" },
@@ -23,6 +27,5 @@ export const codeElement = createGuElementSpec(
   codeFields,
   (_, errors, __, fields) => {
     return <CodeElementForm errors={errors} fields={fields} />;
-  },
-  createValidator({ html: [required("empty code field")] })
+  }
 );

--- a/src/elements/createGuElementSpec.ts
+++ b/src/elements/createGuElementSpec.ts
@@ -20,7 +20,7 @@ type FlexibleModelElement<FDesc extends FieldDescriptions<string>> = {
 export const createGuElementSpec = <FDesc extends FieldDescriptions<string>>(
   FieldDescriptions: FDesc,
   consumer: Consumer<ReactElement, FDesc>,
-  validate: Validator<FDesc>,
+  validate: Validator<FDesc> | undefined = undefined,
   isMandatory?: boolean
 ) => {
   return createReactElementSpec(FieldDescriptions, consumer, validate, {

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -11,11 +11,7 @@ import {
   createFlatRichTextField,
 } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
-import {
-  createValidator,
-  htmlMaxLength,
-  htmlRequired,
-} from "../../plugin/helpers/validation";
+import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { ImageElementForm } from "./DemoImageElementForm";
 
@@ -42,16 +38,22 @@ export const createImageFields = (
   onCropImage: (mediaId: string, setMedia: DemoSetMedia) => void
 ) => {
   return {
-    caption: createDefaultRichTextField(),
+    caption: createDefaultRichTextField([htmlRequired()]),
     restrictedTextField: createFlatRichTextField({
       createPlugins: (schema) => exampleSetup({ schema }),
       nodeSpec: {
         marks: "em",
       },
     }),
-    altText: createTextField({ isMultiline: true, rows: 2 }),
+    altText: createTextField({
+      multilineOptions: { isMultiline: true, rows: 2 },
+      validators: [htmlMaxLength(100), htmlRequired()],
+    }),
     src: createTextField(),
-    code: createTextField({ isMultiline: true, rows: 4 }, true),
+    code: createTextField({
+      multilineOptions: { isMultiline: true, rows: 4 },
+      isCode: true,
+    }),
     mainImage: createCustomField<ImageField, ImageProps>(
       { mediaId: undefined, mediaApiUri: undefined, assets: [] },
       {
@@ -90,9 +92,5 @@ export const createDemoImageElement = (
           fieldValues={fieldValues}
         />
       );
-    },
-    createValidator({
-      altText: [htmlMaxLength(100), htmlRequired()],
-      caption: [htmlRequired()],
-    })
+    }
   );

--- a/src/elements/demo-image/DemoImageElementForm.tsx
+++ b/src/elements/demo-image/DemoImageElementForm.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
 import { Label } from "../../editorial-source-components/Label";
+import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
 import type { FieldValidationErrors } from "../../plugin/elementSpec";
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
 import type { CustomField, FieldNameToField } from "../../plugin/types/Element";
@@ -23,7 +24,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
   errors,
   fieldValues,
 }) => (
-  <div data-cy={ImageElementTestId}>
+  <FieldLayoutVertical data-cy={ImageElementTestId}>
     <FieldWrapper
       label="Caption"
       field={fields.caption}
@@ -71,7 +72,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
     <hr />
     <Label>Element values</Label>
     <pre>{JSON.stringify(fieldValues)}</pre>
-  </div>
+  </FieldLayoutVertical>
 );
 
 type ImageViewProps = {

--- a/src/elements/demo-image/DemoImageElementForm.tsx
+++ b/src/elements/demo-image/DemoImageElementForm.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
 import { Label } from "../../editorial-source-components/Label";
+import type { FieldValidationErrors } from "../../plugin/elementSpec";
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
 import type { CustomField, FieldNameToField } from "../../plugin/types/Element";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
@@ -10,7 +11,7 @@ import type { createImageFields, DemoSetMedia } from "./DemoImageElement";
 
 type Props = {
   fieldValues: FieldNameToValueMap<ReturnType<typeof createImageFields>>;
-  errors: Record<string, string[]>;
+  errors: FieldValidationErrors;
   fields: FieldNameToField<ReturnType<typeof createImageFields>>;
 };
 

--- a/src/elements/embed/EmbedForm.tsx
+++ b/src/elements/embed/EmbedForm.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import type { FieldValidationErrors } from "../../plugin/elementSpec";
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
 import type { FieldNameToField } from "../../plugin/types/Element";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
@@ -8,7 +9,7 @@ import type { embedFields } from "./EmbedSpec";
 
 type Props = {
   fieldValues: FieldNameToValueMap<typeof embedFields>;
-  errors: Record<string, string[]>;
+  errors: FieldValidationErrors;
   fields: FieldNameToField<typeof embedFields>;
 };
 

--- a/src/elements/embed/EmbedForm.tsx
+++ b/src/elements/embed/EmbedForm.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
 import type { FieldValidationErrors } from "../../plugin/elementSpec";
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
 import type { FieldNameToField } from "../../plugin/types/Element";
@@ -19,7 +20,7 @@ export const EmbedElementForm: React.FunctionComponent<Props> = ({
   errors,
   fields,
 }) => (
-  <div data-cy={EmbedElementTestId}>
+  <FieldLayoutVertical data-cy={EmbedElementTestId}>
     <CustomDropdownView
       field={fields.weighting}
       label="Weighting"
@@ -50,5 +51,5 @@ export const EmbedElementForm: React.FunctionComponent<Props> = ({
       errors={errors.required}
       label="This element is required for publication"
     />
-  </div>
+  </FieldLayoutVertical>
 );

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -10,7 +10,7 @@ import {
   htmlRequired,
   maxLength,
 } from "../../plugin/helpers/validation";
-import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+import { createGuElementSpec } from "../createGuElementSpec";
 import { EmbedElementForm } from "./EmbedForm";
 
 export const embedFields = {
@@ -36,7 +36,7 @@ export const embedFields = {
 };
 
 export const createEmbedElement = () =>
-  createReactElementSpec(embedFields, (fieldValues, errors, __, fields) => {
+  createGuElementSpec(embedFields, (fieldValues, errors, __, fields) => {
     return (
       <EmbedElementForm
         fields={fields}

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -6,7 +6,6 @@ import {
 import { createDefaultRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import {
-  createValidator,
   htmlMaxLength,
   htmlRequired,
   maxLength,
@@ -23,27 +22,26 @@ export const embedFields = {
     { text: "immersive", value: "immersive" },
   ]),
   sourceUrl: createTextField(),
-  embedCode: createTextField({ isMultiline: true, rows: 2 }, true),
-  caption: createDefaultRichTextField(),
-  altText: createTextField({ isMultiline: true, rows: 2 }),
+  embedCode: createTextField({
+    multilineOptions: { isMultiline: true, rows: 2 },
+    isCode: true,
+    validators: [htmlRequired()],
+  }),
+  caption: createDefaultRichTextField([maxLength(1000)]),
+  altText: createTextField({
+    multilineOptions: { isMultiline: true, rows: 2 },
+    validators: [htmlMaxLength(1000), htmlRequired()],
+  }),
   required: createCustomField(true, true),
 };
 
 export const createEmbedElement = () =>
-  createReactElementSpec(
-    embedFields,
-    (fieldValues, errors, __, fields) => {
-      return (
-        <EmbedElementForm
-          fields={fields}
-          errors={errors}
-          fieldValues={fieldValues}
-        />
-      );
-    },
-    createValidator({
-      altText: [htmlMaxLength(1000), htmlRequired()],
-      embedCode: [htmlRequired()],
-      caption: [maxLength(1000)],
-    })
-  );
+  createReactElementSpec(embedFields, (fieldValues, errors, __, fields) => {
+    return (
+      <EmbedElementForm
+        fields={fields}
+        errors={errors}
+        fieldValues={fieldValues}
+      />
+    );
+  });

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -4,7 +4,7 @@ import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
 import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
-import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+import { createGuElementSpec } from "../createGuElementSpec";
 import { ImageElementForm } from "./ImageElementForm";
 import { largestAssetMinDimension } from "./imageElementValidation";
 
@@ -90,7 +90,7 @@ export const createImageFields = (
 export const createImageElement = (
   openImageSelector: (setMedia: SetMedia, mediaId?: string) => void
 ) =>
-  createReactElementSpec(
+  createGuElementSpec(
     createImageFields(openImageSelector),
     (fieldValues, errors, __, fields) => {
       return (

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { ImageElementForm } from "./ImageElementForm";
+import { largestAssetMinDimension } from "./imageElementValidation";
 
 export type MediaPayload = {
   mediaId: string;
@@ -102,5 +103,6 @@ export const createImageElement = (
       altText: [htmlMaxLength(1000), htmlRequired()],
       source: [htmlMaxLength(250), htmlRequired()],
       photographer: [htmlMaxLength(250)],
+      mainImage: [largestAssetMinDimension(460)],
     })
   );

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -3,11 +3,7 @@ import React from "react";
 import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
 import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
-import {
-  createValidator,
-  htmlMaxLength,
-  htmlRequired,
-} from "../../plugin/helpers/validation";
+import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { ImageElementForm } from "./ImageElementForm";
 import { largestAssetMinDimension } from "./imageElementValidation";
@@ -50,12 +46,16 @@ export const createImageFields = (
   openImageSelector: (setMedia: SetMedia, mediaId?: string) => void
 ) => {
   return {
-    altText: createTextField({ isMultiline: true, rows: 2 }),
+    altText: createTextField({
+      multilineOptions: { isMultiline: true, rows: 2 },
+      validators: [htmlMaxLength(1000), htmlRequired()],
+    }),
     caption: createFlatRichTextField({
       createPlugins: (schema) => exampleSetup({ schema }),
       nodeSpec: {
         marks: "em strong link strike",
       },
+      validators: [htmlMaxLength(600)],
     }),
     displayCreditInformation: createCustomField(true, true),
     imageType: createCustomField("Photograph", [
@@ -63,7 +63,7 @@ export const createImageFields = (
       { text: "Illustration", value: "Illustration" },
       { text: "Composite", value: "Composite" },
     ]),
-    photographer: createTextField(),
+    photographer: createTextField({ validators: [htmlMaxLength(250)] }),
     mainImage: createCustomField<MainImageData, MainImageProps>(
       {
         mediaId: undefined,
@@ -71,9 +71,12 @@ export const createImageFields = (
         assets: [],
         suppliersReference: "",
       },
-      { openImageSelector }
+      { openImageSelector },
+      [largestAssetMinDimension(460)]
     ),
-    source: createTextField(),
+    source: createTextField({
+      validators: [htmlMaxLength(250), htmlRequired()],
+    }),
     weighting: createCustomField("none-selected", [
       { text: "inline (default)", value: "none-selected" },
       { text: "supporting", value: "supporting" },
@@ -97,12 +100,5 @@ export const createImageElement = (
           fields={fields}
         />
       );
-    },
-    createValidator({
-      caption: [htmlMaxLength(600)],
-      altText: [htmlMaxLength(1000), htmlRequired()],
-      source: [htmlMaxLength(250), htmlRequired()],
-      photographer: [htmlMaxLength(250)],
-      mainImage: [largestAssetMinDimension(460)],
-    })
+    }
   );

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -1,4 +1,6 @@
 import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+import { space } from "@guardian/src-foundations";
 import { SvgCamera } from "@guardian/src-icons";
 import { Column, Columns, Inline } from "@guardian/src-layout";
 import React from "react";
@@ -38,6 +40,10 @@ type ImageViewProps = {
   errors: ValidationError[];
   field: CustomField<MainImageData, MainImageProps>;
 };
+
+const AltText = styled.span`
+  margin-right: ${space[2]}px;
+`;
 
 export const ImageElementTestId = "ImageElement";
 
@@ -79,18 +85,20 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
           <FieldWrapper
             field={fields.altText}
             errors={errors.altText}
-            label="Alt text"
+            label={
+              <span>
+                <AltText>Alt text</AltText>
+                <Button
+                  priority="primary"
+                  size="xsmall"
+                  iconSide="left"
+                  onClick={() => fields.altText.update(fieldValues.caption)}
+                >
+                  Copy from caption
+                </Button>
+              </span>
+            }
           />
-        </span>
-        <span>
-          <Button
-            priority="primary"
-            size="xsmall"
-            iconSide="left"
-            onClick={() => fields.altText.update(fieldValues.caption)}
-          >
-            Copy from caption
-          </Button>
         </span>
         <Inline space={2}>
           <FieldWrapper

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -1,8 +1,8 @@
 import { css } from "@emotion/react";
-import { Button } from "@guardian/src-button";
 import { SvgCamera } from "@guardian/src-icons";
 import { Column, Columns, Inline } from "@guardian/src-layout";
 import React from "react";
+import { Button } from "../../editorial-source-components/Button";
 import { Error } from "../../editorial-source-components/Error";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
 import type {

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -85,7 +85,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
               <span>
                 <AltText>Alt text</AltText>
                 <Button
-                  priority="primary"
+                  priority="secondary"
                   size="xsmall"
                   iconSide="left"
                   onClick={() => fields.altText.update(fieldValues.caption)}
@@ -164,7 +164,7 @@ const ImageView = ({ field, onChange, errors }: ImageViewProps) => {
         <img css={imageViewStysles} src={getImageSrc()} />
       </div>
       <Button
-        priority="primary"
+        priority="secondary"
         size="xsmall"
         icon={<SvgCamera />}
         iconSide="left"

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { space } from "@guardian/src-foundations";
 import { SvgCamera } from "@guardian/src-icons";
-import { Column, Columns, Tiles } from "@guardian/src-layout";
+import { Column, Columns } from "@guardian/src-layout";
 import React from "react";
 import { Button } from "../../editorial-source-components/Button";
 import { Error } from "../../editorial-source-components/Error";

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { space } from "@guardian/src-foundations";
 import { SvgCamera } from "@guardian/src-icons";
-import { Column, Columns } from "@guardian/src-layout";
+import { Column, Columns, Tiles } from "@guardian/src-layout";
 import React from "react";
 import { Button } from "../../editorial-source-components/Button";
 import { Error } from "../../editorial-source-components/Error";
@@ -11,6 +11,7 @@ import type {
   FieldValidationErrors,
   ValidationError,
 } from "../../plugin/elementSpec";
+import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
 import type { CustomField, FieldNameToField } from "../../plugin/types/Element";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
@@ -51,6 +52,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
   <div data-cy={ImageElementTestId}>
     <Columns>
       <Column width={2 / 5}>
+<<<<<<< HEAD
         <CustomDropdownView
           field={fields.weighting}
           label="Weighting"
@@ -70,14 +72,36 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
           label={"Image type"}
           errors={errors.imageType}
         />
+=======
+        <FieldLayoutVertical>
+          <CustomDropdownView
+            field={fields.weighting}
+            label="Weighting"
+            errors={errors.weighting}
+          />
+          <ImageView
+            field={fields.mainImage}
+            onChange={({ caption, source, photographer }) => {
+              fields.caption.update(caption);
+              fields.source.update(source);
+              fields.photographer.update(photographer);
+            }}
+          />
+          <CustomDropdownView
+            field={fields.imageType}
+            label={"Image type"}
+            errors={errors.imageType}
+          />
+        </FieldLayoutVertical>
+>>>>>>> a68b722... Add FieldLayoutVertical
       </Column>
       <Column width={3 / 5}>
-        <FieldWrapper
-          field={fields.caption}
-          errors={errors.caption}
-          label="Caption"
-        />
-        <span>
+        <FieldLayoutVertical>
+          <FieldWrapper
+            field={fields.caption}
+            errors={errors.caption}
+            label="Caption"
+          />
           <FieldWrapper
             field={fields.altText}
             errors={errors.altText}
@@ -95,28 +119,28 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
               </span>
             }
           />
-        </span>
-        <Columns>
-          <Column width={1 / 2}>
-            <FieldWrapper
-              field={fields.photographer}
-              errors={errors.photographer}
-              label="Photographer"
-            />
-          </Column>
-          <Column width={1 / 2}>
-            <FieldWrapper
-              field={fields.source}
-              errors={errors.source}
-              label="Source"
-            />
-          </Column>
-        </Columns>
-        <CustomCheckboxView
-          field={fields.displayCreditInformation}
-          errors={errors.displayCreditInformation}
-          label="Display credit information"
-        />
+          <Columns>
+            <Column width={1 / 2}>
+              <FieldWrapper
+                field={fields.photographer}
+                errors={errors.photographer}
+                label="Photographer"
+              />
+            </Column>
+            <Column width={1 / 2}>
+              <FieldWrapper
+                field={fields.source}
+                errors={errors.source}
+                label="Source"
+              />
+            </Column>
+          </Columns>
+          <CustomCheckboxView
+            field={fields.displayCreditInformation}
+            errors={errors.displayCreditInformation}
+            label="Display credit information"
+          />
+        </FieldLayoutVertical>
       </Column>
     </Columns>
   </div>
@@ -158,11 +182,16 @@ const ImageView = ({ field, onChange, errors }: ImageViewProps) => {
   };
 
   return (
+<<<<<<< HEAD
     <>
       <Errors errors={errors.map((e) => e.error)} />
       <div>
         <img css={imageViewStysles} src={getImageSrc()} />
       </div>
+=======
+    <div>
+      <img css={imageViewStysles} src={getImageSrc()} />
+>>>>>>> a68b722... Add FieldLayoutVertical
       <Button
         priority="secondary"
         size="xsmall"
@@ -177,6 +206,6 @@ const ImageView = ({ field, onChange, errors }: ImageViewProps) => {
       >
         Re-crop image
       </Button>
-    </>
+    </div>
   );
 };

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -3,8 +3,12 @@ import { Button } from "@guardian/src-button";
 import { SvgCamera } from "@guardian/src-icons";
 import { Column, Columns, Inline } from "@guardian/src-layout";
 import React from "react";
+import { Error } from "../../editorial-source-components/Error";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
-import type { FieldValidationErrors } from "../../plugin/elementSpec";
+import type {
+  FieldValidationErrors,
+  ValidationError,
+} from "../../plugin/elementSpec";
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
 import type { CustomField, FieldNameToField } from "../../plugin/types/Element";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
@@ -31,6 +35,7 @@ type Props = {
 
 type ImageViewProps = {
   onChange: SetMedia;
+  errors: ValidationError[];
   field: CustomField<MainImageData, MainImageProps>;
 };
 
@@ -56,6 +61,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
             fields.source.update(source);
             fields.photographer.update(photographer);
           }}
+          errors={errors.mainImage}
         />
         <CustomDropdownView
           field={fields.imageType}
@@ -114,7 +120,10 @@ const imageViewStysles = css`
   width: 100%;
 `;
 
-const ImageView = ({ field, onChange }: ImageViewProps) => {
+const Errors = ({ errors }: { errors: string[] }) =>
+  !errors.length ? null : <Error>{errors.join(", ")}</Error>;
+
+const ImageView = ({ field, onChange, errors }: ImageViewProps) => {
   const [imageFields, setImageFields] = useCustomFieldState(field);
   const setMedia = (mediaPayload: MediaPayload) => {
     const { mediaId, mediaApiUri, assets, suppliersReference } = mediaPayload;
@@ -139,12 +148,12 @@ const ImageView = ({ field, onChange }: ImageViewProps) => {
     const assets = imageFields.assets
       .filter((asset) => !asset.fields.isMaster)
       .sort(sortByWidthDifference);
-
     return assets.length > 0 ? assets[0].url : undefined;
   };
 
   return (
     <>
+      <Errors errors={errors.map((e) => e.error)} />
       <div>
         <img css={imageViewStysles} src={getImageSrc()} />
       </div>

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { space } from "@guardian/src-foundations";
 import { SvgCamera } from "@guardian/src-icons";
-import { Column, Columns, Inline } from "@guardian/src-layout";
+import { Column, Columns } from "@guardian/src-layout";
 import React from "react";
 import { Button } from "../../editorial-source-components/Button";
 import { Error } from "../../editorial-source-components/Error";
@@ -24,10 +24,6 @@ import type {
   MediaPayload,
   SetMedia,
 } from "./ImageElement";
-
-const inlineStyles = css`
-  width: 40%;
-`;
 
 type Props = {
   fieldValues: FieldNameToValueMap<ReturnType<typeof createImageFields>>;
@@ -100,20 +96,22 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
             }
           />
         </span>
-        <Inline space={2}>
-          <FieldWrapper
-            field={fields.photographer}
-            errors={errors.photographer}
-            label="Photographer"
-            css={inlineStyles}
-          />
-          <FieldWrapper
-            field={fields.source}
-            errors={errors.source}
-            label="Source"
-            css={inlineStyles}
-          />
-        </Inline>
+        <Columns>
+          <Column width={1 / 2}>
+            <FieldWrapper
+              field={fields.photographer}
+              errors={errors.photographer}
+              label="Photographer"
+            />
+          </Column>
+          <Column width={1 / 2}>
+            <FieldWrapper
+              field={fields.source}
+              errors={errors.source}
+              label="Source"
+            />
+          </Column>
+        </Columns>
         <CustomCheckboxView
           field={fields.displayCreditInformation}
           errors={errors.displayCreditInformation}

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -4,6 +4,7 @@ import { SvgCamera } from "@guardian/src-icons";
 import { Column, Columns, Inline } from "@guardian/src-layout";
 import React from "react";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import type { FieldValidationErrors } from "../../plugin/elementSpec";
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
 import type { CustomField, FieldNameToField } from "../../plugin/types/Element";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
@@ -24,7 +25,7 @@ const inlineStyles = css`
 
 type Props = {
   fieldValues: FieldNameToValueMap<ReturnType<typeof createImageFields>>;
-  errors: Record<string, string[]>;
+  errors: FieldValidationErrors;
   fields: FieldNameToField<ReturnType<typeof createImageFields>>;
 };
 

--- a/src/elements/image/imageElementValidation.tsx
+++ b/src/elements/image/imageElementValidation.tsx
@@ -1,0 +1,52 @@
+import type { Validator } from "../../plugin/helpers/validation";
+import type { Asset } from "./ImageElement";
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === "object" && value !== null;
+};
+
+const isValidImageAsset = (maybeImage: unknown): maybeImage is Asset => {
+  return (
+    isRecord(maybeImage) &&
+    maybeImage.fields !== undefined &&
+    isRecord(maybeImage.fields) &&
+    maybeImage.fields.width !== undefined &&
+    maybeImage.fields.height !== undefined &&
+    typeof maybeImage.fields.width === "number" &&
+    typeof maybeImage.fields.height === "number"
+  );
+};
+
+const hasAssets = (maybeData: unknown): maybeData is { assets: Asset[] } => {
+  return (
+    isRecord(maybeData) &&
+    maybeData.assets != undefined &&
+    Array.isArray(maybeData.assets) &&
+    maybeData.assets.every((asset) => isValidImageAsset(asset))
+  );
+};
+
+export const largestAssetMinDimension = (minSize: number): Validator => (
+  value
+) => {
+  if (hasAssets(value)) {
+    const largestImageAsset = value.assets.sort(function (a, b) {
+      return b.fields.width - a.fields.width;
+    })[0];
+
+    if (
+      largestImageAsset.fields.width < minSize &&
+      largestImageAsset.fields.height < minSize
+    ) {
+      return [
+        {
+          error: "Warning: Small image, only thumbnail available",
+          message:
+            "Image should be greater than 460 x 460px for uses other than a thumbnail.",
+        },
+      ];
+    }
+  }
+
+  return [];
+};

--- a/src/elements/image/imageElementValidation.tsx
+++ b/src/elements/image/imageElementValidation.tsx
@@ -1,4 +1,4 @@
-import type { Validator } from "../../plugin/helpers/validation";
+import type { FieldValidator } from "../../plugin/elementSpec";
 import type { Asset } from "./ImageElement";
 
 const isRecord = (value: unknown): value is Record<string, unknown> => {
@@ -26,7 +26,7 @@ const hasAssets = (maybeData: unknown): maybeData is { assets: Asset[] } => {
   );
 };
 
-export const largestAssetMinDimension = (minSize: number): Validator => (
+export const largestAssetMinDimension = (minSize: number): FieldValidator => (
   value
 ) => {
   if (hasAssets(value)) {

--- a/src/elements/pullquote/PullquoteForm.tsx
+++ b/src/elements/pullquote/PullquoteForm.tsx
@@ -22,8 +22,8 @@ export const PullquoteElementForm: React.FunctionComponent<Props> = ({
       <Column width={2 / 3}>
         <FieldWrapper
           label="Pullquote"
-          field={fields.pullquote}
-          errors={errors.pullquote}
+          field={fields.html}
+          errors={errors.html}
         />
       </Column>
       <Column width={1 / 3}>
@@ -32,7 +32,7 @@ export const PullquoteElementForm: React.FunctionComponent<Props> = ({
           field={fields.attribution}
           errors={errors.attribution}
         />
-        <CustomDropdownView label="Weighting" field={fields.weighting} />
+        <CustomDropdownView label="Weighting" field={fields.role} />
       </Column>
     </Columns>
   </div>

--- a/src/elements/pullquote/PullquoteForm.tsx
+++ b/src/elements/pullquote/PullquoteForm.tsx
@@ -22,8 +22,8 @@ export const PullquoteElementForm: React.FunctionComponent<Props> = ({
       <Column width={2 / 3}>
         <FieldWrapper
           label="Pullquote"
-          field={fields.html}
-          errors={errors.html}
+          field={fields.pullquote}
+          errors={errors.pullquote}
         />
       </Column>
       <Column width={1 / 3}>
@@ -32,7 +32,7 @@ export const PullquoteElementForm: React.FunctionComponent<Props> = ({
           field={fields.attribution}
           errors={errors.attribution}
         />
-        <CustomDropdownView label="Weighting" field={fields.role} />
+        <CustomDropdownView label="Weighting" field={fields.weighting} />
       </Column>
     </Columns>
   </div>

--- a/src/elements/pullquote/PullquoteForm.tsx
+++ b/src/elements/pullquote/PullquoteForm.tsx
@@ -1,12 +1,13 @@
 import { Column, Columns } from "@guardian/src-layout";
 import React from "react";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import type { FieldValidationErrors } from "../../plugin/elementSpec";
 import type { FieldNameToField } from "../../plugin/types/Element";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import type { pullquoteFields } from "./PullquoteSpec";
 
 type Props = {
-  errors: Record<string, string[]>;
+  errors: FieldValidationErrors;
   fields: FieldNameToField<typeof pullquoteFields>;
 };
 

--- a/src/elements/pullquote/PullquoteForm.tsx
+++ b/src/elements/pullquote/PullquoteForm.tsx
@@ -2,6 +2,7 @@ import { Column, Columns } from "@guardian/src-layout";
 import React from "react";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
 import type { FieldValidationErrors } from "../../plugin/elementSpec";
+import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
 import type { FieldNameToField } from "../../plugin/types/Element";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import type { pullquoteFields } from "./PullquoteSpec";
@@ -27,12 +28,23 @@ export const PullquoteElementForm: React.FunctionComponent<Props> = ({
         />
       </Column>
       <Column width={1 / 3}>
+<<<<<<< HEAD
         <FieldWrapper
           label="Attribution"
           field={fields.attribution}
           errors={errors.attribution}
         />
         <CustomDropdownView label="Weighting" field={fields.role} />
+=======
+        <FieldLayoutVertical>
+          <FieldWrapper
+            label="Attribution"
+            field={fields.attribution}
+            errors={errors.attribution}
+          />
+          <CustomDropdownView label="Weighting" field={fields.weighting} />
+        </FieldLayoutVertical>
+>>>>>>> a68b722... Add FieldLayoutVertical
       </Column>
     </Columns>
   </div>

--- a/src/elements/pullquote/PullquoteSpec.tsx
+++ b/src/elements/pullquote/PullquoteSpec.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 import { createCustomDropdownField } from "../../plugin/fieldViews/CustomFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
-import { createValidator, htmlRequired } from "../../plugin/helpers/validation";
+import { htmlRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { PullquoteElementForm } from "./PullquoteForm";
 
 export const pullquoteFields = {
-  html: createTextField({ isMultiline: true, rows: 4 }),
+  html: createTextField({
+    multilineOptions: { isMultiline: true, rows: 4 },
+    validators: [htmlRequired()],
+  }),
   attribution: createTextField(),
   role: createCustomDropdownField("supporting", [
     { text: "supporting (default)", value: "supporting" },
@@ -19,6 +22,5 @@ export const pullquoteElement = createReactElementSpec(
   pullquoteFields,
   (_, errors, __, fields) => {
     return <PullquoteElementForm errors={errors} fields={fields} />;
-  },
-  createValidator({ pullquote: [htmlRequired()] })
+  }
 );

--- a/src/elements/pullquote/PullquoteSpec.tsx
+++ b/src/elements/pullquote/PullquoteSpec.tsx
@@ -6,9 +6,9 @@ import { createReactElementSpec } from "../../renderers/react/createReactElement
 import { PullquoteElementForm } from "./PullquoteForm";
 
 export const pullquoteFields = {
-  pullquote: createTextField({ isMultiline: true, rows: 4 }),
+  html: createTextField({ isMultiline: true, rows: 4 }),
   attribution: createTextField(),
-  weighting: createCustomDropdownField("supporting", [
+  role: createCustomDropdownField("supporting", [
     { text: "supporting (default)", value: "supporting" },
     { text: "inline", value: "inline" },
     { text: "showcase", value: "showcase" },

--- a/src/elements/pullquote/PullquoteSpec.tsx
+++ b/src/elements/pullquote/PullquoteSpec.tsx
@@ -6,9 +6,9 @@ import { createReactElementSpec } from "../../renderers/react/createReactElement
 import { PullquoteElementForm } from "./PullquoteForm";
 
 export const pullquoteFields = {
-  html: createTextField({ isMultiline: true, rows: 4 }),
+  pullquote: createTextField({ isMultiline: true, rows: 4 }),
   attribution: createTextField(),
-  role: createCustomDropdownField("supporting", [
+  weighting: createCustomDropdownField("supporting", [
     { text: "supporting (default)", value: "supporting" },
     { text: "inline", value: "inline" },
     { text: "showcase", value: "showcase" },

--- a/src/elements/pullquote/PullquoteSpec.tsx
+++ b/src/elements/pullquote/PullquoteSpec.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { createCustomDropdownField } from "../../plugin/fieldViews/CustomFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { htmlRequired } from "../../plugin/helpers/validation";
-import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+import { createGuElementSpec } from "../createGuElementSpec";
 import { PullquoteElementForm } from "./PullquoteForm";
 
 export const pullquoteFields = {
@@ -18,7 +18,7 @@ export const pullquoteFields = {
   ]),
 };
 
-export const pullquoteElement = createReactElementSpec(
+export const pullquoteElement = createGuElementSpec(
   pullquoteFields,
   (_, errors, __, fields) => {
     return <PullquoteElementForm errors={errors} fields={fields} />;

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -360,7 +360,7 @@ describe("buildElementPlugin", () => {
         field1: { type: "richText" },
       },
       () => undefined,
-      () => ({ field1: ["Some error"] })
+      () => ({ field1: [{ error: "Some error", message: "" }] })
     );
 
     const testElementWithDifferentValidation = createElementSpec(
@@ -368,7 +368,11 @@ describe("buildElementPlugin", () => {
         checkbox: { type: "checkbox" },
       },
       () => undefined,
-      () => ({ checkbox: ["Some other error"] })
+      () => ({
+        checkbox: [
+          { error: "Some other error", message: "A human readable message" },
+        ],
+      })
     );
 
     type ExternalData = { nestedElementValues: { field1: string } };
@@ -677,14 +681,23 @@ describe("buildElementPlugin", () => {
               },
             });
 
-            expect(errors).toEqual({ field1: ["Some error"] });
+            expect(errors).toEqual({
+              field1: [{ error: "Some error", message: "" }],
+            });
 
             const otherErrors = validateElementData({
               elementName: "testElementWithDifferentValidation",
               values: { checkbox: true },
             });
 
-            expect(otherErrors).toEqual({ checkbox: ["Some other error"] });
+            expect(otherErrors).toEqual({
+              checkbox: [
+                {
+                  error: "Some other error",
+                  message: "A human readable message",
+                },
+              ],
+            });
           });
 
           it("should output undefined if there are no errors", () => {
@@ -749,7 +762,9 @@ describe("buildElementPlugin", () => {
               )!
             );
 
-            expect(errors).toEqual({ field1: ["Some error"] });
+            expect(errors).toEqual({
+              field1: [{ error: "Some error", message: "" }],
+            });
           });
         });
       });

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -208,7 +208,7 @@ describe("buildElementPlugin", () => {
       );
 
       const expected = trimHtml(`
-        <div pme-element-type="testElement" has-errors="false">
+        <div pme-element-type="testElement">
           <div pme-field-name="testElement_field1" fields="false"></div>
           <div pme-field-name="testElement_field2"><p>Content</p></div>
         </div>`);
@@ -231,7 +231,7 @@ describe("buildElementPlugin", () => {
       })(view.state, view.dispatch);
 
       const expected = trimHtml(`
-        <div pme-element-type="testElement" has-errors="false">
+        <div pme-element-type="testElement">
           <div pme-field-name="testElement_field1" fields="true"></div>
         </div>`);
       expect(getElementAsHTML()).toBe(expected);
@@ -253,7 +253,7 @@ describe("buildElementPlugin", () => {
       })(view.state, view.dispatch);
 
       const expected = trimHtml(`
-        <div pme-element-type="testElement" has-errors="false">
+        <div pme-element-type="testElement">
           <div pme-field-name="testElement_field1"><p>Content</p></div>
         </div>`);
       expect(getElementAsHTML()).toBe(expected);
@@ -279,7 +279,7 @@ describe("buildElementPlugin", () => {
       })(view.state, view.dispatch);
 
       const expected = trimHtml(`
-        <div pme-element-type="testElement" has-errors="false">
+        <div pme-element-type="testElement">
           <div pme-field-name="testElement_field1"><p>Content for field1</p></div>
           <div pme-field-name="testElement_field2"><p>Content for field2</p></div>
         </div>`);
@@ -305,7 +305,7 @@ describe("buildElementPlugin", () => {
       })(view.state, view.dispatch);
 
       const expected = trimHtml(`
-        <div pme-element-type="testElement" has-errors="false">
+        <div pme-element-type="testElement">
           <div pme-field-name="testElement_field1" fields="{&quot;arbitraryValue&quot;:&quot;hai&quot;}"></div>
         </div>`);
       expect(getElementAsHTML()).toBe(expected);
@@ -314,7 +314,7 @@ describe("buildElementPlugin", () => {
 
   describe("Serialisation/deserialisation", () => {
     const testElementHTML = `
-          <div pme-element-type="testElement" has-errors="false">
+          <div pme-element-type="testElement">
           <div pme-field-name="testElement_field1"><p></p></div>
           <div pme-field-name="testElement_field2"></div>
           <div pme-field-name="testElement_field3" fields="true"></div>
@@ -322,14 +322,14 @@ describe("buildElementPlugin", () => {
         `;
 
     const testElement2HTML = `
-        <div pme-element-type="testElement2" has-errors="false">
+        <div pme-element-type="testElement2">
         <div pme-field-name="testElement_field4"><p></p></div>
         <div pme-field-name="testElement_field5"></div>
         </div2>
       `;
 
     const testElementTransformHTML = `
-      <div pme-element-type="testElementWithTransform" has-errors="false">
+      <div pme-element-type="testElementWithTransform">
       <element-testelementwithtransform-field1 pme-field-name="testElement_field1"><p></p></element-testelementwithtransform-field1>
       </div2>
     `;
@@ -436,7 +436,7 @@ describe("buildElementPlugin", () => {
     describe("Element parsing", () => {
       it("should parse fields of all types, respecting values against defaults", () => {
         const elementHTML = `
-          <div pme-element-type="testElement" has-errors="false">
+          <div pme-element-type="testElement">
           <div pme-field-name="testElement_field1"><p>Content</p></div>
           <div pme-field-name="testElement_field2">Content</div>
           <div pme-field-name="testElement_field3" fields="true"></div>
@@ -453,7 +453,7 @@ describe("buildElementPlugin", () => {
 
       it("should parse fields of all types, handling empty content values correctly", () => {
         const elementHTML = `
-          <div pme-element-type="testElement" has-errors="false">
+          <div pme-element-type="testElement">
           <div pme-field-name="testElement_field1"><p></p></div>
           <div pme-field-name="testElement_field2"></div>
           <div pme-field-name="testElement_field3" fields="true"></div>

--- a/src/plugin/element.ts
+++ b/src/plugin/element.ts
@@ -64,7 +64,6 @@ export const buildElementPlugin = <
 
   return {
     insertElement,
-    hasErrors: (state: EditorState) => plugin.getState(state).hasErrors,
     plugin,
     nodeSpec,
     getElementDataFromNode,

--- a/src/plugin/elementSpec.ts
+++ b/src/plugin/elementSpec.ts
@@ -29,9 +29,15 @@ const createUpdater = <
   };
 };
 
+export type ValidationError = {
+  error: string;
+  message: string;
+};
+export type FieldValidationErrors = Record<string, ValidationError[]>;
+
 export type Validator<FDesc extends FieldDescriptions<string>> = (
   fields: FieldNameToValueMap<FDesc>
-) => undefined | Record<string, string[]>;
+) => undefined | FieldValidationErrors;
 
 export type Renderer<FDesc extends FieldDescriptions<string>> = (
   validate: Validator<FDesc>,

--- a/src/plugin/elementSpec.ts
+++ b/src/plugin/elementSpec.ts
@@ -75,7 +75,7 @@ export const createElementSpec = <
       validate,
       dom,
       fields,
-      (fields) => updateState(fields, !!validate(fields)),
+      (fields) => updateState(fields),
       fieldValues,
       commands,
       updater.subscribe

--- a/src/plugin/fieldViews/CheckboxFieldView.ts
+++ b/src/plugin/fieldViews/CheckboxFieldView.ts
@@ -1,5 +1,6 @@
 import type { Node } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
+import type { FieldValidator } from "../elementSpec";
 import { AttributeFieldView } from "./AttributeFieldView";
 import type { BaseFieldDescription } from "./FieldView";
 
@@ -11,10 +12,12 @@ export interface CheckboxFieldDescription
 }
 
 export const createCheckBox = (
-  defaultValue: boolean
+  defaultValue: boolean,
+  validators?: FieldValidator[]
 ): CheckboxFieldDescription => ({
   type: CheckboxFieldView.fieldName,
   defaultValue,
+  validators,
 });
 
 export class CheckboxFieldView extends AttributeFieldView<CheckboxValue> {

--- a/src/plugin/fieldViews/CustomFieldView.ts
+++ b/src/plugin/fieldViews/CustomFieldView.ts
@@ -1,5 +1,6 @@
 import type { Node } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
+import type { FieldValidator } from "../elementSpec";
 import type { Options } from "./DropdownFieldView";
 import type { BaseFieldDescription, FieldView } from "./FieldView";
 import { FieldType } from "./FieldView";
@@ -13,20 +14,24 @@ export interface CustomFieldDescription<Data = unknown, Props = unknown>
 
 export const createCustomField = <Data, Props>(
   defaultValue: Data,
-  props: Props
+  props: Props,
+  validators?: FieldValidator[]
 ): CustomFieldDescription<Data, Props> => ({
   type: "custom" as const,
   defaultValue,
   props,
+  validators,
 });
 
 export const createCustomDropdownField = (
   defaultValue: string,
-  props: Options
+  props: Options,
+  validators?: FieldValidator[]
 ): CustomFieldDescription<string, Options> => ({
   type: "custom" as const,
   defaultValue,
   props,
+  validators,
 });
 
 type Subscriber<Fields extends unknown> = (fields: Fields) => void;

--- a/src/plugin/fieldViews/DropdownFieldView.ts
+++ b/src/plugin/fieldViews/DropdownFieldView.ts
@@ -1,5 +1,6 @@
 import type { Node } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
+import type { FieldValidator } from "../elementSpec";
 import { AttributeFieldView } from "./AttributeFieldView";
 import type { BaseFieldDescription } from "./FieldView";
 
@@ -13,11 +14,13 @@ export interface DropdownFieldDescription extends BaseFieldDescription<string> {
 
 export const createDropDownField = (
   options: Options,
-  defaultValue: string
+  defaultValue: string,
+  validators?: FieldValidator[]
 ): DropdownFieldDescription => ({
   type: DropdownFieldView.fieldName,
   options,
   defaultValue,
+  validators,
 });
 
 export type DropdownFields = string;

--- a/src/plugin/fieldViews/FieldView.ts
+++ b/src/plugin/fieldViews/FieldView.ts
@@ -1,5 +1,6 @@
 import type { Node } from "prosemirror-model";
 import type { Decoration, DecorationSet } from "prosemirror-view";
+import type { FieldValidator } from "../elementSpec";
 
 /**
  * The specification for an element field, to be modelled as a Node in Prosemirror.
@@ -8,6 +9,7 @@ export interface BaseFieldDescription<DefaultValue extends unknown> {
   // The data type of the field.
   type: string;
   defaultValue?: DefaultValue;
+  validators?: FieldValidator[];
 }
 
 export enum FieldType {

--- a/src/plugin/fieldViews/RichTextFieldView.ts
+++ b/src/plugin/fieldViews/RichTextFieldView.ts
@@ -4,6 +4,7 @@ import { keymap } from "prosemirror-keymap";
 import type { Node, NodeSpec, Schema } from "prosemirror-model";
 import type { EditorState, Plugin, Transaction } from "prosemirror-state";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
+import type { FieldValidator } from "../elementSpec";
 import type { BaseFieldDescription } from "./FieldView";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
 
@@ -16,19 +17,23 @@ export interface RichTextFieldDescription extends BaseFieldDescription<string> {
 type RichTextOptions = {
   createPlugins?: (schema: Schema) => Plugin[];
   nodeSpec?: Partial<NodeSpec>;
+  validators?: FieldValidator[];
 };
 
 export const createRichTextField = ({
   createPlugins,
   nodeSpec,
+  validators,
 }: RichTextOptions): RichTextFieldDescription => ({
   type: RichTextFieldView.fieldName,
   createPlugins,
   nodeSpec,
+  validators,
 });
 
 type FlatRichTextOptions = RichTextOptions & {
   nodeSpec?: Partial<Omit<NodeSpec, "content">>;
+  validators?: FieldValidator[];
 };
 
 /**
@@ -38,6 +43,7 @@ type FlatRichTextOptions = RichTextOptions & {
 export const createFlatRichTextField = ({
   createPlugins,
   nodeSpec,
+  validators,
 }: FlatRichTextOptions): RichTextFieldDescription =>
   createRichTextField({
     createPlugins: (schema) => {
@@ -65,14 +71,20 @@ export const createFlatRichTextField = ({
       ...nodeSpec,
       content: "(text|hard_break)*",
     },
+    validators,
   });
 
 /**
  * Create a rich text field with a default setup. Largely for demonstrative
  * purposes, as library users are likely to want different defaults.
  */
-export const createDefaultRichTextField = (): RichTextFieldDescription =>
-  createRichTextField({ createPlugins: (schema) => exampleSetup({ schema }) });
+export const createDefaultRichTextField = (
+  validators?: FieldValidator[]
+): RichTextFieldDescription =>
+  createRichTextField({
+    createPlugins: (schema) => exampleSetup({ schema }),
+    validators,
+  });
 
 export class RichTextFieldView extends ProseMirrorFieldView {
   public static fieldName = "richText" as const;

--- a/src/plugin/fieldViews/TextFieldView.ts
+++ b/src/plugin/fieldViews/TextFieldView.ts
@@ -5,6 +5,7 @@ import { keymap } from "prosemirror-keymap";
 import type { Node, Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
+import type { FieldValidator } from "../elementSpec";
 import type { BaseFieldDescription } from "./FieldView";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
 
@@ -22,19 +23,31 @@ export interface TextFieldDescription extends BaseFieldDescription<string> {
 
 type MultilineOptions = {
   isMultiline: boolean;
-  rows?: number;
+  rows: number;
 };
+
+type TextFieldOptions = {
+  multilineOptions?: MultilineOptions;
+  isCode?: boolean;
+  validators?: FieldValidator[];
+};
+
 export const createTextField = (
-  { isMultiline = false, rows = 1 }: MultilineOptions = {
-    isMultiline: false,
-    rows: 1,
-  },
-  isCode = false
+  {
+    multilineOptions = { isMultiline: false, rows: 1 },
+    isCode = false,
+    validators = [],
+  }: TextFieldOptions | undefined = {
+    multilineOptions: { isMultiline: false, rows: 1 },
+    isCode: false,
+    validators: [],
+  }
 ): TextFieldDescription => ({
   type: TextFieldView.fieldName,
-  isMultiline,
-  rows,
+  isMultiline: multilineOptions.isMultiline,
+  rows: multilineOptions.rows,
   isCode,
+  validators,
 });
 
 export class TextFieldView extends ProseMirrorFieldView {

--- a/src/plugin/helpers/element.ts
+++ b/src/plugin/helpers/element.ts
@@ -1,4 +1,5 @@
 import type { DOMSerializer, Node, Schema } from "prosemirror-model";
+import type { FieldValidationErrors } from "../elementSpec";
 import type { FieldNameToValueMap } from "../fieldViews/helpers";
 import { fieldTypeToViewMap } from "../fieldViews/helpers";
 import { createNodesForFieldValues, getFieldNameFromNode } from "../nodeSpec";
@@ -133,7 +134,7 @@ export const createElementDataValidator = <
   elementName,
   values,
 }: ExtractDataTypeFromElementSpec<ESpec, ElementNames>):
-  | Record<string, string[]>
+  | FieldValidationErrors
   | undefined => {
   const element = elementTypeMap[elementName];
 

--- a/src/plugin/helpers/validation.spec.ts
+++ b/src/plugin/helpers/validation.spec.ts
@@ -14,7 +14,9 @@ describe("Validation helpers", () => {
 
       expect(result).toEqual({
         field1: [],
-        field2: ["Too long: 7/5"],
+        field2: [
+          { error: "Too long: 7/5", message: "field2 is too long: 7/5" },
+        ],
       });
     });
 
@@ -28,7 +30,7 @@ describe("Validation helpers", () => {
       });
 
       expect(result).toEqual({
-        field1: ["Required"],
+        field1: [{ error: "Required", message: "field1 is required" }],
       });
     });
   });

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -1,14 +1,9 @@
-import type { FieldValidationErrors, ValidationError } from "../elementSpec";
+import type { FieldValidationErrors, FieldValidator } from "../elementSpec";
 import type { FieldNameToValueMap } from "../fieldViews/helpers";
 import type { FieldDescriptions } from "../types/Element";
 
-export type Validator = (
-  fieldValue: unknown,
-  fieldName: string
-) => ValidationError[];
-
 export const createValidator = (
-  fieldValidationMap: Record<string, Validator[]>
+  fieldValidationMap: Record<string, FieldValidator[]>
 ) => <FDesc extends FieldDescriptions<string>>(
   fieldValues: FieldNameToValueMap<FDesc>
 ): FieldValidationErrors => {
@@ -28,7 +23,7 @@ export const createValidator = (
 export const htmlMaxLength = (
   maxLength: number,
   customMessage: string | undefined = undefined
-): Validator => (value, field) => {
+): FieldValidator => (value, field) => {
   if (typeof value !== "string" && value !== undefined) {
     const typeError = `html max length check: ${field} value is incorrect`;
     return [
@@ -57,7 +52,7 @@ export const htmlMaxLength = (
 export const maxLength = (
   maxLength: number,
   customMessage: string | undefined = undefined
-): Validator => (value, field) => {
+): FieldValidator => (value, field) => {
   if (typeof value !== "string" && value !== undefined) {
     const typeError = `max length check: ${field} value is incorrect`;
     return [
@@ -82,7 +77,7 @@ export const maxLength = (
 
 export const htmlRequired = (
   customMessage: string | undefined = undefined
-): Validator => (value, field) => {
+): FieldValidator => (value, field) => {
   if (typeof value !== "string" && value !== undefined) {
     const typeError = `required check: ${field} value is incorrect`;
     return [
@@ -104,7 +99,7 @@ export const htmlRequired = (
 
 export const required = (
   customMessage: string | undefined = undefined
-): Validator => (value, field) => {
+): FieldValidator => (value, field) => {
   if (typeof value !== "string" && value !== undefined) {
     const typeError = `required check: ${field} value is incorrect`;
     return [

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -1,64 +1,93 @@
+import type { FieldValidationErrors, ValidationError } from "../elementSpec";
 import type { FieldNameToValueMap } from "../fieldViews/helpers";
 import type { FieldDescriptions } from "../types/Element";
 
-type Validator = (fieldValue: unknown) => string[];
+type Validator = (fieldValue: unknown, fieldName: string) => ValidationError[];
 
 export const createValidator = (
   fieldValidationMap: Record<string, Validator[]>
 ) => <FDesc extends FieldDescriptions<string>>(
   fieldValues: FieldNameToValueMap<FDesc>
-): Record<string, string[]> => {
-  const errors: Record<string, string[]> = {};
+): FieldValidationErrors => {
+  const errors: FieldValidationErrors = {};
 
   for (const fieldName in fieldValidationMap) {
     const validators = fieldValidationMap[fieldName];
     const value = fieldValues[fieldName];
-    const fieldErrors = validators.flatMap((validator) => validator(value));
+    const fieldErrors = validators.flatMap((validator) =>
+      validator(value, fieldName)
+    );
     errors[fieldName] = fieldErrors;
   }
   return errors;
 };
 
-export const htmlMaxLength = (maxLength: number): Validator => (value) => {
+export const htmlMaxLength = (
+  maxLength: number,
+  customMessage: string | undefined = undefined
+): Validator => (value, field) => {
   if (typeof value !== "string") {
     throw new Error(`[htmlMaxLength]: value is not of type string`);
   }
   const el = document.createElement("div");
   el.innerHTML = value;
   if (el.innerText.length > maxLength) {
-    return [`Too long: ${el.innerText.length}/${maxLength}`];
+    return [
+      {
+        error: `Too long: ${value.length}/${maxLength}`,
+        message:
+          customMessage ?? `${field} is too long: ${value.length}/${maxLength}`,
+      },
+    ];
   }
   return [];
 };
 
-export const maxLength = (maxLength: number): Validator => (value) => {
+export const maxLength = (
+  maxLength: number,
+  customMessage: string | undefined = undefined
+): Validator => (value, field) => {
   if (typeof value !== "string") {
     throw new Error(`[maxLength]: value is not of type string`);
   }
   if (value.length > maxLength) {
-    return [`Too long: ${value.length}/${maxLength}`];
+    return [
+      {
+        error: `Too long: ${value.length}/${maxLength}`,
+        message:
+          customMessage ?? `${field} is too long: ${value.length}/${maxLength}`,
+      },
+    ];
   }
   return [];
 };
 
-export const htmlRequired = (): Validator => (value) => {
+export const htmlRequired = (
+  customMessage: string | undefined = undefined
+): Validator => (value, field) => {
   if (typeof value !== "string") {
     throw new Error(`[maxLength]: value is not of type string`);
   }
   const el = document.createElement("div");
   el.innerHTML = value;
   if (!el.innerText.length) {
-    return ["Required"];
+    return [
+      { error: "Required", message: customMessage ?? `${field} is required` },
+    ];
   }
   return [];
 };
 
-export const required = (): Validator => (value) => {
+export const required = (
+  customMessage: string | undefined = undefined
+): Validator => (value, field) => {
   if (typeof value !== "string") {
     throw new Error(`[maxLength]: value is not of type string`);
   }
   if (!value.length) {
-    return ["Required"];
+    return [
+      { error: "Required", message: customMessage ?? `${field} is required` },
+    ];
   }
   return [];
 };

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -29,17 +29,25 @@ export const htmlMaxLength = (
   maxLength: number,
   customMessage: string | undefined = undefined
 ): Validator => (value, field) => {
-  if (typeof value !== "string") {
-    throw new Error(`[htmlMaxLength]: value is not of type string`);
-  }
-  const el = document.createElement("div");
-  el.innerHTML = value;
-  if (el.innerText.length > maxLength) {
+  if (typeof value !== "string" && value !== undefined) {
+    const typeError = `html max length check: ${field} value is incorrect`;
     return [
       {
-        error: `Too long: ${value.length}/${maxLength}`,
+        message: typeError,
+        error: typeError,
+      },
+    ];
+  }
+
+  const el = document.createElement("div");
+  el.innerHTML = value ?? "";
+  const length = el.innerText.length;
+  if (length > maxLength) {
+    return [
+      {
+        error: `Too long: ${length}/${maxLength}`,
         message:
-          customMessage ?? `${field} is too long: ${value.length}/${maxLength}`,
+          customMessage ?? `${field} is too long: ${length}/${maxLength}`,
       },
     ];
   }
@@ -50,15 +58,22 @@ export const maxLength = (
   maxLength: number,
   customMessage: string | undefined = undefined
 ): Validator => (value, field) => {
-  if (typeof value !== "string") {
-    throw new Error(`[maxLength]: value is not of type string`);
-  }
-  if (value.length > maxLength) {
+  if (typeof value !== "string" && value !== undefined) {
+    const typeError = `max length check: ${field} value is incorrect`;
     return [
       {
-        error: `Too long: ${value.length}/${maxLength}`,
+        message: typeError,
+        error: typeError,
+      },
+    ];
+  }
+  const length = (value ?? "").length;
+  if (length > maxLength) {
+    return [
+      {
+        error: `Too long: ${length}/${maxLength}`,
         message:
-          customMessage ?? `${field} is too long: ${value.length}/${maxLength}`,
+          customMessage ?? `${field} is too long: ${length}/${maxLength}`,
       },
     ];
   }
@@ -68,11 +83,17 @@ export const maxLength = (
 export const htmlRequired = (
   customMessage: string | undefined = undefined
 ): Validator => (value, field) => {
-  if (typeof value !== "string") {
-    throw new Error(`[maxLength]: value is not of type string`);
+  if (typeof value !== "string" && value !== undefined) {
+    const typeError = `required check: ${field} value is incorrect`;
+    return [
+      {
+        message: typeError,
+        error: typeError,
+      },
+    ];
   }
   const el = document.createElement("div");
-  el.innerHTML = value;
+  el.innerHTML = value ?? "";
   if (!el.innerText.length) {
     return [
       { error: "Required", message: customMessage ?? `${field} is required` },
@@ -84,10 +105,17 @@ export const htmlRequired = (
 export const required = (
   customMessage: string | undefined = undefined
 ): Validator => (value, field) => {
-  if (typeof value !== "string") {
-    throw new Error(`[maxLength]: value is not of type string`);
+  if (typeof value !== "string" && value !== undefined) {
+    const typeError = `required check: ${field} value is incorrect`;
+    return [
+      {
+        message: typeError,
+        error: typeError,
+      },
+    ];
   }
-  if (!value.length) {
+  const length = (value ?? "").length;
+  if (!length) {
     return [
       { error: "Required", message: customMessage ?? `${field} is required` },
     ];

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -2,7 +2,10 @@ import type { FieldValidationErrors, ValidationError } from "../elementSpec";
 import type { FieldNameToValueMap } from "../fieldViews/helpers";
 import type { FieldDescriptions } from "../types/Element";
 
-type Validator = (fieldValue: unknown, fieldName: string) => ValidationError[];
+export type Validator = (
+  fieldValue: unknown,
+  fieldName: string
+) => ValidationError[];
 
 export const createValidator = (
   fieldValidationMap: Record<string, Validator[]>

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -44,9 +44,6 @@ const getNodeSpecForElement = (
       addUpdateDecoration: {
         default: true,
       },
-      hasErrors: {
-        default: false,
-      },
     },
     draggable: false,
     toDOM: (node: Node) => [
@@ -54,7 +51,6 @@ const getNodeSpecForElement = (
       {
         [elementTypeAttr]: node.attrs.type as string,
         fields: JSON.stringify(node.attrs.fields),
-        "has-errors": JSON.stringify(node.attrs.hasErrors),
       },
       0,
     ],
@@ -67,12 +63,9 @@ const getNodeSpecForElement = (
             return false;
           }
 
-          const hasErrorAttr = dom.getAttribute("has-errors");
-
           return {
             type: elementName,
             fields: JSON.parse(dom.getAttribute("fields") ?? "{}") as unknown,
-            hasErrors: hasErrorAttr && hasErrorAttr !== "false",
           };
         },
       },
@@ -187,7 +180,6 @@ const getDefaultToDOMForLeafNode = (nodeName: string) => (node: Node) => [
   {
     [fieldNameAttr]: nodeName,
     fields: JSON.stringify(node.attrs.fields),
-    "has-errors": JSON.stringify(node.attrs.hasErrors),
   },
 ];
 

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -16,7 +16,7 @@ import { getFieldNameFromNode } from "./nodeSpec";
 const decorations = createUpdateDecorations();
 const pluginKey = new PluginKey("prosemirror_elements");
 
-export type PluginState = { hasErrors: boolean };
+export type PluginState = unknown;
 
 export const createPlugin = <
   ElementNames extends string,
@@ -28,32 +28,8 @@ export const createPlugin = <
   },
   commands: Commands
 ): Plugin<PluginState, Schema> => {
-  type ElementNode = Node<Schema>;
-
-  const hasErrors = (doc: Node) => {
-    let foundError = false;
-    doc.descendants((node: ElementNode) => {
-      if (!foundError) {
-        if (node.type.name === "element") {
-          foundError = node.attrs.hasErrors as boolean;
-        }
-      } else {
-        return false;
-      }
-    });
-    return foundError;
-  };
-
   return new Plugin<PluginState, Schema>({
     key: pluginKey,
-    state: {
-      init: (_, state) => ({
-        hasErrors: hasErrors(state.doc),
-      }),
-      apply: (_tr, _value, _oldState, state) => ({
-        hasErrors: hasErrors(state.doc),
-      }),
-    },
     props: {
       decorations,
       nodeViews: createNodeViews(
@@ -162,12 +138,11 @@ const createNodeView = <
   const update = element.createUpdator(
     dom,
     fields,
-    (fields, hasErrors) => {
+    (fields) => {
       view.dispatch(
         view.state.tr.setNodeMarkup(getPos(), undefined, {
           ...initNode.attrs,
           fields,
-          hasErrors,
         })
       );
     },

--- a/src/plugin/types/Consumer.ts
+++ b/src/plugin/types/Consumer.ts
@@ -1,13 +1,13 @@
+import type { FieldValidationErrors } from "../elementSpec";
 import type { FieldNameToValueMap } from "../fieldViews/helpers";
 import type { FieldDescriptions, FieldNameToField } from "./Element";
-import type { Errors } from "./Errors";
 
 export type Consumer<
   ConsumerResult,
   FDesc extends FieldDescriptions<string>
 > = (
   fieldValues: FieldNameToValueMap<FDesc>,
-  errors: Errors,
+  errors: FieldValidationErrors,
   updateFields: (fieldValues: FieldNameToValueMap<FDesc>) => void,
   fields: FieldNameToField<FDesc>
 ) => ConsumerResult;

--- a/src/plugin/types/Element.ts
+++ b/src/plugin/types/Element.ts
@@ -98,10 +98,7 @@ export type ElementSpec<
   createUpdator: (
     dom: HTMLElement,
     fields: FieldNameToField<FDesc>,
-    updateState: (
-      fields: FieldNameToValueMap<FDesc>,
-      hasErrors: boolean
-    ) => void,
+    updateState: (fields: FieldNameToValueMap<FDesc>) => void,
     initFields: FieldNameToValueMap<FDesc>,
     commands: ReturnType<CommandCreator>
   ) => (

--- a/src/plugin/types/Errors.ts
+++ b/src/plugin/types/Errors.ts
@@ -1,1 +1,0 @@
-export type Errors = Record<string, string[]>;

--- a/src/renderers/react/ElementProvider.tsx
+++ b/src/renderers/react/ElementProvider.tsx
@@ -1,6 +1,9 @@
 import type { ReactElement } from "react";
 import React, { Component } from "react";
-import type { Validator } from "../../plugin/elementSpec";
+import type {
+  FieldValidationErrors,
+  Validator,
+} from "../../plugin/elementSpec";
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
 import type { Commands } from "../../plugin/types/Commands";
 import type { Consumer } from "../../plugin/types/Consumer";
@@ -8,12 +11,11 @@ import type {
   FieldDescriptions,
   FieldNameToField,
 } from "../../plugin/types/Element";
-import type { Errors } from "../../plugin/types/Errors";
 import { ElementWrapper } from "./ElementWrapper";
 
 const fieldErrors = <FDesc extends FieldDescriptions<string>>(
   fields: FieldNameToValueMap<FDesc>,
-  errors: Errors | undefined
+  errors: FieldValidationErrors | undefined
 ) =>
   Object.keys(fields).reduce(
     (acc, key) => ({

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -38,8 +38,7 @@ const Panel = styled("div")`
   background: ${neutral[97]};
   flex-grow: 1;
   overflow: hidden;
-  padding-left: ${space[3]}px;
-  padding-right: ${space[3]}px;
+  padding: ${space[3]}px;
 `;
 
 const Button = styled("button")<{ expanded?: boolean }>`

--- a/src/renderers/react/FieldView.tsx
+++ b/src/renderers/react/FieldView.tsx
@@ -5,14 +5,12 @@ import type { Field } from "../../plugin/types/Element";
 
 type Props<F extends Field<unknown>> = {
   field: F;
-  hasErrors?: boolean;
 };
 
 export const getFieldViewTestId = (name: string) => `FieldView-${name}`;
 
 export const FieldView = <F extends Field<TFieldView<unknown>>>({
   field,
-  hasErrors = false,
 }: Props<F>) => {
   const editorRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -23,10 +21,6 @@ export const FieldView = <F extends Field<TFieldView<unknown>>>({
   }, []);
 
   return (
-    <Editor
-      hasErrors={hasErrors}
-      data-cy={getFieldViewTestId(field.name)}
-      ref={editorRef}
-    ></Editor>
+    <Editor data-cy={getFieldViewTestId(field.name)} ref={editorRef}></Editor>
   );
 };

--- a/src/renderers/react/FieldView.tsx
+++ b/src/renderers/react/FieldView.tsx
@@ -5,12 +5,14 @@ import type { Field } from "../../plugin/types/Element";
 
 type Props<F extends Field<unknown>> = {
   field: F;
+  hasValidationErrors: boolean;
 };
 
 export const getFieldViewTestId = (name: string) => `FieldView-${name}`;
 
 export const FieldView = <F extends Field<TFieldView<unknown>>>({
   field,
+  hasValidationErrors,
 }: Props<F>) => {
   const editorRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -21,6 +23,10 @@ export const FieldView = <F extends Field<TFieldView<unknown>>>({
   }, []);
 
   return (
-    <Editor data-cy={getFieldViewTestId(field.name)} ref={editorRef}></Editor>
+    <Editor
+      data-cy={getFieldViewTestId(field.name)}
+      hasValidationErrors={hasValidationErrors}
+      ref={editorRef}
+    ></Editor>
   );
 };

--- a/src/renderers/react/createReactElementSpec.tsx
+++ b/src/renderers/react/createReactElementSpec.tsx
@@ -14,10 +14,10 @@ export const createReactElementSpec = <
   FDesc extends FieldDescriptions<string>,
   ExternalData
 >(
-  FieldDescriptions: FDesc,
+  fieldDescriptions: FDesc,
   consumer: Consumer<ReactElement, FDesc>,
-  validate: Validator<FDesc>,
-  transformers?: Transformers<FDesc, ExternalData>
+  validate: Validator<FDesc> | undefined = undefined,
+  transformers: Transformers<FDesc, ExternalData> | undefined = undefined
 ) => {
   const renderer: Renderer<FDesc> = (
     validate,
@@ -41,5 +41,5 @@ export const createReactElementSpec = <
       dom
     );
 
-  return createElementSpec(FieldDescriptions, renderer, validate, transformers);
+  return createElementSpec(fieldDescriptions, renderer, validate, transformers);
 };

--- a/src/renderers/react/customFieldViewComponents/CustomCheckboxView.tsx
+++ b/src/renderers/react/customFieldViewComponents/CustomCheckboxView.tsx
@@ -1,11 +1,12 @@
 import { CustomCheckbox } from "../../../editorial-source-components/CustomCheckbox";
+import type { ValidationError } from "../../../plugin/elementSpec";
 import type { CustomField } from "../../../plugin/types/Element";
 import { getFieldViewTestId } from "../FieldView";
 import { useCustomFieldState } from "../useCustomFieldViewState";
 
 type CustomCheckboxViewProps = {
   field: CustomField<boolean, boolean>;
-  errors: string[];
+  errors: ValidationError[];
   label: string;
 };
 
@@ -19,7 +20,7 @@ export const CustomCheckboxView = ({
     <CustomCheckbox
       checked={boolean}
       text={label}
-      error={errors.join(", ")}
+      error={errors.map((e) => e.error).join(", ")}
       onChange={() => {
         setBoolean(!boolean);
       }}

--- a/src/renderers/react/customFieldViewComponents/CustomDropdownView.tsx
+++ b/src/renderers/react/customFieldViewComponents/CustomDropdownView.tsx
@@ -1,5 +1,4 @@
 import { CustomDropdown } from "../../../editorial-source-components/CustomDropdown";
-import { InputGroup } from "../../../editorial-source-components/InputGroup";
 import type { ValidationError } from "../../../plugin/elementSpec";
 import type { Options } from "../../../plugin/fieldViews/DropdownFieldView";
 import type { CustomField } from "../../../plugin/types/Element";
@@ -21,18 +20,16 @@ export const CustomDropdownView = ({
 }: CustomDropdownViewProps) => {
   const [selectedElement, setSelectedElement] = useCustomFieldState(field);
   return (
-    <InputGroup>
-      <CustomDropdown
-        display={display}
-        options={field.description.props}
-        selected={selectedElement}
-        label={label}
-        onChange={(event) => {
-          setSelectedElement(event.target.value);
-        }}
-        error={errors.map((e) => e.error).join(", ")}
-        dataCy={getFieldViewTestId(field.name)}
-      />
-    </InputGroup>
+    <CustomDropdown
+      display={display}
+      options={field.description.props}
+      selected={selectedElement}
+      label={label}
+      onChange={(event) => {
+        setSelectedElement(event.target.value);
+      }}
+      error={errors.map((e) => e.error).join(", ")}
+      dataCy={getFieldViewTestId(field.name)}
+    />
   );
 };

--- a/src/renderers/react/customFieldViewComponents/CustomDropdownView.tsx
+++ b/src/renderers/react/customFieldViewComponents/CustomDropdownView.tsx
@@ -1,5 +1,6 @@
 import { CustomDropdown } from "../../../editorial-source-components/CustomDropdown";
 import { InputGroup } from "../../../editorial-source-components/InputGroup";
+import type { ValidationError } from "../../../plugin/elementSpec";
 import type { Options } from "../../../plugin/fieldViews/DropdownFieldView";
 import type { CustomField } from "../../../plugin/types/Element";
 import { getFieldViewTestId } from "../FieldView";
@@ -7,7 +8,7 @@ import { useCustomFieldState } from "../useCustomFieldViewState";
 
 type CustomDropdownViewProps = {
   field: CustomField<string, Options>;
-  errors?: string[];
+  errors?: ValidationError[];
   label: string;
   display?: "inline" | "block";
 };
@@ -29,7 +30,7 @@ export const CustomDropdownView = ({
         onChange={(event) => {
           setSelectedElement(event.target.value);
         }}
-        error={errors.join(", ")}
+        error={errors.map((e) => e.error).join(", ")}
         dataCy={getFieldViewTestId(field.name)}
       />
     </InputGroup>


### PR DESCRIPTION
## What does this change?

Adds a layout component to take care of spacing our fields vertically.

This was previously done with margins, which mostly worked – but because `flex` doesn't permit [margin-collapse](https://css-tricks.com/the-rules-of-margin-collapse/), we had a problem with fields meeting flex containers.

A single component in charge of vertical spacing makes easier to make global adjustments to layout.

Here's a fun spot-the-difference that I've ruined for everyone! 

Before:

<img width="967" alt="Screenshot 2021-09-09 at 12 07 41" src="https://user-images.githubusercontent.com/7767575/132681310-b2a506a1-61fa-4e93-ae79-87dd1ba99e08.png">

After: 

<img width="1193" alt="Screenshot 2021-09-09 at 12 46 16" src="https://user-images.githubusercontent.com/7767575/132681135-6b9f2134-2b0e-499e-b469-8ae2dca43e79.png">


## How to test

Besides the small change in the before/after, this should be a no-op. Do all the elements look as they should?

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [x] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
