### PR TITLE
feat: Add placeholder option for text and rich text fields

### DIFF
--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -1,4 +1,5 @@
 import type { WindowType } from "../../demo/types";
+import { placeholderTestAttribute } from "../../src/plugin/helpers/placeholder";
 import {
   ChangeTestDecoStringAction,
   trimHtml,
@@ -35,6 +36,13 @@ export const typeIntoProsemirror = (content: string) =>
 
 export const getElementRichTextField = (fieldName: string) =>
   cy.get(`div${selectDataCy(getFieldViewTestId(fieldName))} .ProseMirror`);
+
+export const getElementRichTextFieldPlaceholder = (fieldName: string) =>
+  cy.get(
+    `div${selectDataCy(
+      getFieldViewTestId(fieldName)
+    )} [data-cy=${placeholderTestAttribute}]`
+  );
 
 export const getElementField = (fieldName: string) =>
   cy.get(`div${selectDataCy(getFieldViewTestId(fieldName))}`);

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -7,6 +7,7 @@ import {
   getElementField,
   getElementMenuButton,
   getElementRichTextField,
+  getElementRichTextFieldPlaceholder,
   getSerialisedHtml,
   italicShortcut,
   selectDataCy,
@@ -25,6 +26,13 @@ describe("ImageElement", () => {
 
   describe("Fields", () => {
     describe("Rich text field", () => {
+      it(`caption – should have a placeholder`, () => {
+        addImageElement();
+        getElementRichTextFieldPlaceholder("caption").should(
+          "have.text",
+          "Enter caption"
+        );
+      });
       it(`caption – should accept input in an element`, () => {
         addImageElement();
         const text = `caption text`;
@@ -153,6 +161,14 @@ describe("ImageElement", () => {
     });
 
     describe("Text field", () => {
+      it(`should have a placeholder`, () => {
+        addImageElement();
+        getElementRichTextFieldPlaceholder("src").should(
+          "have.text",
+          "Add src"
+        );
+      });
+
       it(`should accept input in an element`, () => {
         addImageElement();
         const text = `Src text`;

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -11,6 +11,7 @@ import {
   createFlatRichTextField,
 } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
+import { placeholderTestAttribute } from "../../plugin/helpers/placeholder";
 import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { ImageElementForm } from "./DemoImageElementForm";
@@ -28,6 +29,22 @@ type ImageField = {
   assets: string[];
 };
 
+const getCustomPlaceholder = (text: string) => () => {
+  const span = document.createElement("span");
+  span.style.fontFamily = "Comic Sans MS";
+  span.style.display = "inline-block";
+  span.style.height = "0px";
+  span.style.width = "0px";
+  span.style.whiteSpace = "nowrap";
+  span.style.color = "#888";
+  span.style.pointerEvents = "none";
+  span.style.cursor = "text";
+  span.draggable = false;
+  span.innerHTML = text;
+  span.setAttribute("data-cy", placeholderTestAttribute);
+  return span;
+};
+
 type ImageProps = {
   onSelectImage: (setMedia: DemoSetMedia) => void;
   onCropImage: (mediaId: string, setMedia: DemoSetMedia) => void;
@@ -38,18 +55,20 @@ export const createImageFields = (
   onCropImage: (mediaId: string, setMedia: DemoSetMedia) => void
 ) => {
   return {
-    caption: createDefaultRichTextField([htmlRequired()]),
+    caption: createDefaultRichTextField([htmlRequired()], "Enter caption"),
     restrictedTextField: createFlatRichTextField({
+      placeholder: "Enter restricted text",
       createPlugins: (schema) => exampleSetup({ schema }),
       nodeSpec: {
         marks: "em",
       },
     }),
     altText: createTextField({
+      placeholder: "Alt text",
       rows: 2,
       validators: [htmlMaxLength(100), htmlRequired()],
     }),
-    src: createTextField({ placeholder: "Add src here" }),
+    src: createTextField({ placeholder: getCustomPlaceholder("Add src") }),
     code: createTextField({
       rows: 4,
       isCode: true,

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -49,10 +49,11 @@ export const createImageFields = (
       rows: 2,
       validators: [htmlMaxLength(100), htmlRequired()],
     }),
-    src: createTextField(),
+    src: createTextField({ placeholder: "Add src here" }),
     code: createTextField({
       rows: 4,
       isCode: true,
+      placeholder: "Write code here",
     }),
     mainImage: createCustomField<ImageField, ImageProps>(
       { mediaId: undefined, mediaApiUri: undefined, assets: [] },

--- a/src/plugin/fieldViews/RichTextFieldView.ts
+++ b/src/plugin/fieldViews/RichTextFieldView.ts
@@ -129,7 +129,8 @@ export class RichTextFieldView extends ProseMirrorFieldView {
           "Mod-y": () => redo(outerView.state, outerView.dispatch),
         }),
         ...(field.createPlugins ? field.createPlugins(node.type.schema) : []),
-      ]
+      ],
+      field.placeholder
     );
 
     this.fieldViewElement.classList.add("ProseMirrorElements__RichTextField");

--- a/src/plugin/fieldViews/RichTextFieldView.ts
+++ b/src/plugin/fieldViews/RichTextFieldView.ts
@@ -5,10 +5,11 @@ import type { Node, NodeSpec, Schema } from "prosemirror-model";
 import type { EditorState, Plugin, Transaction } from "prosemirror-state";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import type { FieldValidator } from "../elementSpec";
-import type { BaseFieldDescription } from "./FieldView";
+import type { PlaceholderOption } from "../helpers/placeholder";
+import type { AbstractTextFieldDescription } from "./ProseMirrorFieldView";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
 
-export interface RichTextFieldDescription extends BaseFieldDescription<string> {
+export interface RichTextFieldDescription extends AbstractTextFieldDescription {
   type: typeof RichTextFieldView.fieldName;
   createPlugins?: (schema: Schema) => Plugin[];
   nodeSpec?: Partial<NodeSpec>;
@@ -22,6 +23,7 @@ type RichTextOptions = {
   createPlugins?: (schema: Schema) => Plugin[];
   nodeSpec?: Partial<NodeSpec>;
   validators?: FieldValidator[];
+  placeholder?: PlaceholderOption;
 };
 
 export const createRichTextField = ({
@@ -29,12 +31,14 @@ export const createRichTextField = ({
   createPlugins,
   nodeSpec,
   validators,
+  placeholder,
 }: RichTextOptions): RichTextFieldDescription => ({
   type: RichTextFieldView.fieldName,
   createPlugins,
   nodeSpec,
   validators,
   absentOnEmpty,
+  placeholder,
 });
 
 type FlatRichTextOptions = RichTextOptions & {
@@ -50,6 +54,7 @@ export const createFlatRichTextField = ({
   createPlugins,
   nodeSpec,
   validators,
+  placeholder,
 }: FlatRichTextOptions): RichTextFieldDescription =>
   createRichTextField({
     createPlugins: (schema) => {
@@ -78,6 +83,7 @@ export const createFlatRichTextField = ({
       content: "(text|hard_break)*",
     },
     validators,
+    placeholder,
   });
 
 /**
@@ -85,11 +91,13 @@ export const createFlatRichTextField = ({
  * purposes, as library users are likely to want different defaults.
  */
 export const createDefaultRichTextField = (
-  validators?: FieldValidator[]
+  validators?: FieldValidator[],
+  placeholder?: string
 ): RichTextFieldDescription =>
   createRichTextField({
     createPlugins: (schema) => exampleSetup({ schema }),
     validators,
+    placeholder: placeholder ?? "",
   });
 
 export class RichTextFieldView extends ProseMirrorFieldView {
@@ -106,8 +114,7 @@ export class RichTextFieldView extends ProseMirrorFieldView {
     offset: number,
     // The initial decorations for the FieldView.
     decorations: DecorationSet | Decoration[],
-    // The plugins passed by the consumer into the FieldView, if any.
-    plugins: Plugin[]
+    field: RichTextFieldDescription
   ) {
     super(
       node,
@@ -121,7 +128,7 @@ export class RichTextFieldView extends ProseMirrorFieldView {
           "Mod-z": () => undo(outerView.state, outerView.dispatch),
           "Mod-y": () => redo(outerView.state, outerView.dispatch),
         }),
-        ...plugins,
+        ...(field.createPlugins ? field.createPlugins(node.type.schema) : []),
       ]
     );
 

--- a/src/plugin/fieldViews/TextFieldView.ts
+++ b/src/plugin/fieldViews/TextFieldView.ts
@@ -6,10 +6,11 @@ import type { Node, Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import type { FieldValidator } from "../elementSpec";
-import type { BaseFieldDescription } from "./FieldView";
+import type { PlaceholderOption } from "../helpers/placeholder";
+import type { AbstractTextFieldDescription } from "./ProseMirrorFieldView";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
 
-export interface TextFieldDescription extends BaseFieldDescription<string> {
+export interface TextFieldDescription extends AbstractTextFieldDescription {
   type: typeof TextFieldView.fieldName;
   // Can this field display over multiple lines? This will
   // insert line breaks (<br>) when the user hits the Enter key.
@@ -29,6 +30,7 @@ type TextFieldOptions = {
   isCode?: boolean;
   absentOnEmpty?: boolean;
   validators?: FieldValidator[];
+  placeholder?: PlaceholderOption;
 };
 
 export const createTextField = (
@@ -37,11 +39,13 @@ export const createTextField = (
     isCode = false,
     absentOnEmpty = false,
     validators,
+    placeholder,
   }: TextFieldOptions | undefined = {
     rows: 1,
     isCode: false,
     absentOnEmpty: false,
     validators: [],
+    placeholder: undefined,
   }
 ): TextFieldDescription => ({
   type: TextFieldView.fieldName,
@@ -50,6 +54,7 @@ export const createTextField = (
   isCode,
   absentOnEmpty,
   validators,
+  placeholder,
 });
 
 export class TextFieldView extends ProseMirrorFieldView {
@@ -66,7 +71,7 @@ export class TextFieldView extends ProseMirrorFieldView {
     offset: number,
     // The initial decorations for the FieldView.
     decorations: DecorationSet | Decoration[],
-    { isMultiline, rows, isCode }: TextFieldDescription
+    { isMultiline, rows, isCode, placeholder }: TextFieldDescription
   ) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars -- remove 'enter' commands from keymap
     const { Enter, "Mod-Enter": ModEnter, ...modifiedBaseKeymap } = baseKeymap;
@@ -99,7 +104,8 @@ export class TextFieldView extends ProseMirrorFieldView {
       offset,
       decorations,
       TextFieldView.fieldName,
-      [keymap(keymapping)]
+      [keymap(keymapping)],
+      placeholder
     );
 
     if (isCode && this.innerEditorView) {

--- a/src/plugin/helpers/__tests__/placeholder.spec.ts
+++ b/src/plugin/helpers/__tests__/placeholder.spec.ts
@@ -1,0 +1,36 @@
+import { schema } from "prosemirror-schema-basic";
+import { DecorationSet } from "prosemirror-view";
+import { createPlaceholderDecos } from "../placeholder";
+import { getDecoSpecs } from "../test";
+
+describe("createPlaceholderDecos", () => {
+  it("should not add a decoration given a contentful inline doc", () => {
+    const doc = schema.nodes.doc.create({}, schema.text("Content"));
+    expect(createPlaceholderDecos("Placeholder")({ doc })).toBe(
+      DecorationSet.empty
+    );
+  });
+  it("should add a decoration given a contentless inline doc", () => {
+    const doc = schema.nodes.doc.create({});
+    const decoSpecs = getDecoSpecs(
+      createPlaceholderDecos("Placeholder")({ doc })
+    );
+    expect(decoSpecs).toEqual([{ from: 0, to: 0 }]);
+  });
+  it("should not add a decoration given a contentful doc with paragraphs", () => {
+    const doc = schema.nodes.doc.create(
+      {},
+      schema.nodes.paragraph.create({}, schema.text("Content"))
+    );
+    expect(createPlaceholderDecos("Placeholder")({ doc })).toBe(
+      DecorationSet.empty
+    );
+  });
+  it("should add a decoration given a contentless doc with paragraphs", () => {
+    const doc = schema.nodes.doc.create({}, schema.nodes.paragraph.create({}));
+    const decoSpecs = getDecoSpecs(
+      createPlaceholderDecos("Placeholder")({ doc })
+    );
+    expect(decoSpecs).toEqual([{ from: 2, to: 2 }]);
+  });
+});

--- a/src/plugin/helpers/__tests__/placeholder.spec.ts
+++ b/src/plugin/helpers/__tests__/placeholder.spec.ts
@@ -31,6 +31,6 @@ describe("createPlaceholderDecos", () => {
     const decoSpecs = getDecoSpecs(
       createPlaceholderDecos("Placeholder")({ doc })
     );
-    expect(decoSpecs).toEqual([{ from: 2, to: 2 }]);
+    expect(decoSpecs).toEqual([{ from: 1, to: 1 }]);
   });
 });

--- a/src/plugin/helpers/fieldView.ts
+++ b/src/plugin/helpers/fieldView.ts
@@ -95,7 +95,7 @@ export const getElementFieldViewFromType = (
         getPos,
         offset,
         innerDecos,
-        field.createPlugins ? field.createPlugins(node.type.schema) : []
+        field
       );
     case "checkbox":
       return new CheckboxFieldView(

--- a/src/plugin/helpers/placeholder.ts
+++ b/src/plugin/helpers/placeholder.ts
@@ -35,19 +35,25 @@ const getFirstPlaceholderPosition = (node: Node, currentPos = 0): number =>
       )
     : currentPos + node.content.size;
 
+export const createPlaceholderDecos = (text: string) => ({
+  doc,
+}: {
+  doc: Node;
+}) => {
+  if (doc.textContent) {
+    return DecorationSet.empty;
+  }
+
+  // If the document contains inline content only, just place the widget at its start.
+  const pos = doc.inlineContent ? 0 : getFirstPlaceholderPosition(doc);
+  return DecorationSet.create(doc, [
+    Decoration.widget(pos, getPlaceholder(text)),
+  ]);
+};
+
 export const createPlaceholderPlugin = (text: string) =>
   new Plugin({
     props: {
-      decorations: ({ doc }) => {
-        if (doc.textContent) {
-          return DecorationSet.empty;
-        }
-
-        // If the document contains inline content only, just place the widget at its start.
-        const pos = doc.inlineContent ? 0 : getFirstPlaceholderPosition(doc);
-        return DecorationSet.create(doc, [
-          Decoration.widget(pos, getPlaceholder(text)),
-        ]);
-      },
+      decorations: createPlaceholderDecos(text),
     },
   });

--- a/src/plugin/helpers/placeholder.ts
+++ b/src/plugin/helpers/placeholder.ts
@@ -1,0 +1,53 @@
+import type { Node } from "prosemirror-model";
+import { Plugin } from "prosemirror-state";
+import { Decoration, DecorationSet } from "prosemirror-view";
+
+const placeholderAttribute = "data-cy-is-placeholder";
+
+const getPlaceholder = (text: string) => {
+  const span = document.createElement("span");
+  span.style.display = "inline-block";
+  span.style.height = "0px";
+  span.style.width = "0px";
+  span.style.whiteSpace = "nowrap";
+  span.style.fontStyle = "italic";
+  span.style.color = "#777";
+  span.style.pointerEvents = "none";
+  span.style.cursor = "text";
+  span.draggable = false;
+  span.innerHTML = text;
+  span.setAttribute(placeholderAttribute, "true");
+  return span;
+};
+
+export const containsPlaceholder = (element: HTMLElement): boolean =>
+  !!element.querySelector(`span[${placeholderAttribute}]`);
+
+/**
+ * Get the first placeholder position in the document – assumed
+ * to be the starting position of the deepest first child.
+ */
+const getFirstPlaceholderPosition = (node: Node, currentPos = 0): number =>
+  node.firstChild
+    ? getFirstPlaceholderPosition(
+        node.firstChild,
+        currentPos + node.content.size
+      )
+    : currentPos + node.content.size;
+
+export const createPlaceholderPlugin = (text: string) =>
+  new Plugin({
+    props: {
+      decorations: ({ doc }) => {
+        if (doc.textContent) {
+          return DecorationSet.empty;
+        }
+
+        // If the document contains inline content only, just place the widget at its start.
+        const pos = doc.inlineContent ? 0 : getFirstPlaceholderPosition(doc);
+        return DecorationSet.create(doc, [
+          Decoration.widget(pos, getPlaceholder(text)),
+        ]);
+      },
+    },
+  });

--- a/src/plugin/helpers/placeholder.ts
+++ b/src/plugin/helpers/placeholder.ts
@@ -10,7 +10,8 @@ const getDefaultPlaceholder = (text: string) => {
   span.style.height = "0px";
   span.style.width = "0px";
   span.style.whiteSpace = "nowrap";
-  span.style.color = "#888";
+  // Passes accessibility contrast on a white background
+  span.style.color = "#777575";
   span.style.pointerEvents = "none";
   span.style.cursor = "text";
   span.draggable = false;

--- a/src/plugin/helpers/placeholder.ts
+++ b/src/plugin/helpers/placeholder.ts
@@ -4,14 +4,13 @@ import { Decoration, DecorationSet } from "prosemirror-view";
 
 const placeholderAttribute = "data-cy-is-placeholder";
 
-const getPlaceholder = (text: string) => {
+const getDefaultPlaceholder = (text: string) => {
   const span = document.createElement("span");
   span.style.display = "inline-block";
   span.style.height = "0px";
   span.style.width = "0px";
   span.style.whiteSpace = "nowrap";
-  span.style.fontStyle = "italic";
-  span.style.color = "#777";
+  span.style.color = "#888";
   span.style.pointerEvents = "none";
   span.style.cursor = "text";
   span.draggable = false;
@@ -35,23 +34,26 @@ const getFirstPlaceholderPosition = (node: Node, currentPos = 0): number =>
       )
     : currentPos + node.content.size;
 
-export const createPlaceholderDecos = (text: string) => ({
-  doc,
-}: {
-  doc: Node;
-}) => {
-  if (doc.textContent) {
-    return DecorationSet.empty;
-  }
+export type PlaceholderOption = string | (() => HTMLElement);
 
-  // If the document contains inline content only, just place the widget at its start.
-  const pos = doc.inlineContent ? 0 : getFirstPlaceholderPosition(doc);
-  return DecorationSet.create(doc, [
-    Decoration.widget(pos, getPlaceholder(text)),
-  ]);
+export const createPlaceholderDecos = (placeholder: PlaceholderOption) => {
+  const getPlaceholder =
+    typeof placeholder === "string"
+      ? getDefaultPlaceholder(placeholder)
+      : placeholder;
+
+  return ({ doc }: { doc: Node }) => {
+    if (doc.textContent) {
+      return DecorationSet.empty;
+    }
+
+    // If the document contains inline content only, just place the widget at its start.
+    const pos = doc.inlineContent ? 0 : getFirstPlaceholderPosition(doc);
+    return DecorationSet.create(doc, [Decoration.widget(pos, getPlaceholder)]);
+  };
 };
 
-export const createPlaceholderPlugin = (text: string) =>
+export const createPlaceholderPlugin = (text: PlaceholderOption) =>
   new Plugin({
     props: {
       decorations: createPlaceholderDecos(text),

--- a/src/plugin/helpers/placeholder.ts
+++ b/src/plugin/helpers/placeholder.ts
@@ -2,7 +2,7 @@ import type { Node } from "prosemirror-model";
 import { Plugin } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
 
-const placeholderAttribute = "data-cy-is-placeholder";
+export const placeholderTestAttribute = "placeholder";
 
 const getDefaultPlaceholder = (text: string) => {
   const span = document.createElement("span");
@@ -15,12 +15,12 @@ const getDefaultPlaceholder = (text: string) => {
   span.style.cursor = "text";
   span.draggable = false;
   span.innerHTML = text;
-  span.setAttribute(placeholderAttribute, "true");
+  span.setAttribute("data-cy", placeholderTestAttribute);
   return span;
 };
 
 export const containsPlaceholder = (element: HTMLElement): boolean =>
-  !!element.querySelector(`span[${placeholderAttribute}]`);
+  !!element.querySelector(`span[${placeholderTestAttribute}]`);
 
 /**
  * Get the first placeholder position in the document – assumed
@@ -28,11 +28,8 @@ export const containsPlaceholder = (element: HTMLElement): boolean =>
  */
 const getFirstPlaceholderPosition = (node: Node, currentPos = 0): number =>
   node.firstChild
-    ? getFirstPlaceholderPosition(
-        node.firstChild,
-        currentPos + node.content.size
-      )
-    : currentPos + node.content.size;
+    ? getFirstPlaceholderPosition(node.firstChild, currentPos + 1)
+    : currentPos;
 
 export type PlaceholderOption = string | (() => HTMLElement);
 

--- a/src/plugin/helpers/test.ts
+++ b/src/plugin/helpers/test.ts
@@ -117,3 +117,9 @@ export const createEditorWithElements = <
     validateElementData,
   };
 };
+
+export const getDecoSpecs = (decoSet: DecorationSet) =>
+  decoSet.find().map(({ from, to }) => ({
+    from,
+    to,
+  }));

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -7,8 +7,8 @@ import type {
   FieldDescriptions,
   FieldNameToField,
 } from "../plugin/types/Element";
-import type { FieldNameToValueMap } from "./helpers/fieldView";
 import { getElementFieldViewFromType } from "./helpers/fieldView";
+import type { FieldNameToValueMap } from "./helpers/fieldView";
 import type { Commands } from "./helpers/prosemirror";
 import { createUpdateDecorations } from "./helpers/prosemirror";
 import { getFieldNameFromNode } from "./nodeSpec";


### PR DESCRIPTION
## What does this change?

Adds a placeholder option for text and rich text fields.

The placeholder option can be a string, which PME will use to populate a span element of its own styling – or a function that returns a span, which the user can style and add content to themselves.

Behold!

<img width="481" alt="Screenshot 2021-09-29 at 12 27 31" src="https://user-images.githubusercontent.com/7767575/135259747-d2c3c6a4-5cbc-44b7-8a70-ef85f97505c7.png">

NB: This does not address placeholders for accessibility purposes (e.g. `aria-placeholder`). We can address this is a separate PR.

## How to test

- Both unit and integration tests should pass, and convince you that the placeholders are working as expected.
- Have a play locally – does everything look OK?

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [x] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [ ] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [ ] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
