### PR TITLE
feat: Changes validators to accept a partial representation of the element

### DIFF
--- a/src/plugin/__tests__/elementSpec.spec.ts
+++ b/src/plugin/__tests__/elementSpec.spec.ts
@@ -56,9 +56,9 @@ describe("mount", () => {
         () => () => undefined,
         (fields) => {
           // field1 is derived from the fieldDescriptions, and is a string b/c it's a richText field
-          fields.field1.toString();
+          fields.field1?.toString();
           // field2 is a boolean b/c it's a checkbox field
-          fields.field2.valueOf();
+          fields.field2?.valueOf();
           return undefined;
         }
       );

--- a/src/plugin/elementSpec.ts
+++ b/src/plugin/elementSpec.ts
@@ -35,7 +35,7 @@ export type ValidationError = {
 export type FieldValidationErrors = Record<string, ValidationError[]>;
 
 export type Validator<FDesc extends FieldDescriptions<string>> = (
-  fields: FieldNameToValueMap<FDesc>
+  fields: Partial<FieldNameToValueMap<FDesc>>
 ) => undefined | FieldValidationErrors;
 
 export type FieldValidator = (
@@ -67,7 +67,7 @@ export const createElementSpec = <FDesc extends FieldDescriptions<string>>(
   validate: Validator<FDesc> | undefined = undefined
 ): ElementSpec<FDesc> => {
   const validateWithFieldAndElementValidators: Validator<FDesc> = (
-    fields: FieldNameToValueMap<FDesc>
+    fields: Partial<FieldNameToValueMap<FDesc>>
   ) => {
     const fieldErrors: FieldValidationErrors = {};
     for (const field in fieldDescriptions) {

--- a/src/plugin/elementSpec.ts
+++ b/src/plugin/elementSpec.ts
@@ -35,6 +35,7 @@ export type ValidationError = {
 export type FieldValidationErrors = Record<string, ValidationError[]>;
 
 export type Validator<FDesc extends FieldDescriptions<string>> = (
+  // Fields is partial to allow for validating an incomplete element representation
   fields: Partial<FieldNameToValueMap<FDesc>>
 ) => undefined | FieldValidationErrors;
 

--- a/src/plugin/helpers/validation.spec.ts
+++ b/src/plugin/helpers/validation.spec.ts
@@ -33,5 +33,20 @@ describe("Validation helpers", () => {
         field1: [{ error: "Required", message: "field1 is required" }],
       });
     });
+
+    it("should receive a validation map, and return the results of validators for partial data", () => {
+      const validator = createValidator({
+        field1: [maxLength(5)],
+        field2: [required()],
+      });
+      const result = validator({
+        field1: "OK!",
+      });
+
+      expect(result).toEqual({
+        field1: [],
+        field2: [{ error: "Required", message: "field2 is required" }],
+      });
+    });
   });
 });

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -5,7 +5,7 @@ import type { FieldDescriptions } from "../types/Element";
 export const createValidator = (
   fieldValidationMap: Record<string, FieldValidator[]>
 ) => <FDesc extends FieldDescriptions<string>>(
-  fieldValues: FieldNameToValueMap<FDesc>
+  fieldValues: Partial<FieldNameToValueMap<FDesc>>
 ): FieldValidationErrors => {
   const errors: FieldValidationErrors = {};
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Building on the work from #120, this PR changes the validator type to accept a partial representation of the element data. This should allow us validate elements that are missing data. This will be helpfully when validating elements in Composer which currently model empty fields as undefined.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This should be a no-op for the demo and I have added an additional unit test to check a partial element.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
We are able to determine if elements are valid or not with a partial set of data.

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
