### PR TITLE
feat: Image element tweaks II

### DIFF
--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -1,7 +1,10 @@
 import type { Schema } from "prosemirror-model";
 import type { Plugin } from "prosemirror-state";
 import React from "react";
-import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
+import {
+  createCustomDropdownField,
+  createCustomField,
+} from "../../plugin/fieldViews/CustomFieldView";
 import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
@@ -46,6 +49,12 @@ export type MainImageProps = {
 
 export const undefinedDropdownValue = "none-selected";
 
+export const minAssetValidation = largestAssetMinDimension(460);
+export const thumbnailOption = {
+  text: "thumbnail",
+  value: "thumbnail",
+};
+
 export const createImageFields = ({
   createCaptionPlugins,
   openImageSelector,
@@ -77,16 +86,16 @@ export const createImageFields = ({
         suppliersReference: "",
       },
       { openImageSelector },
-      [largestAssetMinDimension(460)]
+      [minAssetValidation]
     ),
     source: createTextField({
       validators: [htmlMaxLength(250), htmlRequired()],
     }),
-    role: createCustomField(undefinedDropdownValue, [
+    role: createCustomDropdownField(undefinedDropdownValue, [
       { text: "inline (default)", value: undefinedDropdownValue },
       { text: "supporting", value: "supporting" },
       { text: "showcase", value: "showcase" },
-      { text: "thumbnail", value: "thumbnail" },
+      thumbnailOption,
       { text: "immersive", value: "immersive" },
     ]),
   };

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -25,6 +25,7 @@ import type {
   MediaPayload,
   SetMedia,
 } from "./ImageElement";
+import { minAssetValidation, thumbnailOption } from "./ImageElement";
 
 type Props = {
   fieldValues: FieldNameToValueMap<ReturnType<typeof createImageFields>>;
@@ -34,6 +35,7 @@ type Props = {
 
 type ImageViewProps = {
   updateFields: SetMedia;
+  updateRole: (value: string) => void;
   errors: ValidationError[];
   field: CustomField<MainImageData, MainImageProps>;
 };
@@ -63,6 +65,11 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
             field={fields.role}
             label="Weighting"
             errors={errors.role}
+            options={
+              minAssetValidation(fieldValues.mainImage, "").length
+                ? [thumbnailOption]
+                : undefined
+            }
           />
           <ImageView
             field={fields.mainImage}
@@ -71,6 +78,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
               fields.source.update(source);
               fields.photographer.update(photographer);
             }}
+            updateRole={(value) => fields.role.update(value)}
             errors={errors.mainImage}
           />
           <CustomDropdownView
@@ -139,7 +147,12 @@ const imageViewStysles = css`
 const Errors = ({ errors }: { errors: string[] }) =>
   !errors.length ? null : <Error>{errors.join(", ")}</Error>;
 
-const ImageView = ({ field, updateFields, errors }: ImageViewProps) => {
+const ImageView = ({
+  field,
+  updateFields,
+  updateRole,
+  errors,
+}: ImageViewProps) => {
   const [imageFields, setImageFields] = useCustomFieldState(field);
 
   const setMedia = (previousMediaId: string | undefined) => (
@@ -152,6 +165,9 @@ const ImageView = ({ field, updateFields, errors }: ImageViewProps) => {
       assets,
       suppliersReference,
     });
+    if (minAssetValidation({ assets }, "").length) {
+      updateRole(thumbnailOption.value);
+    }
     if (previousMediaId && previousMediaId !== mediaId) {
       updateFields(mediaPayload);
     }

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -33,7 +33,7 @@ type Props = {
 };
 
 type ImageViewProps = {
-  onChange: SetMedia;
+  updateFields: SetMedia;
   errors: ValidationError[];
   field: CustomField<MainImageData, MainImageProps>;
 };
@@ -66,7 +66,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
           />
           <ImageView
             field={fields.mainImage}
-            onChange={({ caption, source, photographer }) => {
+            updateFields={({ caption, source, photographer }) => {
               fields.caption.update(caption);
               fields.source.update(source);
               fields.photographer.update(photographer);
@@ -139,9 +139,12 @@ const imageViewStysles = css`
 const Errors = ({ errors }: { errors: string[] }) =>
   !errors.length ? null : <Error>{errors.join(", ")}</Error>;
 
-const ImageView = ({ field, onChange, errors }: ImageViewProps) => {
+const ImageView = ({ field, updateFields, errors }: ImageViewProps) => {
   const [imageFields, setImageFields] = useCustomFieldState(field);
-  const setMedia = (mediaPayload: MediaPayload) => {
+
+  const setMedia = (previousMediaId: string | undefined) => (
+    mediaPayload: MediaPayload
+  ) => {
     const { mediaId, mediaApiUri, assets, suppliersReference } = mediaPayload;
     setImageFields({
       mediaId,
@@ -149,7 +152,9 @@ const ImageView = ({ field, onChange, errors }: ImageViewProps) => {
       assets,
       suppliersReference,
     });
-    onChange(mediaPayload);
+    if (previousMediaId && previousMediaId !== mediaId) {
+      updateFields(mediaPayload);
+    }
   };
 
   const imageSrc = useMemo(() => {
@@ -186,7 +191,7 @@ const ImageView = ({ field, onChange, errors }: ImageViewProps) => {
         iconSide="left"
         onClick={() => {
           field.description.props.openImageSelector(
-            setMedia,
+            setMedia(imageFields.mediaId),
             imageFields.mediaId
           );
         }}

--- a/src/elements/image/imageElementValidation.ts
+++ b/src/elements/image/imageElementValidation.ts
@@ -57,6 +57,7 @@ export const largestAssetMinDimension = (minSize: number): FieldValidator => (
           error: "Warning: Small image, only thumbnail available",
           message:
             "Image should be greater than 460 x 460px for uses other than a thumbnail.",
+          level: "WARN",
         },
       ];
     }

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -354,7 +354,7 @@ describe("buildElementPlugin", () => {
         field1: { type: "richText" },
       },
       () => undefined,
-      () => ({ field1: [{ error: "Some error", message: "" }] })
+      () => ({ field1: [{ error: "Some error", message: "", level: "ERROR" }] })
     );
 
     const testElementWithDifferentValidation = createElementSpec(
@@ -364,7 +364,11 @@ describe("buildElementPlugin", () => {
       () => undefined,
       () => ({
         checkbox: [
-          { error: "Some other error", message: "A human readable message" },
+          {
+            error: "Some other error",
+            message: "A human readable message",
+            level: "ERROR",
+          },
         ],
       })
     );
@@ -730,7 +734,7 @@ describe("buildElementPlugin", () => {
             });
 
             expect(errors).toEqual({
-              field1: [{ error: "Some error", message: "" }],
+              field1: [{ error: "Some error", message: "", level: "ERROR" }],
             });
 
             const otherErrors = validateElementData({
@@ -743,6 +747,7 @@ describe("buildElementPlugin", () => {
                 {
                   error: "Some other error",
                   message: "A human readable message",
+                  level: "ERROR",
                 },
               ],
             });
@@ -811,7 +816,7 @@ describe("buildElementPlugin", () => {
             );
 
             expect(errors).toEqual({
-              field1: [{ error: "Some error", message: "" }],
+              field1: [{ error: "Some error", message: "", level: "ERROR" }],
             });
           });
         });

--- a/src/plugin/elementSpec.ts
+++ b/src/plugin/elementSpec.ts
@@ -29,9 +29,12 @@ const createUpdater = <
   };
 };
 
+export type ErrorLevel = "ERROR" | "WARN";
+
 export type ValidationError = {
   error: string;
   message: string;
+  level: ErrorLevel;
 };
 export type FieldValidationErrors = Record<string, ValidationError[]>;
 

--- a/src/plugin/helpers/__tests__/validation.spec.ts
+++ b/src/plugin/helpers/__tests__/validation.spec.ts
@@ -21,7 +21,11 @@ describe("Validation helpers", () => {
       expect(result).toEqual({
         field1: [],
         field2: [
-          { error: "Too long: 7/5", message: "field2 is too long: 7/5" },
+          {
+            error: "Too long: 7/5",
+            message: "field2 is too long: 7/5",
+            level: "ERROR",
+          },
         ],
       });
     });
@@ -36,7 +40,9 @@ describe("Validation helpers", () => {
       });
 
       expect(result).toEqual({
-        field1: [{ error: "Required", message: "field1 is required" }],
+        field1: [
+          { error: "Required", message: "field1 is required", level: "ERROR" },
+        ],
       });
     });
 
@@ -51,7 +57,9 @@ describe("Validation helpers", () => {
 
       expect(result).toEqual({
         field1: [],
-        field2: [{ error: "Required", message: "field2 is required" }],
+        field2: [
+          { error: "Required", message: "field2 is required", level: "ERROR" },
+        ],
       });
     });
   });
@@ -81,7 +89,11 @@ describe("Validation helpers", () => {
       expect(result).toEqual({
         field1: [],
         field2: [
-          { error: "Too long: 7/5", message: "field2 is too long: 7/5" },
+          {
+            error: "Too long: 7/5",
+            message: "field2 is too long: 7/5",
+            level: "ERROR",
+          },
         ],
       });
     });
@@ -103,7 +115,11 @@ describe("Validation helpers", () => {
       expect(result).toEqual({
         field1: [],
         field2: [
-          { error: "Too long: 7/5", message: "field2 is too long: 7/5" },
+          {
+            error: "Too long: 7/5",
+            message: "field2 is too long: 7/5",
+            level: "ERROR",
+          },
         ],
       });
     });
@@ -129,10 +145,18 @@ describe("Validation helpers", () => {
 
       expect(result).toEqual({
         field1: [
-          { error: "Too long: 7/5", message: "field1 is too long: 7/5" },
+          {
+            error: "Too long: 7/5",
+            message: "field1 is too long: 7/5",
+            level: "ERROR",
+          },
         ],
         field2: [
-          { error: "Too long: 7/5", message: "field2 is too long: 7/5" },
+          {
+            error: "Too long: 7/5",
+            message: "field2 is too long: 7/5",
+            level: "ERROR",
+          },
         ],
       });
     });

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -1,4 +1,5 @@
 import type {
+  ErrorLevel,
   FieldValidationErrors,
   FieldValidator,
   Validator,
@@ -52,7 +53,8 @@ export const validateWithFieldAndElementValidators = <
 
 export const htmlMaxLength = (
   maxLength: number,
-  customMessage: string | undefined = undefined
+  customMessage: string | undefined = undefined,
+  level: ErrorLevel = "ERROR"
 ): FieldValidator => (value, field) => {
   if (typeof value !== "string" && value !== undefined) {
     const typeError = `html max length check: ${field} value is incorrect`;
@@ -60,6 +62,7 @@ export const htmlMaxLength = (
       {
         message: typeError,
         error: typeError,
+        level,
       },
     ];
   }
@@ -73,6 +76,7 @@ export const htmlMaxLength = (
         error: `Too long: ${length}/${maxLength}`,
         message:
           customMessage ?? `${field} is too long: ${length}/${maxLength}`,
+        level,
       },
     ];
   }
@@ -81,7 +85,8 @@ export const htmlMaxLength = (
 
 export const maxLength = (
   maxLength: number,
-  customMessage: string | undefined = undefined
+  customMessage: string | undefined = undefined,
+  level: ErrorLevel = "ERROR"
 ): FieldValidator => (value, field) => {
   if (typeof value !== "string" && value !== undefined) {
     const typeError = `max length check: ${field} value is incorrect`;
@@ -89,6 +94,7 @@ export const maxLength = (
       {
         message: typeError,
         error: typeError,
+        level,
       },
     ];
   }
@@ -99,6 +105,7 @@ export const maxLength = (
         error: `Too long: ${length}/${maxLength}`,
         message:
           customMessage ?? `${field} is too long: ${length}/${maxLength}`,
+        level,
       },
     ];
   }
@@ -106,7 +113,8 @@ export const maxLength = (
 };
 
 export const htmlRequired = (
-  customMessage: string | undefined = undefined
+  customMessage: string | undefined = undefined,
+  level: ErrorLevel = "ERROR"
 ): FieldValidator => (value, field) => {
   if (typeof value !== "string" && value !== undefined) {
     const typeError = `required check: ${field} value is incorrect`;
@@ -114,6 +122,7 @@ export const htmlRequired = (
       {
         message: typeError,
         error: typeError,
+        level,
       },
     ];
   }
@@ -121,14 +130,19 @@ export const htmlRequired = (
   el.innerHTML = value ?? "";
   if (!el.innerText.length) {
     return [
-      { error: "Required", message: customMessage ?? `${field} is required` },
+      {
+        error: "Required",
+        message: customMessage ?? `${field} is required`,
+        level,
+      },
     ];
   }
   return [];
 };
 
 export const required = (
-  customMessage: string | undefined = undefined
+  customMessage: string | undefined = undefined,
+  level: ErrorLevel = "ERROR"
 ): FieldValidator => (value, field) => {
   if (typeof value !== "string" && value !== undefined) {
     const typeError = `required check: ${field} value is incorrect`;
@@ -136,13 +150,18 @@ export const required = (
       {
         message: typeError,
         error: typeError,
+        level,
       },
     ];
   }
   const length = (value ?? "").length;
   if (!length) {
     return [
-      { error: "Required", message: customMessage ?? `${field} is required` },
+      {
+        error: "Required",
+        message: customMessage ?? `${field} is required`,
+        level,
+      },
     ];
   }
   return [];

--- a/src/renderers/react/customFieldViewComponents/CustomDropdownView.tsx
+++ b/src/renderers/react/customFieldViewComponents/CustomDropdownView.tsx
@@ -7,6 +7,7 @@ import { useCustomFieldState } from "../useCustomFieldViewState";
 
 type CustomDropdownViewProps = {
   field: CustomField<string, Options>;
+  options?: Options;
   errors?: ValidationError[];
   label: string;
   display?: "inline" | "block";
@@ -14,6 +15,7 @@ type CustomDropdownViewProps = {
 
 export const CustomDropdownView = ({
   field,
+  options,
   errors = [],
   label,
   display = "block",
@@ -22,7 +24,7 @@ export const CustomDropdownView = ({
   return (
     <CustomDropdown
       display={display}
-      options={field.description.props}
+      options={options ?? field.description.props}
       selected={selectedElement}
       label={label}
       onChange={(event) => {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR builds on the work of #133 and implements a few missing bits of functionality for the image element. These features currently exist in the Composer version.

These are: 

1. Preserving field values if a new crop is for the same image
2. Restricting image role values to "thumbnail" if the crop is too small
3. Adding an error level to validation errors to be used in pre-publish checks

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
For the image element:
1. Changing an image crop should preserve the field values if the image is the same, and replace them if it's different
2. Choosing a small crop should restrict the role value to "thumbnail"
3. Validation errors should appear as normal but have an associated level

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Our PME image element closely matches the Composer version.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![image](https://user-images.githubusercontent.com/4633246/135276032-e453f8e1-41ab-41c1-9686-ab26d79c3169.png)

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [ ] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [ ] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
