### PR TITLE
chore: removes keyofStringsOnly flag

### DIFF
--- a/src/plugin/element.ts
+++ b/src/plugin/element.ts
@@ -20,8 +20,8 @@ import type {
  * by those elements, and a method to insert elements into the document.
  */
 export const buildElementPlugin = <
-  FDesc extends FieldDescriptions<keyof FDesc>,
-  ElementNames extends keyof ESpecMap,
+  FDesc extends FieldDescriptions<Extract<keyof FDesc, string>>,
+  ElementNames extends Extract<keyof ESpecMap, string>,
   ESpecMap extends ElementSpecMap<FDesc, ElementNames>
 >(
   elementSpecs: ESpecMap,

--- a/src/plugin/helpers/element.ts
+++ b/src/plugin/helpers/element.ts
@@ -17,8 +17,8 @@ import { fieldTypeToViewMap } from "./fieldView";
  * returns undefined.
  */
 export const createGetNodeFromElementData = <
-  FDesc extends FieldDescriptions<keyof FDesc>,
-  ElementNames extends keyof ESpecMap,
+  FDesc extends FieldDescriptions<Extract<keyof FDesc, string>>,
+  ElementNames extends Extract<keyof ESpecMap, string>,
   ESpecMap extends ElementSpecMap<FDesc, ElementNames>
 >(
   elementTypeMap: ESpecMap
@@ -67,8 +67,8 @@ export const createGetNodeFromElementData = <
  * returns undefined.
  */
 export const createGetElementDataFromNode = <
-  FDesc extends FieldDescriptions<keyof FDesc>,
-  ElementNames extends keyof ESpecMap,
+  FDesc extends FieldDescriptions<Extract<keyof FDesc, string>>,
+  ElementNames extends Extract<keyof ESpecMap, string>,
   ESpecMap extends ElementSpecMap<FDesc, ElementNames>
 >(
   elementTypeMap: ESpecMap
@@ -144,8 +144,8 @@ const getValuesFromRichContentNode = (
 const getValuesFromTextContentNode = (node: Node) => node.textContent;
 
 export const createElementDataValidator = <
-  FDesc extends FieldDescriptions<keyof FDesc>,
-  ElementNames extends keyof ESpec,
+  FDesc extends FieldDescriptions<Extract<keyof FDesc, string>>,
+  ElementNames extends Extract<keyof ESpec, string>,
   ESpec extends ElementSpecMap<FDesc, ElementNames>
 >(
   elementTypeMap: ESpec

--- a/src/plugin/helpers/fieldView.ts
+++ b/src/plugin/helpers/fieldView.ts
@@ -57,7 +57,7 @@ export type FieldTypeToValueMap<
  * `{ altText: string }, { isVisible: { value: boolean }}`
  */
 export type FieldNameToValueMap<
-  FDesc extends FieldDescriptions<keyof FDesc>
+  FDesc extends FieldDescriptions<Extract<keyof FDesc, string>>
 > = {
   [Name in keyof FDesc]: FieldTypeToValueMap<FDesc, Name>[FDesc[Name]["type"]];
 };
@@ -67,7 +67,7 @@ export type FieldNameToValueMap<
  * to produce a result that reflects the output type of `getElementDataFromNode`.
  */
 export type FieldNameToValueMapWithEmptyValues<
-  FDesc extends FieldDescriptions<keyof FDesc>
+  FDesc extends FieldDescriptions<Extract<keyof FDesc, string>>
 > = Optional<
   FieldNameToValueMap<FDesc>,
   KeysWithValsOfType<FDesc, { absentOnEmpty: true }>

--- a/src/plugin/helpers/test.ts
+++ b/src/plugin/helpers/test.ts
@@ -68,8 +68,8 @@ export const createNoopElement = <FDesc extends FieldDescriptions<string>>(
   );
 
 export const createEditorWithElements = <
-  FDesc extends FieldDescriptions<keyof FDesc>,
-  ElementNames extends keyof ESpecMap,
+  FDesc extends FieldDescriptions<Extract<keyof FDesc, string>>,
+  ElementNames extends Extract<keyof ESpecMap, string>,
   ESpecMap extends ElementSpecMap<FDesc, ElementNames>
 >(
   elements: ESpecMap,

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -12,7 +12,6 @@
     "jsxImportSource": "@emotion/react",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "keyofStringsOnly": true,
     "rootDir": "./src",
     "outDir": "dist/esm",
     "declarationDir": "dist/declaration"


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR removes the `keyofStringsOnly` tsconfig flag to allow us to use the latest version of Lodash. This flag was introduced as [temporary solution for a breaking change in Typescript](https://www.typescriptlang.org/tsconfig#keyofStringsOnly), the [changes in this P remove the flag and make the [necessary changes to compile](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html#support-number-and-symbol-named-properties-with-keyof-and-mapped-types). 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This change should be a NO-OP and continue to work as before.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
I believe that the change made in this PR is the equivalent to having the flag switched on. However, we should make sure Composer has no issues as a result. 

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->
 
N/A