### PR TITLE
fix: Adds placeholder text to existing elements

### DIFF
--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -63,6 +63,7 @@ export const createImageFields = ({
     alt: createTextField({
       rows: 2,
       validators: [htmlMaxLength(1000), htmlRequired()],
+      placeholder: "Enter some alt text…",
     }),
     caption: createFlatRichTextField({
       createPlugins: createCaptionPlugins,
@@ -70,6 +71,7 @@ export const createImageFields = ({
         marks: "em strong link strike",
       },
       validators: [htmlMaxLength(600)],
+      placeholder: "Enter a caption for this media…",
     }),
     displayCredit: createCustomField(true, true),
     imageType: createCustomField("Photograph", [
@@ -77,7 +79,10 @@ export const createImageFields = ({
       { text: "Illustration", value: "Illustration" },
       { text: "Composite", value: "Composite" },
     ]),
-    photographer: createTextField({ validators: [htmlMaxLength(250)] }),
+    photographer: createTextField({
+      validators: [htmlMaxLength(250)],
+      placeholder: "Enter the photographer…",
+    }),
     mainImage: createCustomField<MainImageData, MainImageProps>(
       {
         mediaId: undefined,
@@ -90,6 +95,7 @@ export const createImageFields = ({
     ),
     source: createTextField({
       validators: [htmlMaxLength(250), htmlRequired()],
+      placeholder: "Enter the source…",
     }),
     role: createCustomDropdownField(undefinedDropdownValue, [
       { text: "inline (default)", value: undefinedDropdownValue },

--- a/src/elements/pullquote/PullquoteSpec.tsx
+++ b/src/elements/pullquote/PullquoteSpec.tsx
@@ -10,8 +10,12 @@ export const pullquoteFields = {
     rows: 4,
     validators: [htmlRequired("Pullquote cannot be empty")],
     absentOnEmpty: true,
+    placeholder: "Enter a pull quote here…",
   }),
-  attribution: createTextField({ absentOnEmpty: true }),
+  attribution: createTextField({
+    absentOnEmpty: true,
+    placeholder: "Enter attribution here…",
+  }),
   role: createCustomDropdownField("supporting", [
     { text: "supporting (default)", value: "supporting" },
     { text: "inline", value: "inline" },


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR uses the work from #138 to add placeholder text to the fields in the existing elements.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Create an image and pullquote element in the demo environment. Does placeholder text appear when there is no content?
Does the placeholder look as it should?

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

Image:
![image](https://user-images.githubusercontent.com/4633246/135423728-a1f7918f-d5ca-4fe2-87ba-721c15ce5388.png)

Pullquote:
![image](https://user-images.githubusercontent.com/4633246/135423906-eb48125f-e1a1-4c5b-9a44-0e6af20b19cc.png)

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->
There are placeholder features not yet implemented as mentioned in #138

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [ ] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [ ] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
