### PR TITLE
feat: Add typerighter attrs to image caption and alt text

### DIFF
--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -71,9 +71,9 @@ export const createImageFields = ({
     caption: createFlatRichTextField({
       createPlugins: createCaptionPlugins,
       marks: "em strong link strike",
-      attrs: useTyperighterAttrs,
       validators: [htmlMaxLength(600, undefined, "WARN")],
       placeholder: "Enter a caption for this media…",
+      attrs: useTyperighterAttrs,
     }),
     displayCredit: createCustomField(true, true),
     imageType: createCustomField("Photograph", [

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -9,6 +9,7 @@ import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldVi
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+import { useTyperighterAttrs } from "../helpers/typerighter";
 import { ImageElementForm } from "./ImageElementForm";
 import { largestAssetMinDimension } from "./imageElementValidation";
 
@@ -69,6 +70,7 @@ export const createImageFields = ({
     caption: createFlatRichTextField({
       createPlugins: createCaptionPlugins,
       marks: "em strong link strike",
+      attrs: useTyperighterAttrs,
       validators: [htmlMaxLength(600, undefined, "WARN")],
       placeholder: "Enter a caption for this media…",
     }),

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -66,6 +66,7 @@ export const createImageFields = ({
       validators: [htmlMaxLength(1000), htmlRequired()],
       placeholder: "Enter some alt text…",
       isResizeable: true,
+      attrs: useTyperighterAttrs,
     }),
     caption: createFlatRichTextField({
       createPlugins: createCaptionPlugins,

--- a/src/plugin/fieldViews/RichTextFieldView.ts
+++ b/src/plugin/fieldViews/RichTextFieldView.ts
@@ -64,9 +64,7 @@ type FlatRichTextOptions = RichTextOptions & {
  */
 export const createFlatRichTextField = ({
   createPlugins,
-  validators,
-  placeholder,
-  marks,
+  ...rest
 }: FlatRichTextOptions): RichTextFieldDescription =>
   createRichTextField({
     createPlugins: (schema) => {
@@ -91,9 +89,7 @@ export const createFlatRichTextField = ({
       return [plugin, ...(createPlugins?.(schema) ?? [])];
     },
     content: "(text|hard_break)*",
-    validators,
-    placeholder,
-    marks,
+    ...rest,
   });
 
 /**


### PR DESCRIPTION
## What does this change?

Adds Typerighter attrs to the image caption.

## How to test

Run locally. Is the `useTyperighter` attribute set for the image caption node?

<img width="422" alt="Screenshot 2021-10-05 at 09 54 02" src="https://user-images.githubusercontent.com/7767575/135992404-7a82dc50-d4f5-43d7-89a5-567f8cb0db40.png">

## Accessibility

N/A