### PR TITLE
fix: Corrects custom dropdown font

### DIFF
--- a/src/editorial-source-components/CustomDropdown.tsx
+++ b/src/editorial-source-components/CustomDropdown.tsx
@@ -50,13 +50,14 @@ const SelectWrapper = styled.div<{ display: "block" | "inline" }>`
 
 const selectStyles = css`
   ${inputBorder}
+  font-size: 14px;
   height: ${space[6]}px;
   width: initial;
   padding-right: 50px !important;
   :hover {
     cursor: pointer;
   }
-  font-family: "GuardianTextEgyptian, Guardian Text Egyptian";
+  font-family: "Guardian Agate Sans";
 `;
 
 type CustomDropdownProps = {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR address the font in the custom dropdown.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Load the demo environment and in Composer, does the dropdown font look correct?

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


Before:
![image](https://user-images.githubusercontent.com/4633246/137296377-9b9cf810-eda5-4992-8df9-cd498440bcfd.png)

After:
![image](https://user-images.githubusercontent.com/4633246/137296297-185430a7-257b-4b9c-a7fa-82725afdc43c.png)

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [ ] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [ ] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
