### PR TITLE
fix: Address problem w/ html tags in plain text field

### DIFF
--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -171,13 +171,13 @@ describe("ImageElement", () => {
         );
       });
 
-      it(`should remove marks when content is created with them`, () => {
+      it(`should treat html tags as text, not html`, () => {
         addImageElement({
           src: "<strong>bold text</strong> <em>italic text</em>",
         });
         getElementRichTextField("src").should(
-          "have.html",
-          "bold text italic text"
+          "have.text",
+          "<strong>bold text</strong> <em>italic text</em>"
         );
       });
 

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -468,6 +468,36 @@ describe("buildElementPlugin", () => {
           // that's been serialised from the defaults
           expect(node).toBe(undefined);
         });
+
+        it("should not retain HTML chars in rich text", () => {
+          const { getNodeFromElementData, view } = createEditorWithElements({
+            testElement,
+          });
+
+          const fieldText = "<html></html>";
+
+          const node = getNodeFromElementData(
+            { elementName: "testElement", values: { field1: fieldText } },
+            view.state.schema
+          );
+
+          expect(node?.textContent).toBe("");
+        });
+
+        it("should retain HTML chars in plain text", () => {
+          const { getNodeFromElementData, view } = createEditorWithElements({
+            testElement,
+          });
+
+          const fieldText = "<html></html>";
+
+          const node = getNodeFromElementData(
+            { elementName: "testElement", values: { field2: fieldText } },
+            view.state.schema
+          );
+
+          expect(node?.textContent).toBe(fieldText);
+        });
       });
 
       describe("Conversion from node to data", () => {


### PR DESCRIPTION
## What does this change?

#127 did not address a problem with HTML chars on ingress via `getNodeFromElementData` – we were using `innerHTML` to parse text.

This PR makes text nodes a special case on ingress (as #127 does on egress), manually creating text nodes rather than parsing as HTML.

As well as being more correct, this should also be quicker!

## How to test

I don't _think_ there's a way to access this behaviour via the demo UI.  But the automated tests should pass, and you should be convinced they test for the problem. I wrote the unit test in a failing state, and then fixed. The amended integration test is also good confirmation.


