### PR TITLE
fix: Warn on caption length ... for now

### DIFF
--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -68,7 +68,7 @@ export const createImageFields = ({
     caption: createFlatRichTextField({
       createPlugins: createCaptionPlugins,
       marks: "em strong link strike",
-      validators: [htmlMaxLength(600)],
+      validators: [htmlMaxLength(600, undefined, "WARN")],
       placeholder: "Enter a caption for this media…",
     }),
     displayCredit: createCustomField(true, true),


### PR DESCRIPTION
## What does this change?

Downgrade caption length to warning. Error-level validation triggers prepublish checks.

## How to test

Import this into Composer. Do caption length validation errors no longer appear in prepublish checks?