### PR TITLE
fix: Do not deserialise to HTML for required or length checks

### DIFF
--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -66,10 +66,8 @@ export const htmlMaxLength = (
       },
     ];
   }
-
-  const el = document.createElement("div");
-  el.innerHTML = value ?? "";
-  const length = el.innerText.length;
+  const strWithoutHtml = removeHTMLFromStr(value);
+  const length = strWithoutHtml.length;
   if (length > maxLength) {
     return [
       {
@@ -126,9 +124,8 @@ export const htmlRequired = (
       },
     ];
   }
-  const el = document.createElement("div");
-  el.innerHTML = value ?? "";
-  if (!el.innerText.length) {
+  const strWithoutHtml = removeHTMLFromStr(value);
+  if (!strWithoutHtml.length) {
     return [
       {
         error: "Required",
@@ -165,4 +162,11 @@ export const required = (
     ];
   }
   return [];
+};
+
+const removeHTMLFromStr = (str: string | undefined) => {
+  // At the moment, we don't remove HTML – it's proved too costly to strip
+  // html with .innerHTML parsing on the fly in large documents. If we find
+  // a fast solution, we can revisit this.
+  return str ?? "";
 };


### PR DESCRIPTION
## What does this change?

This PR avoids deserialising to HTML for required or length checks.

This is necessary to avoid performance problems whilst validating large documents.

It's crude, and won't work w/ required validation for rich text elements with surrounding `<p>` tags, for instance – but we don't have any of those right now, and this solves a problem in production.

## How to test

- Do the fields' required and length validation still work roughly as expected (barring discrepancies with html entities)?

