### PR TITLE
feat: add `absentOnEmpty` option for text fields

### DIFF
--- a/src/elements/code/CodeElementSpec.tsx
+++ b/src/elements/code/CodeElementSpec.tsx
@@ -10,6 +10,7 @@ export const codeFields = {
     rows: 4,
     isCode: true,
     validators: [required("empty code field")],
+    absentOnEmpty: true,
   }),
   language: createCustomDropdownField("text", [
     { text: "Plain text", value: "text" },

--- a/src/elements/code/CodeElementSpec.tsx
+++ b/src/elements/code/CodeElementSpec.tsx
@@ -7,7 +7,7 @@ import { CodeElementForm } from "./CodeElementForm";
 
 export const codeFields = {
   html: createTextField({
-    multilineOptions: { isMultiline: true, rows: 4 },
+    rows: 4,
     isCode: true,
     validators: [required("empty code field")],
   }),

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -46,12 +46,12 @@ export const createImageFields = (
       },
     }),
     altText: createTextField({
-      multilineOptions: { isMultiline: true, rows: 2 },
+      rows: 2,
       validators: [htmlMaxLength(100), htmlRequired()],
     }),
     src: createTextField(),
     code: createTextField({
-      multilineOptions: { isMultiline: true, rows: 4 },
+      rows: 4,
       isCode: true,
     }),
     mainImage: createCustomField<ImageField, ImageProps>(

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -23,13 +23,13 @@ export const embedFields = {
   ]),
   sourceUrl: createTextField(),
   embedCode: createTextField({
-    multilineOptions: { isMultiline: true, rows: 2 },
+    rows: 2,
     isCode: true,
     validators: [htmlRequired()],
   }),
   caption: createDefaultRichTextField([maxLength(1000)]),
   altText: createTextField({
-    multilineOptions: { isMultiline: true, rows: 2 },
+    rows: 2,
     validators: [htmlMaxLength(1000), htmlRequired()],
   }),
   required: createCustomField(true, true),

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -47,7 +47,7 @@ export const createImageFields = (
 ) => {
   return {
     altText: createTextField({
-      multilineOptions: { isMultiline: true, rows: 2 },
+      rows: 2,
       validators: [htmlMaxLength(1000), htmlRequired()],
     }),
     caption: createFlatRichTextField({

--- a/src/elements/pullquote/PullquoteSpec.tsx
+++ b/src/elements/pullquote/PullquoteSpec.tsx
@@ -9,8 +9,9 @@ export const pullquoteFields = {
   html: createTextField({
     rows: 4,
     validators: [htmlRequired("Pullquote cannot be empty")],
+    absentOnEmpty: true,
   }),
-  attribution: createTextField(),
+  attribution: createTextField({ absentOnEmpty: true }),
   role: createCustomDropdownField("supporting", [
     { text: "supporting (default)", value: "supporting" },
     { text: "inline", value: "inline" },

--- a/src/elements/pullquote/PullquoteSpec.tsx
+++ b/src/elements/pullquote/PullquoteSpec.tsx
@@ -7,7 +7,7 @@ import { PullquoteElementForm } from "./PullquoteForm";
 
 export const pullquoteFields = {
   html: createTextField({
-    multilineOptions: { isMultiline: true, rows: 4 },
+    rows: 4,
     validators: [htmlRequired("Pullquote cannot be empty")],
   }),
   attribution: createTextField(),

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -414,6 +414,17 @@ describe("buildElementPlugin", () => {
       }
     );
 
+    const elementWithAbsentOn = createNoopElement({
+      field1: { type: "richText", absentOnEmpty: true },
+      field2: {
+        type: "text",
+        absentOnEmpty: true,
+        isMultiline: false,
+        rows: 1,
+        isCode: false,
+      },
+    });
+
     const testElementValues = {
       elementName: "testElement",
       errors: undefined,
@@ -540,6 +551,63 @@ describe("buildElementPlugin", () => {
           // We expect the node we've just manually created to match the node
           // that's been serialised from the defaults
           expect(element).toEqual(testElementValues);
+        });
+
+        it("should not output keys that match the field's `absentOn` value", () => {
+          const {
+            getElementDataFromNode,
+            insertElement,
+            view,
+            serializer,
+          } = createEditorWithElements({ elementWithAbsentOn });
+
+          insertElement({
+            elementName: "elementWithAbsentOn",
+            values: {
+              field1: "",
+              field2: "",
+            },
+          })(view.state, view.dispatch);
+
+          const element = getElementDataFromNode(
+            view.state.doc.firstChild as Node,
+            serializer
+          );
+
+          expect(element).toEqual({
+            elementName: "elementWithAbsentOn",
+            values: {},
+          });
+        });
+
+        it("should make keys with `absentOn` optional in the output type", () => {
+          const {
+            getElementDataFromNode,
+            insertElement,
+            view,
+            serializer,
+          } = createEditorWithElements({ elementWithAbsentOn });
+
+          insertElement({
+            elementName: "elementWithAbsentOn",
+            values: {},
+          })(view.state, view.dispatch);
+
+          const element = getElementDataFromNode(
+            view.state.doc.firstChild as Node,
+            serializer
+          );
+
+          if (element) {
+            try {
+              // @ts-expect-error -- this field should be optional
+              element.values.field1.toString();
+              // @ts-expect-error -- this field should be optional
+              element.values.field2.toString();
+            } catch (e) {
+              // We expect to fail here
+            }
+          }
         });
 
         it("should return undefined, given an non-element node", () => {

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -553,7 +553,7 @@ describe("buildElementPlugin", () => {
           expect(element).toEqual(testElementValues);
         });
 
-        it("should not output keys that match the field's `absentOn` value", () => {
+        it("should not output keys that match the field's `absentOn` value if they are empty", () => {
           const {
             getElementDataFromNode,
             insertElement,
@@ -577,6 +577,36 @@ describe("buildElementPlugin", () => {
           expect(element).toEqual({
             elementName: "elementWithAbsentOn",
             values: {},
+          });
+        });
+
+        it("should output keys that match the field's `absentOn` value if they have content", () => {
+          const {
+            getElementDataFromNode,
+            insertElement,
+            view,
+            serializer,
+          } = createEditorWithElements({ elementWithAbsentOn });
+
+          insertElement({
+            elementName: "elementWithAbsentOn",
+            values: {
+              field1: "<p>Content</p>",
+              field2: "Content",
+            },
+          })(view.state, view.dispatch);
+
+          const element = getElementDataFromNode(
+            view.state.doc.firstChild as Node,
+            serializer
+          );
+
+          expect(element).toEqual({
+            elementName: "elementWithAbsentOn",
+            values: {
+              field1: "<p>Content</p>",
+              field2: "Content",
+            },
           });
         });
 

--- a/src/plugin/fieldViews/RichTextFieldView.ts
+++ b/src/plugin/fieldViews/RichTextFieldView.ts
@@ -12,6 +12,9 @@ export interface RichTextFieldDescription extends BaseFieldDescription<string> {
   type: typeof RichTextFieldView.fieldName;
   createPlugins?: (schema: Schema) => Plugin[];
   nodeSpec?: Partial<NodeSpec>;
+  // If the text content produced by this node is an empty string, don't
+  // include its key in the output data created by `getElementDataFromNode`.
+  absentOnEmpty?: boolean;
 }
 
 type RichTextOptions = {

--- a/src/plugin/fieldViews/RichTextFieldView.ts
+++ b/src/plugin/fieldViews/RichTextFieldView.ts
@@ -18,12 +18,14 @@ export interface RichTextFieldDescription extends BaseFieldDescription<string> {
 }
 
 type RichTextOptions = {
+  absentOnEmpty?: boolean;
   createPlugins?: (schema: Schema) => Plugin[];
   nodeSpec?: Partial<NodeSpec>;
   validators?: FieldValidator[];
 };
 
 export const createRichTextField = ({
+  absentOnEmpty,
   createPlugins,
   nodeSpec,
   validators,
@@ -32,6 +34,7 @@ export const createRichTextField = ({
   createPlugins,
   nodeSpec,
   validators,
+  absentOnEmpty,
 });
 
 type FlatRichTextOptions = RichTextOptions & {

--- a/src/plugin/fieldViews/TextFieldView.ts
+++ b/src/plugin/fieldViews/TextFieldView.ts
@@ -24,32 +24,31 @@ export interface TextFieldDescription extends BaseFieldDescription<string> {
   absentOnEmpty?: boolean;
 }
 
-type MultilineOptions = {
-  isMultiline: boolean;
-  rows: number;
-};
-
 type TextFieldOptions = {
-  multilineOptions?: MultilineOptions;
+  rows?: number;
   isCode?: boolean;
+  absentOnEmpty?: boolean;
   validators?: FieldValidator[];
 };
 
 export const createTextField = (
   {
-    multilineOptions = { isMultiline: false, rows: 1 },
+    rows = 1,
     isCode = false,
-    validators = [],
+    absentOnEmpty = false,
+    validators,
   }: TextFieldOptions | undefined = {
-    multilineOptions: { isMultiline: false, rows: 1 },
+    rows: 1,
     isCode: false,
+    absentOnEmpty: false,
     validators: [],
   }
 ): TextFieldDescription => ({
   type: TextFieldView.fieldName,
-  isMultiline: multilineOptions.isMultiline,
-  rows: multilineOptions.rows,
+  isMultiline: rows > 1,
+  rows,
   isCode,
+  absentOnEmpty,
   validators,
 });
 

--- a/src/plugin/fieldViews/TextFieldView.ts
+++ b/src/plugin/fieldViews/TextFieldView.ts
@@ -19,6 +19,9 @@ export interface TextFieldDescription extends BaseFieldDescription<string> {
   rows: number;
   // The text field is used to display code
   isCode: boolean;
+  // If the text field is empty (""), don't include its key in the output data
+  // created by `getElementDataFromNode`.
+  absentOnEmpty?: boolean;
 }
 
 type MultilineOptions = {

--- a/src/plugin/fieldViews/helpers.ts
+++ b/src/plugin/fieldViews/helpers.ts
@@ -1,3 +1,4 @@
+import type { KeysWithValsOfType, Optional } from "../helpers/types";
 import type { FieldDescriptions } from "../types/Element";
 import { CheckboxFieldView } from "./CheckboxFieldView";
 import type { CheckboxValue } from "./CheckboxFieldView";
@@ -58,3 +59,10 @@ export type FieldNameToValueMap<
 > = {
   [Name in keyof FDesc]: FieldTypeToValueMap<FDesc, Name>[FDesc[Name]["type"]];
 };
+
+export type FieldNameToValueMapWithEmptyValues<
+  FDesc extends FieldDescriptions<keyof FDesc>
+> = Optional<
+  FieldNameToValueMap<FDesc>,
+  KeysWithValsOfType<FDesc, { absentOnEmpty: true }>
+>;

--- a/src/plugin/fieldViews/helpers.ts
+++ b/src/plugin/fieldViews/helpers.ts
@@ -60,6 +60,10 @@ export type FieldNameToValueMap<
   [Name in keyof FDesc]: FieldTypeToValueMap<FDesc, Name>[FDesc[Name]["type"]];
 };
 
+/**
+ * As with `FieldNameToValueMap`, but respects the `absentOnEmpty` value
+ * to produce a result that reflects the output type of `getElementDataFromNode`.
+ */
 export type FieldNameToValueMapWithEmptyValues<
   FDesc extends FieldDescriptions<keyof FDesc>
 > = Optional<

--- a/src/plugin/helpers/element.ts
+++ b/src/plugin/helpers/element.ts
@@ -105,7 +105,8 @@ export const createGetElementDataFromNode = <
     if (
       (fieldDescription.type === "richText" ||
         fieldDescription.type === "text") &&
-      fieldDescription.absentOnEmpty
+      fieldDescription.absentOnEmpty &&
+      !node.textContent
     ) {
       return;
     }

--- a/src/plugin/helpers/types.ts
+++ b/src/plugin/helpers/types.ts
@@ -1,8 +1,14 @@
+// Make the keys on the given object optional. For example,
+//  Optional<{ a: 1, b: 2 }, "a"> is equivalent to
+//  { a?: 1, b: 2}
 export type Optional<
   T extends Record<string, unknown>,
   K extends keyof T
 > = Omit<T, K> & Partial<Pick<T, K>>;
 
+// Get a union of all the keys that match the shape of the given object. For eaxmple,
+//  KeysWithValsOfType<{ a: 1, b: 2, c: "string" }, number> is equivalent to
+//  "a" | "b"
 export type KeysWithValsOfType<T, V> = keyof {
   [P in keyof T as T[P] extends V ? P : never]: P;
 } &

--- a/src/plugin/helpers/types.ts
+++ b/src/plugin/helpers/types.ts
@@ -1,0 +1,9 @@
+export type Optional<
+  T extends Record<string, unknown>,
+  K extends keyof T
+> = Omit<T, K> & Partial<Pick<T, K>>;
+
+export type KeysWithValsOfType<T, V> = keyof {
+  [P in keyof T as T[P] extends V ? P : never]: P;
+} &
+  keyof T;

--- a/src/plugin/types/Element.ts
+++ b/src/plugin/types/Element.ts
@@ -15,6 +15,7 @@ import type {
 import type { FieldView } from "../fieldViews/FieldView";
 import type {
   FieldNameToValueMap,
+  FieldNameToValueMapWithEmptyValues,
   FieldTypeToViewMap,
 } from "../fieldViews/helpers";
 import type {
@@ -118,7 +119,7 @@ export type ExtractFieldValues<ESpec> = ESpec extends ElementSpec<
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- we don't need this type.
   infer E
 >
-  ? FieldNameToValueMap<F>
+  ? FieldNameToValueMapWithEmptyValues<F>
   : never;
 
 export type ExtractExternalData<ESpec> = ESpec extends ElementSpec<


### PR DESCRIPTION
_co-authored-by: @rhystmills_ 

## What does this change?

Adds an `absentOnEmpty` option for text fields. Setting this option to `true` will not set a key-value pair on data returned from `getElementDataFromNode` if the field is empty.

Empty here means no text content, so a rich text field that serialises to e.g. `<p></p>` will be considered empty.

This change is required to better match the way absent data is modelled in Composer, the Guardian's content management system.

## How to test

The automated tests should pass, and test for the presence and absence of fields that use this flag, as well as the typesafety of the resulting data.

## Dev notes

The surface area of this work is slightly larger than might be expected for two reasons:

- it was better to refactor the options object of the text fields to incorporate `absentOnEmpty`, which touched every element that used them
- the type work to ensure the output of `getElementDataFromNode` was correct necessitated a few helper types.