### PR TITLE
fix: Do not html-encode plain text

### DIFF
--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -488,6 +488,48 @@ describe("buildElementPlugin", () => {
           expect(element).toEqual(testElementValues);
         });
 
+        it("should escape HTML chars in rich text", () => {
+          const {
+            getElementDataFromNode,
+            insertElement,
+            view,
+            serializer,
+          } = createEditorWithElements({ testElement });
+
+          insertElement({
+            elementName: "testElement",
+            values: { field1: "<p>><</p>" },
+          })(view.state, view.dispatch);
+
+          const element = getElementDataFromNode(
+            view.state.doc.firstChild as Node,
+            serializer
+          );
+
+          expect(element?.values.field1).toEqual("<p>&gt;&lt;</p>");
+        });
+
+        it("should not escape HTML chars in plain text", () => {
+          const {
+            getElementDataFromNode,
+            insertElement,
+            view,
+            serializer,
+          } = createEditorWithElements({ testElement });
+
+          insertElement({
+            elementName: "testElement",
+            values: { field2: "<>" },
+          })(view.state, view.dispatch);
+
+          const element = getElementDataFromNode(
+            view.state.doc.firstChild as Node,
+            serializer
+          );
+
+          expect(element?.values.field2).toEqual("<>");
+        });
+
         it("should not output keys that match the field's `absentOn` value if they are empty", () => {
           const {
             getElementDataFromNode,


### PR DESCRIPTION
## What does this change?

Avoids parsing plain text fields as HTML, which has the side effect of [encoding HTML entities](https://developer.mozilla.org/en-US/docs/Glossary/Entity). This was showing up in pullquote and code elements.

This might be considered a nice side effect in some cases, but probably shouldn't be a default. We could consider adding this as a parameter if needed.

## How to test

- The new automated tests should pass, and convince you that they test for the correct behaviour.