### PR TITLE
fix: Fix validation bug

### DIFF
--- a/src/plugin/helpers/validation.spec.ts
+++ b/src/plugin/helpers/validation.spec.ts
@@ -1,4 +1,10 @@
-import { createValidator, maxLength, required } from "./validation";
+import { createDefaultRichTextField } from "../fieldViews/RichTextFieldView";
+import {
+  createValidator,
+  maxLength,
+  required,
+  validateWithFieldAndElementValidators,
+} from "./validation";
 
 describe("Validation helpers", () => {
   describe("buildValidator", () => {
@@ -46,6 +52,88 @@ describe("Validation helpers", () => {
       expect(result).toEqual({
         field1: [],
         field2: [{ error: "Required", message: "field2 is required" }],
+      });
+    });
+  });
+
+  describe("validateWithFieldAndElementValidators", () => {
+    it("should be able to validate with an element validator", () => {
+      const fieldDescriptions = {
+        field1: createDefaultRichTextField(),
+        field2: createDefaultRichTextField(),
+      };
+
+      const elementValidator = createValidator({
+        field1: [maxLength(5)],
+        field2: [maxLength(5)],
+      });
+
+      const validator = validateWithFieldAndElementValidators(
+        fieldDescriptions,
+        elementValidator
+      );
+
+      const result = validator({
+        field1: "OK!",
+        field2: "Not OK!",
+      });
+
+      expect(result).toEqual({
+        field1: [],
+        field2: [
+          { error: "Too long: 7/5", message: "field2 is too long: 7/5" },
+        ],
+      });
+    });
+    it("should be able to validate with a field validators", () => {
+      const fieldDescriptions = {
+        field1: createDefaultRichTextField([maxLength(5)]),
+        field2: createDefaultRichTextField([maxLength(5)]),
+      };
+
+      const validator = validateWithFieldAndElementValidators(
+        fieldDescriptions
+      );
+
+      const result = validator({
+        field1: "OK!",
+        field2: "Not OK!",
+      });
+
+      expect(result).toEqual({
+        field1: [],
+        field2: [
+          { error: "Too long: 7/5", message: "field2 is too long: 7/5" },
+        ],
+      });
+    });
+    it("should be able to validate with a mix of validators", () => {
+      const fieldDescriptions = {
+        field1: createDefaultRichTextField([maxLength(5)]),
+        field2: createDefaultRichTextField(),
+      };
+
+      const elementValidator = createValidator({
+        field2: [maxLength(5)],
+      });
+
+      const validator = validateWithFieldAndElementValidators(
+        fieldDescriptions,
+        elementValidator
+      );
+
+      const result = validator({
+        field1: "Not OK!",
+        field2: "Not OK!",
+      });
+
+      expect(result).toEqual({
+        field1: [
+          { error: "Too long: 7/5", message: "field1 is too long: 7/5" },
+        ],
+        field2: [
+          { error: "Too long: 7/5", message: "field2 is too long: 7/5" },
+        ],
       });
     });
   });

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -32,17 +32,20 @@ export const validateWithFieldAndElementValidators = <
 ): Validator<FDesc> => (fields: Partial<FieldNameToValueMap<FDesc>>) => {
   const fieldErrors: FieldValidationErrors = {};
   for (const field in fieldDescriptions) {
-    fieldErrors[field] = [];
     const value = fields[field];
     const validators = fieldDescriptions[field].validators;
-    validators?.forEach((validate) => {
-      fieldErrors[field] = [...fieldErrors[field], ...validate(value, field)];
-    });
+    if (validators?.length) {
+      fieldErrors[field] = [];
+      validators.forEach((validate) => {
+        const errors = validate(value, field);
+        fieldErrors[field].push(...errors);
+      });
+    }
   }
 
   const elementErrors = validateElement ? validateElement(fields) : {};
 
-  const allErrors = { ...elementErrors, ...fieldErrors };
+  const allErrors = { ...fieldErrors, ...elementErrors };
 
   return Object.keys(allErrors).length > 0 ? allErrors : undefined;
 };


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR aims to fix a small bug which was causing validation errors to be lost. This would happen if a field had multiple validators. These validators could then overwrite previous errors. 

This PR fixes the bug and adds additional unit tests to ensure there are no further issues.

NB: I think the API for the validator needs to be reconsidered. The format of errors we output is slightly confusing, occasionally outputting undefined or fields with an empty error array. In addition, the error and field errors don't currently play nicely. I think these are changes which can be handled under a separate PR.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Are the unit tests thorough enough to give us confidence the change is working? Does the image element source character limit display as expected? 

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Field validation errors are surfaced correctly.

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [ ] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [ ] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
