### PR TITLE
feat: Image element tweaks

### DIFF
--- a/src/editorial-source-components/Description.tsx
+++ b/src/editorial-source-components/Description.tsx
@@ -1,0 +1,13 @@
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+import { textSans } from "@guardian/src-foundations/typography";
+
+export const descriptionStyles = css`
+  ${textSans.small({ lineHeight: "loose" })}
+  font-family: "Guardian Agate Sans";
+  display: block;
+`;
+
+export const Description = styled.div`
+  ${descriptionStyles}
+`;

--- a/src/editorial-source-components/FieldWrapper.tsx
+++ b/src/editorial-source-components/FieldWrapper.tsx
@@ -8,6 +8,7 @@ type Props<F> = {
   field: F;
   errors: ValidationError[];
   label: React.ReactNode;
+  description?: React.ReactNode;
   className?: string;
 };
 
@@ -15,10 +16,15 @@ export const FieldWrapper = <F extends Field<TFieldView<unknown>>>({
   field,
   errors,
   label,
+  description,
   className,
 }: Props<F>) => (
   <div className={className}>
-    <InputHeading label={label} errors={errors.map((e) => e.error)} />
+    <InputHeading
+      label={label}
+      description={description}
+      errors={errors.map((e) => e.error)}
+    />
     <FieldView field={field} hasValidationErrors={!!errors.length} />
   </div>
 );

--- a/src/editorial-source-components/InputHeading.tsx
+++ b/src/editorial-source-components/InputHeading.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import { space } from "@guardian/src-foundations";
+import { Description } from "./Description";
 import { Error } from "./Error";
 import { Label } from "./Label";
 
@@ -20,12 +21,17 @@ const Errors = ({ errors }: { errors: string[] }) =>
 
 type Props = {
   label: React.ReactNode;
+  description?: React.ReactNode;
   errors: string[];
 };
 
-export const InputHeading = ({ label, errors }: Props) => (
+export const InputHeading = ({ label, description, errors }: Props) => (
   <InputHeadingContainer>
     <Label>{label}</Label>
-    <Errors errors={errors} />
+    {errors.length > 0 ? (
+      <Errors errors={errors} />
+    ) : description ? (
+      <Description>{description}</Description>
+    ) : null}
   </InputHeadingContainer>
 );

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -44,6 +44,8 @@ export type MainImageProps = {
   createCaptionPlugins?: (schema: Schema) => Plugin[];
 };
 
+export const undefinedDropdownValue = "none-selected";
+
 export const createImageFields = ({
   createCaptionPlugins,
   openImageSelector,
@@ -80,8 +82,8 @@ export const createImageFields = ({
     source: createTextField({
       validators: [htmlMaxLength(250), htmlRequired()],
     }),
-    role: createCustomField("none-selected", [
-      { text: "inline (default)", value: "none-selected" },
+    role: createCustomField(undefinedDropdownValue, [
+      { text: "inline (default)", value: undefinedDropdownValue },
       { text: "supporting", value: "supporting" },
       { text: "showcase", value: "showcase" },
       { text: "thumbnail", value: "thumbnail" },

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -26,8 +26,8 @@ export type Asset = {
   mimeType: string;
   url: string;
   fields: {
-    width: number;
-    height: number;
+    width: number | string;
+    height: number | string;
     isMaster: boolean | undefined;
   };
 };

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -152,26 +152,32 @@ const ImageView = ({ field, onChange, errors }: ImageViewProps) => {
     onChange(mediaPayload);
   };
 
-  const getImageSrc = () => {
+  const getImageSrc = (assets: Asset[]) => {
     const desiredWidth = 1200;
 
     const widthDifference = (width: number) => Math.abs(desiredWidth - width);
 
-    const sortByWidthDifference = (assetA: Asset, assetB: Asset) =>
-      widthDifference(assetA.fields.width) -
-      widthDifference(assetB.fields.width);
+    const stringOrNumberToNumber = (value: string | number) => {
+      const parsedValue = parseInt(value.toString());
+      return !isNaN(parsedValue) ? parsedValue : 0;
+    };
 
-    const assets = imageFields.assets
+    const sortByWidthDifference = (assetA: Asset, assetB: Asset) =>
+      widthDifference(stringOrNumberToNumber(assetA.fields.width)) -
+      widthDifference(stringOrNumberToNumber(assetB.fields.width));
+
+    const sortedAssets = assets
       .filter((asset) => !asset.fields.isMaster)
       .sort(sortByWidthDifference);
-    return assets.length > 0 ? assets[0].url : undefined;
+
+    return sortedAssets.length > 0 ? assets[0].url : undefined;
   };
 
   return (
     <div>
       <Errors errors={errors.map((e) => e.error)} />
       <div>
-        <img css={imageViewStysles} src={getImageSrc()} />
+        <img css={imageViewStysles} src={getImageSrc(imageFields.assets)} />
       </div>
       <Button
         priority="secondary"

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -44,6 +44,12 @@ const AltText = styled.span`
 
 export const ImageElementTestId = "ImageElement";
 
+const htmlLength = (text: string) => {
+  const el = document.createElement("div");
+  el.innerHTML = text;
+  return el.innerText.length;
+};
+
 export const ImageElementForm: React.FunctionComponent<Props> = ({
   errors,
   fields,
@@ -80,6 +86,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
             field={fields.caption}
             errors={errors.caption}
             label="Caption"
+            description={`${htmlLength(fieldValues.caption)}/600 characters`}
           />
           <FieldWrapper
             field={fields.alt}

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -1,10 +1,10 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { Button } from "@guardian/src-button";
 import { space } from "@guardian/src-foundations";
 import { SvgCamera } from "@guardian/src-icons";
 import { Column, Columns } from "@guardian/src-layout";
 import React, { useMemo } from "react";
+import { Button } from "../../editorial-source-components/Button";
 import { Error } from "../../editorial-source-components/Error";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
 import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -4,7 +4,7 @@ import { Button } from "@guardian/src-button";
 import { space } from "@guardian/src-foundations";
 import { SvgCamera } from "@guardian/src-icons";
 import { Column, Columns } from "@guardian/src-layout";
-import React from "react";
+import React, { useMemo } from "react";
 import { Error } from "../../editorial-source-components/Error";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
 import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
@@ -152,7 +152,7 @@ const ImageView = ({ field, onChange, errors }: ImageViewProps) => {
     onChange(mediaPayload);
   };
 
-  const getImageSrc = (assets: Asset[]) => {
+  const imageSrc = useMemo(() => {
     const desiredWidth = 1200;
 
     const widthDifference = (width: number) => Math.abs(desiredWidth - width);
@@ -166,18 +166,18 @@ const ImageView = ({ field, onChange, errors }: ImageViewProps) => {
       widthDifference(stringOrNumberToNumber(assetA.fields.width)) -
       widthDifference(stringOrNumberToNumber(assetB.fields.width));
 
-    const sortedAssets = assets
+    const sortedAssets = imageFields.assets
       .filter((asset) => !asset.fields.isMaster)
       .sort(sortByWidthDifference);
 
-    return sortedAssets.length > 0 ? assets[0].url : undefined;
-  };
+    return sortedAssets.length > 0 ? sortedAssets[0].url : undefined;
+  }, [imageFields.assets]);
 
   return (
     <div>
       <Errors errors={errors.map((e) => e.error)} />
       <div>
-        <img css={imageViewStysles} src={getImageSrc(imageFields.assets)} />
+        <img css={imageViewStysles} src={imageSrc} />
       </div>
       <Button
         priority="secondary"

--- a/src/elements/image/__tests__/imageElementDataTransformer.spec.ts
+++ b/src/elements/image/__tests__/imageElementDataTransformer.spec.ts
@@ -1,0 +1,157 @@
+import type { FieldNameToValueMap } from "../../../plugin/fieldViews/helpers";
+import type { createImageFields } from "../ImageElement";
+import { undefinedDropdownValue } from "../ImageElement";
+import type { ImageFields } from "../imageElementDataTransformer";
+import { transformElement } from "../imageElementDataTransformer";
+
+const partialPmeElement = (
+  data: Partial<FieldNameToValueMap<ReturnType<typeof createImageFields>>> = {}
+): Partial<FieldNameToValueMap<ReturnType<typeof createImageFields>>> => {
+  return {
+    alt: undefined,
+    caption: undefined,
+    displayCredit: false,
+    imageType: undefined,
+    mainImage: {
+      assets: [],
+      mediaApiUri: undefined,
+      mediaId: undefined,
+      suppliersReference: "",
+    },
+    photographer: undefined,
+    role: "none-selected",
+    source: undefined,
+    ...data,
+  };
+};
+
+const fullPmeElement = (
+  data: Partial<FieldNameToValueMap<ReturnType<typeof createImageFields>>> = {}
+): FieldNameToValueMap<ReturnType<typeof createImageFields>> => {
+  return {
+    alt: "",
+    caption: "",
+    displayCredit: true,
+    imageType: "",
+    mainImage: {
+      assets: [],
+      mediaApiUri: undefined,
+      mediaId: undefined,
+      suppliersReference: "",
+    },
+    photographer: "",
+    role: "none-selected",
+    source: "",
+    ...data,
+  };
+};
+
+const externnalElement = (data: Partial<ImageFields> = {}) => {
+  return {
+    assets: [],
+    fields: {
+      alt: "",
+      caption: "",
+      displayCredit: "true",
+      imageType: "",
+      isMandatory: "true",
+      mediaApiUri: "",
+      mediaId: "",
+      photographer: "",
+      role: undefined,
+      source: "",
+      suppliersReference: "",
+      ...data,
+    },
+  };
+};
+
+describe("image element transform", () => {
+  describe("transformIn", () => {
+    it("should not allow elements which are the wrong type", () => {
+      // @ts-expect-error -- we should not be able to transform a malformed element
+      expect(() => transformElement.in({})).toThrow;
+      expect(() =>
+        transformElement.in({
+          assets: [],
+          // @ts-expect-error -- we should not be able to transform a malformed element
+          fields: { nonExistantField: "123" },
+        })
+      ).toThrow;
+    });
+    it("should partially transform elements with no fields", () => {
+      const element = { assets: [], fields: {} };
+      const result = transformElement.in(element);
+      expect(result).toEqual(partialPmeElement());
+    });
+    it("should partially transform elements with some fields", () => {
+      const altText = "alt text";
+      const element = {
+        assets: [],
+        fields: { alt: altText, displayCredit: "true" },
+      };
+      const result = transformElement.in(element);
+      expect(result).toEqual(
+        partialPmeElement({ alt: altText, displayCredit: true })
+      );
+    });
+    it("should convert undefined dropdown to undefined string", () => {
+      const element = {
+        assets: [],
+        fields: { role: undefined },
+      };
+      const result = transformElement.in(element);
+      expect(result).toEqual(
+        partialPmeElement({ role: undefinedDropdownValue })
+      );
+    });
+    it("should not convert regular dropdown strings", () => {
+      const element = {
+        assets: [],
+        fields: { role: "showcase" },
+      };
+      const result = transformElement.in(element);
+      expect(result).toEqual(partialPmeElement({ role: "showcase" }));
+    });
+    it("should convert displayCredit to boolean", () => {
+      const element = {
+        assets: [],
+        fields: { displayCredit: "false" },
+      };
+      const result = transformElement.in(element);
+      expect(result).toEqual(partialPmeElement({ displayCredit: false }));
+    });
+  });
+  describe("transformOut", () => {
+    it("should not allow elements which are the wrong type", () => {
+      // @ts-expect-error -- we should not be able to transform a malformed element
+      expect(() => transformElement.out({})).toThrow;
+      expect(() =>
+        transformElement.out({
+          // @ts-expect-error -- we should not be able to transform a malformed element
+          nonExistantField: "123",
+        })
+      ).toThrow;
+    });
+    it("should completely transform elements with all fields", () => {
+      const element = fullPmeElement();
+      const result = transformElement.out(element);
+      expect(result).toEqual(externnalElement());
+    });
+    it("should convert undefined dropdown string to undefined", () => {
+      const element = fullPmeElement({ role: undefinedDropdownValue });
+      const result = transformElement.out(element);
+      expect(result).toEqual(externnalElement({ role: undefined }));
+    });
+    it("should not convert regular dropdown strings", () => {
+      const element = fullPmeElement({ role: "showcase" });
+      const result = transformElement.out(element);
+      expect(result).toEqual(externnalElement({ role: "showcase" }));
+    });
+    it("should convert displayCredit to string", () => {
+      const element = fullPmeElement({ displayCredit: false });
+      const result = transformElement.out(element);
+      expect(result).toEqual(externnalElement({ displayCredit: "false" }));
+    });
+  });
+});

--- a/src/elements/image/imageElementDataTransformer.ts
+++ b/src/elements/image/imageElementDataTransformer.ts
@@ -3,7 +3,7 @@ import type { TransformIn, TransformOut } from "../transformer/types/Transform";
 import type { Asset, createImageFields, MainImageData } from "./ImageElement";
 import { undefinedDropdownValue } from "./ImageElement";
 
-type ImageFields = {
+export type ImageFields = {
   alt: string;
   caption: string;
   displayCredit: string;

--- a/src/elements/image/imageElementDataTransformer.ts
+++ b/src/elements/image/imageElementDataTransformer.ts
@@ -1,6 +1,7 @@
 import type { FieldNameToValueMap } from "../../plugin/fieldViews/helpers";
 import type { TransformIn, TransformOut } from "../transformer/types/Transform";
 import type { Asset, createImageFields, MainImageData } from "./ImageElement";
+import { undefinedDropdownValue } from "./ImageElement";
 
 type ImageFields = {
   alt: string;
@@ -11,7 +12,7 @@ type ImageFields = {
   mediaApiUri: string;
   mediaId: string;
   photographer: string;
-  role: string;
+  role: string | undefined;
   source: string;
   suppliersReference: string;
 };
@@ -56,7 +57,7 @@ export const transformElementIn: TransformIn<
     displayCredit: displayCredit === "true",
     imageType,
     photographer,
-    role,
+    role: role ?? undefinedDropdownValue,
     source,
     mainImage,
   };
@@ -88,7 +89,7 @@ export const transformElementOut: TransformOut<
       mediaApiUri: mainImage.mediaApiUri ?? "",
       mediaId: mainImage.mediaId ?? "",
       photographer,
-      role,
+      role: role === undefinedDropdownValue ? undefined : role,
       source,
       suppliersReference: mainImage.suppliersReference,
     },

--- a/src/elements/image/imageElementValidation.ts
+++ b/src/elements/image/imageElementValidation.ts
@@ -22,6 +22,7 @@ const hasAssets = (maybeData: unknown): maybeData is { assets: Asset[] } => {
     isRecord(maybeData) &&
     maybeData.assets != undefined &&
     Array.isArray(maybeData.assets) &&
+    maybeData.assets.length > 0 &&
     maybeData.assets.every((asset) => isValidImageAsset(asset))
   );
 };

--- a/src/elements/image/imageElementValidation.ts
+++ b/src/elements/image/imageElementValidation.ts
@@ -5,6 +5,13 @@ const isRecord = (value: unknown): value is Record<string, unknown> => {
   return typeof value === "object" && value !== null;
 };
 
+const isStringOrNumber = (value: unknown): value is string | number => {
+  return typeof value === "string" || typeof value === "number";
+};
+
+const stringOrNumberToNumber = (value: string | number) =>
+  parseInt(value.toString());
+
 const isValidImageAsset = (maybeImage: unknown): maybeImage is Asset => {
   return (
     isRecord(maybeImage) &&
@@ -12,8 +19,10 @@ const isValidImageAsset = (maybeImage: unknown): maybeImage is Asset => {
     isRecord(maybeImage.fields) &&
     maybeImage.fields.width !== undefined &&
     maybeImage.fields.height !== undefined &&
-    typeof maybeImage.fields.width === "number" &&
-    typeof maybeImage.fields.height === "number"
+    isStringOrNumber(maybeImage.fields.width) &&
+    isStringOrNumber(maybeImage.fields.height) &&
+    !isNaN(stringOrNumberToNumber(maybeImage.fields.width)) &&
+    !isNaN(stringOrNumberToNumber(maybeImage.fields.height))
   );
 };
 
@@ -32,12 +41,16 @@ export const largestAssetMinDimension = (minSize: number): FieldValidator => (
 ) => {
   if (hasAssets(value)) {
     const largestImageAsset = value.assets.sort(function (a, b) {
-      return b.fields.width - a.fields.width;
+      return (
+        stringOrNumberToNumber(b.fields.width) -
+        stringOrNumberToNumber(a.fields.width)
+      );
     })[0];
 
     if (
-      largestImageAsset.fields.width < minSize &&
-      largestImageAsset.fields.height < minSize
+      stringOrNumberToNumber(largestImageAsset.fields.width.toString()) <
+        minSize &&
+      stringOrNumberToNumber(largestImageAsset.fields.height) < minSize
     ) {
       return [
         {

--- a/src/elements/transformer/__tests__/transform.spec.ts
+++ b/src/elements/transformer/__tests__/transform.spec.ts
@@ -1,7 +1,4 @@
-import {
-  transformElementIn,
-  transformElementOut,
-} from "../transformer/transform";
+import { transformElementIn, transformElementOut } from "../transform";
 
 describe("transform", () => {
   describe("transformIn", () => {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR makes various tweaks to the image element, in order to more closely align it to the existing element.

These changes are:

1. Handling the undefined value of the "weighting" dropdown
2. Displaying a character count for the "caption" field
3. Handling assets with a width and heigh of string 
4. Updates button to use "Guardian Agate Sans"

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
The tests should pass and the behaviour described above should work correctly in the demo and composer.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Our PME image element more closely matches the existing composer version.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![image](https://user-images.githubusercontent.com/4633246/134648179-cb8989e0-4de6-4f33-8695-4f2ceb01b621.png)


## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [x] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [x] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [x] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
