### PR TITLE
feat: minor refactors re: feedback

### DIFF
--- a/src/editorial-source-components/FieldWrapper.tsx
+++ b/src/editorial-source-components/FieldWrapper.tsx
@@ -6,7 +6,7 @@ import { InputHeading } from "./InputHeading";
 
 type Props<F> = {
   field: F;
-  errors: ValidationError[];
+  errors?: ValidationError[];
   label: React.ReactNode;
   description?: React.ReactNode;
   className?: string;
@@ -14,7 +14,7 @@ type Props<F> = {
 
 export const FieldWrapper = <F extends Field<TFieldView<unknown>>>({
   field,
-  errors,
+  errors = [],
   label,
   description,
   className,

--- a/src/elements/code/CodeElementSpec.tsx
+++ b/src/elements/code/CodeElementSpec.tsx
@@ -26,7 +26,7 @@ export const codeFields = {
 
 export const codeElement = createReactElementSpec(
   codeFields,
-  (_, errors, __, fields) => {
+  (fields, errors) => {
     return <CodeElementForm errors={errors} fields={fields} />;
   }
 );

--- a/src/elements/code/CodeElementSpec.tsx
+++ b/src/elements/code/CodeElementSpec.tsx
@@ -26,7 +26,7 @@ export const codeFields = {
 
 export const codeElement = createReactElementSpec(
   codeFields,
-  (fields, errors) => {
+  ({ fields, errors }) => {
     return <CodeElementForm errors={errors} fields={fields} />;
   }
 );

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -84,7 +84,7 @@ export const createDemoImageElement = (
 ) =>
   createReactElementSpec(
     createImageFields(onSelect, onCrop),
-    (fields, errors, fieldValues) => {
+    ({ fields, errors, fieldValues }) => {
       return (
         <ImageElementForm
           fields={fields}

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -84,7 +84,7 @@ export const createDemoImageElement = (
 ) =>
   createReactElementSpec(
     createImageFields(onSelect, onCrop),
-    (fieldValues, errors, __, fields) => {
+    (fields, errors, fieldValues) => {
       return (
         <ImageElementForm
           fields={fields}

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -36,7 +36,7 @@ export const embedFields = {
 };
 
 export const createEmbedElement = () =>
-  createReactElementSpec(embedFields, (fields, errors, fieldValues) => {
+  createReactElementSpec(embedFields, ({ fields, errors, fieldValues }) => {
     return (
       <EmbedElementForm
         fields={fields}

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -36,7 +36,7 @@ export const embedFields = {
 };
 
 export const createEmbedElement = () =>
-  createReactElementSpec(embedFields, (fieldValues, errors, __, fields) => {
+  createReactElementSpec(embedFields, (fields, errors, fieldValues) => {
     return (
       <EmbedElementForm
         fields={fields}

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -95,7 +95,7 @@ export const createImageFields = ({
 export const createImageElement = (props: MainImageProps) =>
   createReactElementSpec(
     createImageFields(props),
-    (fieldValues, errors, __, fields) => {
+    (fields, errors, fieldValues) => {
       return (
         <ImageElementForm
           fieldValues={fieldValues}

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -95,7 +95,7 @@ export const createImageFields = ({
 export const createImageElement = (props: MainImageProps) =>
   createReactElementSpec(
     createImageFields(props),
-    (fields, errors, fieldValues) => {
+    ({ fields, errors, fieldValues }) => {
       return (
         <ImageElementForm
           fieldValues={fieldValues}

--- a/src/elements/pullquote/PullquoteSpec.tsx
+++ b/src/elements/pullquote/PullquoteSpec.tsx
@@ -21,7 +21,7 @@ export const pullquoteFields = {
 
 export const pullquoteElement = createReactElementSpec(
   pullquoteFields,
-  (fields, errors) => {
+  ({ fields, errors }) => {
     return <PullquoteElementForm errors={errors} fields={fields} />;
   }
 );

--- a/src/elements/pullquote/PullquoteSpec.tsx
+++ b/src/elements/pullquote/PullquoteSpec.tsx
@@ -21,7 +21,7 @@ export const pullquoteFields = {
 
 export const pullquoteElement = createReactElementSpec(
   pullquoteFields,
-  (_, errors, __, fields) => {
+  (fields, errors) => {
     return <PullquoteElementForm errors={errors} fields={fields} />;
   }
 );

--- a/src/plugin/types/Consumer.ts
+++ b/src/plugin/types/Consumer.ts
@@ -2,12 +2,14 @@ import type { FieldValidationErrors } from "../elementSpec";
 import type { FieldNameToValueMap } from "../fieldViews/helpers";
 import type { FieldDescriptions, FieldNameToField } from "./Element";
 
-export type Consumer<
-  ConsumerResult,
-  FDesc extends FieldDescriptions<string>
-> = (options: {
+type ConsumerOptions<FDesc extends FieldDescriptions<string>> = {
   fields: FieldNameToField<FDesc>;
   errors: FieldValidationErrors;
   fieldValues: FieldNameToValueMap<FDesc>;
   updateFields: (fieldValues: FieldNameToValueMap<FDesc>) => void;
-}) => ConsumerResult;
+};
+
+export type Consumer<
+  ConsumerResult,
+  FDesc extends FieldDescriptions<string>
+> = (options: ConsumerOptions<FDesc>) => ConsumerResult;

--- a/src/plugin/types/Consumer.ts
+++ b/src/plugin/types/Consumer.ts
@@ -6,8 +6,8 @@ export type Consumer<
   ConsumerResult,
   FDesc extends FieldDescriptions<string>
 > = (
-  fieldValues: FieldNameToValueMap<FDesc>,
+  fields: FieldNameToField<FDesc>,
   errors: FieldValidationErrors,
-  updateFields: (fieldValues: FieldNameToValueMap<FDesc>) => void,
-  fields: FieldNameToField<FDesc>
+  fieldValues: FieldNameToValueMap<FDesc>,
+  updateFields: (fieldValues: FieldNameToValueMap<FDesc>) => void
 ) => ConsumerResult;

--- a/src/plugin/types/Consumer.ts
+++ b/src/plugin/types/Consumer.ts
@@ -5,9 +5,9 @@ import type { FieldDescriptions, FieldNameToField } from "./Element";
 export type Consumer<
   ConsumerResult,
   FDesc extends FieldDescriptions<string>
-> = (
-  fields: FieldNameToField<FDesc>,
-  errors: FieldValidationErrors,
-  fieldValues: FieldNameToValueMap<FDesc>,
-  updateFields: (fieldValues: FieldNameToValueMap<FDesc>) => void
-) => ConsumerResult;
+> = (options: {
+  fields: FieldNameToField<FDesc>;
+  errors: FieldValidationErrors;
+  fieldValues: FieldNameToValueMap<FDesc>;
+  updateFields: (fieldValues: FieldNameToValueMap<FDesc>) => void;
+}) => ConsumerResult;

--- a/src/renderers/react/ElementProvider.tsx
+++ b/src/renderers/react/ElementProvider.tsx
@@ -101,12 +101,12 @@ export class ElementProvider<
     );
     return (
       <ElementWrapper {...this.state.commands}>
-        {this.props.consumer(
-          this.props.fields,
+        {this.props.consumer({
+          fields: this.props.fields,
           errors,
-          this.state.fieldValues,
-          this.updateFields
-        )}
+          fieldValues: this.state.fieldValues,
+          updateFields: this.updateFields,
+        })}
       </ElementWrapper>
     );
   }

--- a/src/renderers/react/ElementProvider.tsx
+++ b/src/renderers/react/ElementProvider.tsx
@@ -102,10 +102,10 @@ export class ElementProvider<
     return (
       <ElementWrapper {...this.state.commands}>
         {this.props.consumer(
-          this.state.fieldValues,
+          this.props.fields,
           errors,
-          this.updateFields,
-          this.props.fields
+          this.state.fieldValues,
+          this.updateFields
         )}
       </ElementWrapper>
     );


### PR DESCRIPTION
## What does this change?

- Reorders our consumer arguments in order of most common usage.
- Removes the requirement for an error object on FieldWrapper, avoiding boilerplate for fields that do not have validation.

## How to test

The refactored code should look cleaner, with fewer missed arguments. (There's also an argument for an options object for our consumer arguments, but we can tackle that another time!)

I haven't removed unused error objects in existing fields, because it's a bit risky – I think there's a strong case to colocate the errors on the existing `Field` objects, preventing these sorts of problems in the first place.