### PR TITLE
feat: Changes ImageElement to accept a plugin creator prop

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -45,7 +45,10 @@ type Name =
 
 const { plugin: elementPlugin, insertElement, nodeSpec } = buildElementPlugin({
   demoImageElement: createDemoImageElement(onSelectImage, onDemoCropImage),
-  imageElement: createImageElement(onCropImage),
+  imageElement: createImageElement({
+    openImageSelector: onCropImage,
+    createCaptionPlugins: (schema) => exampleSetup({ schema }),
+  }),
   embedElement: createEmbedElement(),
   codeElement,
   pullquoteElement,

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -1,4 +1,5 @@
-import { exampleSetup } from "prosemirror-example-setup";
+import type { Schema } from "prosemirror-model";
+import type { Plugin } from "prosemirror-state";
 import React from "react";
 import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
 import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
@@ -40,18 +41,20 @@ export type MainImageData = {
 
 export type MainImageProps = {
   openImageSelector: (setMedia: SetMedia, mediaId?: string) => void;
+  createCaptionPlugins?: (schema: Schema) => Plugin[];
 };
 
-export const createImageFields = (
-  openImageSelector: (setMedia: SetMedia, mediaId?: string) => void
-) => {
+export const createImageFields = ({
+  createCaptionPlugins,
+  openImageSelector,
+}: MainImageProps) => {
   return {
     alt: createTextField({
       rows: 2,
       validators: [htmlMaxLength(1000), htmlRequired()],
     }),
     caption: createFlatRichTextField({
-      createPlugins: (schema) => exampleSetup({ schema }),
+      createPlugins: createCaptionPlugins,
       nodeSpec: {
         marks: "em strong link strike",
       },
@@ -87,11 +90,9 @@ export const createImageFields = (
   };
 };
 
-export const createImageElement = (
-  openImageSelector: (setMedia: SetMedia, mediaId?: string) => void
-) =>
+export const createImageElement = (props: MainImageProps) =>
   createReactElementSpec(
-    createImageFields(openImageSelector),
+    createImageFields(props),
     (fieldValues, errors, __, fields) => {
       return (
         <ImageElementForm


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR allows a consumer of the image element to provide a custom set of plugins via a plugin creator function. This should mean we can use Composer's custom menu bar within the caption field.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This should be a no-op as the demo instance will use the same plugins.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
We are able to use the Composer menu bar with the image element.

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [ ] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [ ] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
