### PR TITLE
fix: Fixes the placeholder text overflow UI bug

### DIFF
--- a/src/plugin/helpers/placeholder.ts
+++ b/src/plugin/helpers/placeholder.ts
@@ -7,9 +7,12 @@ export const placeholderTestAttribute = "placeholder";
 const getDefaultPlaceholder = (text: string) => {
   const span = document.createElement("span");
   span.style.display = "inline-block";
-  span.style.height = "0px";
-  span.style.width = "0px";
+  span.style.width = "90%";
   span.style.whiteSpace = "nowrap";
+  span.style.overflowX = "hidden";
+  span.style.textOverflow = "ellipsis";
+  span.style.verticalAlign = "bottom";
+  span.style.fontFamily = "Guardian Agate Sans";
   // Passes accessibility contrast on a white background
   span.style.color = "#777575";
   span.style.pointerEvents = "none";
@@ -17,6 +20,7 @@ const getDefaultPlaceholder = (text: string) => {
   span.draggable = false;
   span.innerHTML = text;
   span.setAttribute("data-cy", placeholderTestAttribute);
+
   return span;
 };
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR fixes a placeholder text overflow issue, causing placeholder text to stretch beyond its bounds. This is achieved through some small styling tweaks.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Load the demo page, does the placeholder test reasonably stay within its bounds?

## Images
Before:
![image](https://user-images.githubusercontent.com/4633246/135443070-05e8c20f-ddd5-4914-bd0b-e035a94a38bc.png)

After (is it me or is this an optical illusion?):
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![PME_OVerflow](https://user-images.githubusercontent.com/4633246/135442992-eb45c59b-d276-405c-b278-1715bc716d0e.gif)

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [ ] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [ ] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
