### PR TITLE
fix: Fix decoration jitter

### DIFF
--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -68,10 +68,60 @@ describe("ImageElement", () => {
           .should("have.text", "deco");
       });
 
-      it(`caption – should map decorations passed from the parent editor correctly when they move`, () => {
+      it(`caption – should map decorations passed from the parent editor correctly when they move – add text before`, () => {
         addImageElement();
-        const text = `caption deco{leftarrow}{leftarrow}{leftarrow}{leftarrow}{leftarrow} more text`;
-        typeIntoElementField("caption", text);
+        typeIntoElementField(
+          "caption",
+          "start deco{leftarrow}{leftarrow}{leftarrow}{leftarrow}{leftarrow} more"
+        );
+        getElementRichTextField("caption")
+          .find(".TestDecoration")
+          .should("have.text", "deco");
+      });
+
+      it(`caption – should map decorations passed from the parent editor correctly when they move – add text after`, () => {
+        addImageElement();
+        typeIntoElementField("caption", "caption deco more text");
+        getElementRichTextField("caption")
+          .find(".TestDecoration")
+          .should("have.text", "deco");
+      });
+
+      it(`caption – should map decorations passed from the parent editor correctly when they move – remove text before`, () => {
+        addImageElement();
+        typeIntoElementField(
+          "caption",
+          "start deco{leftarrow}{leftarrow}{leftarrow}{leftarrow}{leftarrow}{backspace}{backspace}"
+        );
+        getElementRichTextField("caption")
+          .find(".TestDecoration")
+          .should("have.text", "deco");
+      });
+
+      it(`caption – should map decorations passed from the parent editor correctly when they move – remove text after`, () => {
+        addImageElement();
+        typeIntoElementField(
+          "caption",
+          "caption deco more text {backspace}{backspace}"
+        );
+        getElementRichTextField("caption")
+          .find(".TestDecoration")
+          .should("have.text", "deco");
+      });
+
+      it(`caption – should map decorations passed from the parent editor correctly when they move – add text in following field`, () => {
+        addImageElement();
+        typeIntoElementField("caption", "caption deco");
+        typeIntoElementField("altText", "text");
+        getElementRichTextField("caption")
+          .find(".TestDecoration")
+          .should("have.text", "deco");
+      });
+
+      it(`caption – should map decorations passed from the parent editor correctly when they move – remove text in following field`, () => {
+        addImageElement();
+        typeIntoElementField("caption", "caption deco");
+        typeIntoElementField("altText", "text{backspace}{backspace}");
         getElementRichTextField("caption")
           .find(".TestDecoration")
           .should("have.text", "deco");


### PR DESCRIPTION
## What does this change?

Fixes an odd issue where decorations passed to child editors might appear in the wrong place, or not appear at all, in certain situations.

This was caused by the code responsible for applying the decorations reading from class properties that had yet to be updated. A cautionary tale about mutating and reading from local state!

## How to test

The added integration tests should pass. Take a look – do they clearly describe what they're testing?

To test manually, see the gifs below – adding and removing text adjacent to decorations, either in the same field or in a subsequent field, had odd results, as they were working with a stale offset and node.

| Before | After |
| --- | --- |
| ![2021-10-05 09 31 28](https://user-images.githubusercontent.com/7767575/135988703-eabd36fc-0c21-4fb7-8934-3c02bc329933.gif) | ![2021-10-05 09 30 51](https://user-images.githubusercontent.com/7767575/135988686-271755bc-9151-4fb8-8c78-818276235356.gif) |

## Accessibility

N/A