### PR TITLE
fix: Change whitespace rule, fixing code text wrap styling bug

### DIFF
--- a/src/plugin/fieldViews/TextFieldView.ts
+++ b/src/plugin/fieldViews/TextFieldView.ts
@@ -116,7 +116,7 @@ export class TextFieldView extends ProseMirrorFieldView {
     if (isCode && this.innerEditorView) {
       const dom = this.innerEditorView.dom as HTMLDivElement;
       dom.style.fontFamily = "monospace";
-      dom.style.whiteSpace = "pre";
+      dom.style.whiteSpace = "pre-wrap";
     }
 
     if (enableMultiline) {


### PR DESCRIPTION
## What does this change?
Code fields were displaying long lines without wrapping-text, which caused text to overflow the bounds of the element (and  make it impossible to interact with the element interface).

This PR fixes the bug.

**Before:**
![Screenshot 2021-10-12 at 10 09 54](https://user-images.githubusercontent.com/34686302/136927430-ed94a6c1-7576-4965-87e5-5fa1e2f1476c.png)


**After:**
![Screenshot 2021-10-12 at 10 10 01](https://user-images.githubusercontent.com/34686302/136927417-824619cd-7072-4eb0-b89b-e26fda431508.png)


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run `yarn start` from the repository root and add a Code element. Does the element display correctly when a long line of text is added?