### PR TITLE
docs: Add ADR for element transformers

### DIFF
--- a/docs/decision-records/000-element-fields-model.md
+++ b/docs/decision-records/000-element-fields-model.md
@@ -1,4 +1,4 @@
-# ProseMirror Elements Model ADR
+# ADR: Modelling fields as node content
 ## Context
 
 At the Guardian, elements currently exist as block-level elements within a document. They manage an arbitrary amount of state that ranges from relatively simple (e.g. pullquote – one non-rich text field, a few supporting properties) to more complex (e.g. image – many rich text fields, communication with outside code for [Grid](https://github.com/guardian/grid) integration, etc.)

--- a/docs/decision-records/001-transformers.md
+++ b/docs/decision-records/001-transformers.md
@@ -1,0 +1,35 @@
+# ADR: Managing the transformation between pm-elements and consumer element representations
+## Context
+
+The type of data representing elements in consumers may differ from the type of data native to prosemirror-elements elements. This is the case at the Guardian, where our document format (flexible-model) has an element definition that doesn’t correspond with the elements we define with prosemirror-elements.
+
+This is always likely to be the case – there’s usually a difference between data as it’s represented in a model, and data represented in forms designed to feed that model.
+
+As a result, currently prosemirror-elements has a `transformIn` and `transformOut` API, that allows consumers to include the transformation between external and internal types in their element.
+
+As we worked with this API, a few concerns were raised:
+
+- It makes our types harder to reason about, both in terms of writing them, and in terms of reasoning about them as a consumer when things go wrong.
+- Reasoning about partial representations of external data, and hydrating to their complete or partial internal counterparts felt complex.
+- Coupling the definition of our element with a particular set of data requirements for a particular consumer felt arbitrary.
+
+Ultimately, these concerns led us to explore alternatives to this approach.
+
+## Options
+
+1. Keep things as they are, and make do with increased complexity.
+2. Remove the transformers API, and make it the consumer’s responsibility to do this work.
+
+## Decision
+
+We decided to remove the transformers API, and make it the consumer’s responsibility to do this work.
+
+## Consequences
+
+- Reduced complexity within the prosemirror-elements library.
+- (Guardian-specific) We’ll need to implement the logic necessary for these transformations elsewhere.
+
+
+
+
+


### PR DESCRIPTION
## What does this change?

Adds an ADR for the element transformers work. After chatting with the team, this is arguably a bit extra – but it's done now!

## How to review and test

Have a read of the doc. Is it useful? Anything to change?