### PR TITLE
feat: Add alt text tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@guardian/src-layout": "^3.8.0",
     "@guardian/src-select": "^3.7.0",
     "@guardian/src-text-input": "^3.7.0",
+    "@popperjs/core": "^2.10.2",
     "@types/prosemirror-collab": "^1.1.1",
     "emotion": "^9.2.10",
     "lodash": "^4.17.21",
@@ -45,7 +46,9 @@
     "prosemirror-transform": "^1.3.2",
     "prosemirror-view": "^1.18.7",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react-dom": "^17.0.1",
+    "react-popper": "^2.2.5",
+    "react-tooltip": "^4.2.21"
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^5.6.0",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "prosemirror-view": "^1.18.7",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-popper": "^2.2.5",
-    "react-tooltip": "^4.2.21"
+    "react-popper": "^2.2.5"
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^5.6.0",

--- a/src/editorial-source-components/Tooltip.tsx
+++ b/src/editorial-source-components/Tooltip.tsx
@@ -1,4 +1,5 @@
 import { css } from "@emotion/react";
+import styled from "@emotion/styled";
 import { brand, neutral } from "@guardian/src-foundations";
 import { SvgInfo } from "@guardian/src-icons";
 import React, { useEffect, useState } from "react";
@@ -21,7 +22,34 @@ const fadeDuration = 300; //Milliseconds
 
 const timeouts: number[] = [];
 
-const tooltip = css`
+const Arrow = styled.div`
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background: inherit;
+  visibility: hidden;
+  &[data-show] {
+    ::before {
+      visibility: visible;
+    }
+  }
+  &[data-popper-reference-hidden] {
+    ::before {
+      visibility: hidden;
+      pointer-events: none;
+    }
+  }
+  ::before {
+    position: absolute;
+    width: 8px;
+    height: 8px;
+    background: inherit;
+    content: "";
+    transform: rotate(45deg);
+  }
+`;
+
+const TooltipBox = styled.div`
   font-family: "Guardian Agate Sans";
   background-color: ${neutral[10]};
   color: ${neutral[97]};
@@ -52,32 +80,17 @@ const tooltip = css`
     visibility: hidden;
     pointer-events: none;
   }
-`;
-
-const arrow = css`
-  position: absolute;
-  width: 8px;
-  height: 8px;
-  background: inherit;
-  visibility: hidden;
-  &[data-show] {
-    ::before {
-      visibility: visible;
-    }
+  &[data-popper-placement^="top"] > .arrow {
+    bottom: -4px;
   }
-  &[data-popper-reference-hidden] {
-    ::before {
-      visibility: hidden;
-      pointer-events: none;
-    }
+  &[data-popper-placement^="bottom"] > .arrow {
+    top: -4px;
   }
-  ::before {
-    position: absolute;
-    width: 8px;
-    height: 8px;
-    background: inherit;
-    content: "";
-    transform: translate(0px, -4px) rotate(45deg);
+  &[data-popper-placement^="left"] > .arrow {
+    right: -4px;
+  }
+  &[data-popper-placement^="right"] > .arrow {
+    left: -4px;
   }
 `;
 
@@ -145,10 +158,9 @@ export const Tooltip = ({ children }: { children: React.ReactNode }) => {
         <SvgInfo />
       </div>
 
-      <div
+      <TooltipBox
         ref={setPopperElement}
         style={styles.popper}
-        css={tooltip}
         data-show={visible || null}
         data-opaque={opaque || null}
         {...attributes.popper}
@@ -156,13 +168,13 @@ export const Tooltip = ({ children }: { children: React.ReactNode }) => {
         onMouseLeave={handleMouseLeave}
       >
         {children}
-        <div
+        <Arrow
           ref={setArrowElement}
           style={styles.arrow}
-          css={arrow}
+          className="arrow"
           data-show={visible || null}
         />
-      </div>
+      </TooltipBox>
     </>
   );
 };

--- a/src/editorial-source-components/Tooltip.tsx
+++ b/src/editorial-source-components/Tooltip.tsx
@@ -45,6 +45,8 @@ const tooltip = css`
     transition-delay: visibility 1s;
     transition-delay: transition-delay 1s;
     visibility: visible;
+  }
+  &[data-opaque] {
     opacity: 1;
   }
   [data-popper-reference-hidden] {
@@ -62,6 +64,11 @@ const arrow = css`
   &[data-show] {
     ::before {
       visibility: visible;
+    }
+  }
+  &[data-opaque] {
+    ::before {
+      opacity: 1;
     }
   }
   &[data-popper-reference-hidden] {
@@ -89,6 +96,8 @@ export const Tooltip = ({ children }: { children: React.ReactNode }) => {
     null
   );
   const [tooltipVisible, setTooltipVisible] = useState(false);
+  const [timeoutIsValid, setTimeoutIsValid] = useState(false);
+  const [opaque, setOpaque] = useState(false);
   const [arrowElement, setArrowElement] = useState<HTMLDivElement | null>(null);
   const { styles, attributes, update } = usePopper(
     referenceElement,
@@ -111,12 +120,20 @@ export const Tooltip = ({ children }: { children: React.ReactNode }) => {
       <div
         css={infoIcon}
         ref={setReferenceElement}
-        onMouseOver={() => {
+        onMouseEnter={() => {
+          setTimeoutIsValid(false);
+          setOpaque(true);
           setTooltipVisible(true);
           if (update) void update();
         }}
         onMouseLeave={() => {
-          setTooltipVisible(false);
+          setTimeoutIsValid(true);
+          setOpaque(false);
+          setTimeout(() => {
+            if (timeoutIsValid) {
+              setTooltipVisible(false);
+            }
+          }, 2000);
           if (update) void update();
         }}
       >
@@ -128,13 +145,22 @@ export const Tooltip = ({ children }: { children: React.ReactNode }) => {
         style={styles.popper}
         css={tooltip}
         data-show={tooltipVisible ? tooltipVisible : null}
+        data-opaque={opaque ? opaque : null}
         {...attributes.popper}
-        onMouseOver={() => {
+        onMouseEnter={() => {
           setTooltipVisible(true);
+          setOpaque(true);
+          setTimeoutIsValid(false);
           if (update) void update();
         }}
         onMouseLeave={() => {
-          setTooltipVisible(false);
+          setTimeoutIsValid(true);
+          setOpaque(false);
+          setTimeout(() => {
+            if (timeoutIsValid) {
+              setTooltipVisible(false);
+            }
+          }, 2000);
           if (update) void update();
         }}
       >

--- a/src/editorial-source-components/Tooltip.tsx
+++ b/src/editorial-source-components/Tooltip.tsx
@@ -1,0 +1,151 @@
+import { css } from "@emotion/react";
+import { brand, neutral } from "@guardian/src-foundations";
+import { SvgInfo } from "@guardian/src-icons";
+import React, { useState } from "react";
+import { usePopper } from "react-popper";
+
+const infoIcon = css`
+  height: 22px;
+  width: 22px;
+  margin-right: 4px;
+  margin-left: -4px;
+  svg {
+    margin: -1px;
+  }
+  :hover {
+    cursor: pointer;
+  }
+`;
+
+const tooltip = css`
+  font-family: "Guardian Agate Sans";
+  background-color: ${neutral[10]};
+  color: ${neutral[97]};
+  width: 300px;
+  font-weight: 300;
+  border-radius: 4px;
+  line-height: 1.2rem;
+  font-family: "Guardian Agate Sans";
+  filter: drop-shadow(0 2px 4px rgb(0 0 0 / 30%));
+  z-index: 1;
+  p {
+    margin: 10px;
+  }
+  a {
+    color: ${brand[800]};
+  }
+  opacity: 0;
+  transition: opacity 0.3s;
+  /* transition: visibility 0.3s; */
+  transition: visibility 0s;
+  transition-delay: visibility 0s;
+
+  visibility: hidden;
+  &[data-show] {
+    transition-delay: visibility 1s;
+    transition-delay: transition-delay 1s;
+    visibility: visible;
+    opacity: 1;
+  }
+  [data-popper-reference-hidden] {
+    visibility: hidden;
+    pointer-events: none;
+  }
+`;
+
+const arrow = css`
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background: inherit;
+  visibility: hidden;
+  &[data-show] {
+    ::before {
+      visibility: visible;
+    }
+  }
+  &[data-popper-reference-hidden] {
+    ::before {
+      visibility: hidden;
+      pointer-events: none;
+    }
+  }
+  ::before {
+    position: absolute;
+    width: 8px;
+    height: 8px;
+    background: inherit;
+    content: "";
+    transform: translate(0px, -4px) rotate(45deg);
+  }
+`;
+
+export const Tooltip = ({ children }: { children: React.ReactNode }) => {
+  const [
+    referenceElement,
+    setReferenceElement,
+  ] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(
+    null
+  );
+  const [tooltipVisible, setTooltipVisible] = useState(false);
+  const [arrowElement, setArrowElement] = useState<HTMLDivElement | null>(null);
+  const { styles, attributes, update } = usePopper(
+    referenceElement,
+    popperElement,
+    {
+      placement: "top",
+      modifiers: [
+        { name: "arrow", options: { element: arrowElement } },
+        {
+          name: "offset",
+          options: {
+            offset: [0, 4],
+          },
+        },
+      ],
+    }
+  );
+  return (
+    <>
+      <div
+        css={infoIcon}
+        ref={setReferenceElement}
+        onMouseOver={() => {
+          setTooltipVisible(true);
+          if (update) void update();
+        }}
+        onMouseLeave={() => {
+          setTooltipVisible(false);
+          if (update) void update();
+        }}
+      >
+        <SvgInfo />
+      </div>
+
+      <div
+        ref={setPopperElement}
+        style={styles.popper}
+        css={tooltip}
+        data-show={tooltipVisible ? tooltipVisible : null}
+        {...attributes.popper}
+        onMouseOver={() => {
+          setTooltipVisible(true);
+          if (update) void update();
+        }}
+        onMouseLeave={() => {
+          setTooltipVisible(false);
+          if (update) void update();
+        }}
+      >
+        {children}
+        <div
+          ref={setArrowElement}
+          style={styles.arrow}
+          css={arrow}
+          data-show={tooltipVisible ? tooltipVisible : null}
+        />
+      </div>
+    </>
+  );
+};

--- a/src/editorial-source-components/Tooltip.tsx
+++ b/src/editorial-source-components/Tooltip.tsx
@@ -31,7 +31,7 @@ const tooltip = css`
   line-height: 1.2rem;
   font-family: "Guardian Agate Sans";
   filter: drop-shadow(0 2px 4px rgb(0 0 0 / 30%));
-  z-index: 1;
+  z-index: 10; // ProseMirror-menubar has a default z-index of 10
   p {
     margin: 10px;
   }

--- a/src/editorial-source-components/Tooltip.tsx
+++ b/src/editorial-source-components/Tooltip.tsx
@@ -115,6 +115,16 @@ export const Tooltip = ({ children }: { children: React.ReactNode }) => {
     timeouts.forEach((timeout) => clearTimeout(timeout));
   };
 
+  const handleMouseEnter = () => {
+    makeOpaque();
+    if (update) void update();
+  };
+
+  const handleMouseLeave = () => {
+    setOpaque(false);
+    if (update) void update();
+  };
+
   useEffect(() => {
     if (!opaque) {
       const timeout = setTimeout(() => {
@@ -129,14 +139,8 @@ export const Tooltip = ({ children }: { children: React.ReactNode }) => {
       <div
         css={infoIcon}
         ref={setReferenceElement}
-        onMouseEnter={() => {
-          makeOpaque();
-          if (update) void update();
-        }}
-        onMouseLeave={() => {
-          setOpaque(false);
-          if (update) void update();
-        }}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
       >
         <SvgInfo />
       </div>
@@ -148,14 +152,8 @@ export const Tooltip = ({ children }: { children: React.ReactNode }) => {
         data-show={visible || null}
         data-opaque={opaque || null}
         {...attributes.popper}
-        onMouseEnter={() => {
-          makeOpaque();
-          if (update) void update();
-        }}
-        onMouseLeave={() => {
-          setOpaque(false);
-          if (update) void update();
-        }}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
       >
         {children}
         <div

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -111,7 +111,9 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
                       SEO.
                     </p>
                     <p>
-                      <a href="https://example.com">Find out more</a>
+                      <a href="https://docs.google.com/document/d/1oW542iCRyKfI4DS22QU7AH0TQRWLYMm7bTlhJlX5_Ng/edit?usp=sharing">
+                        Find out more
+                      </a>
                     </p>
                   </Tooltip>
                   <Button

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -106,7 +106,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
                 <>
                   <Tooltip>
                     <p>
-                      'Alt text' describes what's in an image. It helps users of
+                      ‘Alt text’ describes what’s in an image. It helps users of
                       screen readers understand our images, and improves our
                       SEO.
                     </p>

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -1,9 +1,10 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { space } from "@guardian/src-foundations";
-import { SvgCamera } from "@guardian/src-icons";
+import { brand, neutral, space } from "@guardian/src-foundations";
+import { SvgCamera, SvgInfo } from "@guardian/src-icons";
 import { Column, Columns } from "@guardian/src-layout";
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
+import { usePopper } from "react-popper";
 import { Button } from "../../editorial-source-components/Button";
 import { Error } from "../../editorial-source-components/Error";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
@@ -44,6 +45,82 @@ const AltText = styled.span`
   margin-right: ${space[2]}px;
 `;
 
+const infoIcon = css`
+  height: 22px;
+  width: 22px;
+  margin-right: 4px;
+  margin-left: -4px;
+  svg {
+    margin: -1px;
+  }
+  :hover {
+    cursor: pointer;
+  }
+`;
+
+const tooltip = css`
+  font-family: "Guardian Agate Sans";
+  background-color: ${neutral[10]};
+  color: ${neutral[97]};
+  width: 300px;
+  font-weight: 300;
+  border-radius: 4px;
+  line-height: 1.2rem;
+  font-family: "Guardian Agate Sans";
+  filter: drop-shadow(0 2px 4px rgb(0 0 0 / 30%));
+  z-index: 1;
+  p {
+    margin: 10px;
+  }
+  a {
+    color: ${brand[800]};
+  }
+  opacity: 0;
+  transition: opacity 0.3s;
+  /* transition: visibility 0.3s; */
+  transition: visibility 0s;
+  transition-delay: visibility 0s;
+
+  visibility: hidden;
+  &[data-show] {
+    transition-delay: visibility 1s;
+    transition-delay: transition-delay 1s;
+    visibility: visible;
+    opacity: 1;
+  }
+  [data-popper-reference-hidden] {
+    visibility: hidden;
+    pointer-events: none;
+  }
+`;
+
+const arrow = css`
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background: inherit;
+  visibility: hidden;
+  &[data-show] {
+    ::before {
+      visibility: visible;
+    }
+  }
+  &[data-popper-reference-hidden] {
+    ::before {
+      visibility: hidden;
+      pointer-events: none;
+    }
+  }
+  ::before {
+    position: absolute;
+    width: 8px;
+    height: 8px;
+    background: inherit;
+    content: "";
+    transform: translate(0px, -4px) rotate(45deg);
+  }
+`;
+
 export const ImageElementTestId = "ImageElement";
 
 const htmlLength = (text: string) => {
@@ -56,93 +133,168 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
   errors,
   fields,
   fieldValues,
-}) => (
-  <div data-cy={ImageElementTestId}>
-    <Columns>
-      <Column width={2 / 5}>
-        <FieldLayoutVertical>
-          <CustomDropdownView
-            field={fields.role}
-            label="Weighting"
-            errors={errors.role}
-            options={
-              minAssetValidation(fieldValues.mainImage, "").length
-                ? [thumbnailOption]
-                : undefined
-            }
-          />
-          <ImageView
-            field={fields.mainImage}
-            updateFields={({ caption, source, photographer }) => {
-              fields.caption.update(caption);
-              fields.source.update(source);
-              fields.photographer.update(photographer);
-            }}
-            updateRole={(value) => fields.role.update(value)}
-            errors={errors.mainImage}
-          />
-          <CustomDropdownView
-            field={fields.imageType}
-            label={"Image type"}
-            errors={errors.imageType}
-          />
-        </FieldLayoutVertical>
-      </Column>
-      <Column width={3 / 5}>
-        <FieldLayoutVertical>
-          <FieldWrapper
-            field={fields.caption}
-            errors={errors.caption}
-            headingLabel="Caption"
-            description={`${htmlLength(fieldValues.caption)}/600 characters`}
-          />
-          <FieldWrapper
-            field={fields.alt}
-            errors={errors.alt}
-            headingLabel={<AltText>Alt text</AltText>}
-            headingContent={
-              <Button
-                priority="secondary"
-                size="xsmall"
-                iconSide="left"
-                onClick={() => fields.alt.update(fieldValues.caption)}
-              >
-                Copy from caption
-              </Button>
-            }
-          />
-          <Columns>
-            <Column width={1 / 2}>
-              <FieldWrapper
-                field={fields.photographer}
-                errors={errors.photographer}
-                headingLabel="Photographer"
-              />
-            </Column>
-            <Column width={1 / 2}>
-              <FieldWrapper
-                field={fields.source}
-                errors={errors.source}
-                headingLabel="Source"
-              />
-            </Column>
-          </Columns>
-          <Columns>
-            <Column width={1 / 2}>
-              <CustomCheckboxView
-                field={fields.displayCredit}
-                errors={errors.displayCredit}
-                label="Display credit information"
-              />
-            </Column>
-          </Columns>
-        </FieldLayoutVertical>
-      </Column>
-    </Columns>
-  </div>
-);
+}) => {
+  const [
+    referenceElement,
+    setReferenceElement,
+  ] = useState<HTMLDivElement | null>(null);
+  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(
+    null
+  );
+  const [tooltipVisible, setTooltipVisible] = useState(false);
+  const [arrowElement, setArrowElement] = useState<HTMLDivElement | null>(null);
+  const { styles, attributes, update } = usePopper(
+    referenceElement,
+    popperElement,
+    {
+      placement: "top",
+      modifiers: [
+        { name: "arrow", options: { element: arrowElement } },
+        {
+          name: "offset",
+          options: {
+            offset: [0, 4],
+          },
+        },
+      ],
+    }
+  );
+  return (
+    <div data-cy={ImageElementTestId}>
+      <Columns>
+        <Column width={2 / 5}>
+          <FieldLayoutVertical>
+            <CustomDropdownView
+              field={fields.role}
+              label="Weighting"
+              errors={errors.role}
+              options={
+                minAssetValidation(fieldValues.mainImage, "").length
+                  ? [thumbnailOption]
+                  : undefined
+              }
+            />
+            <ImageView
+              field={fields.mainImage}
+              updateFields={({ caption, source, photographer }) => {
+                fields.caption.update(caption);
+                fields.source.update(source);
+                fields.photographer.update(photographer);
+              }}
+              updateRole={(value) => fields.role.update(value)}
+              errors={errors.mainImage}
+            />
+            <CustomDropdownView
+              field={fields.imageType}
+              label={"Image type"}
+              errors={errors.imageType}
+            />
+          </FieldLayoutVertical>
+        </Column>
+        <Column width={3 / 5}>
+          <FieldLayoutVertical>
+            <FieldWrapper
+              field={fields.caption}
+              errors={errors.caption}
+              headingLabel="Caption"
+              description={`${htmlLength(fieldValues.caption)}/600 characters`}
+            />
+            <FieldWrapper
+              field={fields.alt}
+              errors={errors.alt}
+              headingLabel={<AltText>Alt text</AltText>}
+              headingContent={
+                <>
+                  <div
+                    css={infoIcon}
+                    ref={setReferenceElement}
+                    onMouseOver={() => {
+                      setTooltipVisible(true);
+                      if (update) void update();
+                    }}
+                    onMouseLeave={() => {
+                      setTooltipVisible(false);
+                      if (update) void update();
+                    }}
+                  >
+                    <SvgInfo />
+                  </div>
 
-const imageViewStysles = css`
+                  <div
+                    ref={setPopperElement}
+                    style={styles.popper}
+                    css={tooltip}
+                    data-show={tooltipVisible ? tooltipVisible : null}
+                    {...attributes.popper}
+                    onMouseOver={() => {
+                      setTooltipVisible(true);
+                      if (update) void update();
+                    }}
+                    onMouseLeave={() => {
+                      setTooltipVisible(false);
+                      if (update) void update();
+                    }}
+                  >
+                    <p>
+                      'Alt text' describes what's in an image. It helps users of
+                      screen readers understand our images, and improves our
+                      SEO.
+                    </p>
+                    <p>
+                      <a href="https://example.com">Find out more</a>
+                    </p>
+
+                    <div
+                      ref={setArrowElement}
+                      style={styles.arrow}
+                      css={arrow}
+                      data-show={tooltipVisible ? tooltipVisible : null}
+                    />
+                  </div>
+                  <Button
+                    priority="secondary"
+                    size="xsmall"
+                    iconSide="left"
+                    onClick={() => fields.alt.update(fieldValues.caption)}
+                  >
+                    Copy from caption
+                  </Button>
+                </>
+              }
+            />
+            <Columns>
+              <Column width={1 / 2}>
+                <FieldWrapper
+                  field={fields.photographer}
+                  errors={errors.photographer}
+                  headingLabel="Photographer"
+                />
+              </Column>
+              <Column width={1 / 2}>
+                <FieldWrapper
+                  field={fields.source}
+                  errors={errors.source}
+                  headingLabel="Source"
+                />
+              </Column>
+            </Columns>
+            <Columns>
+              <Column width={1 / 2}>
+                <CustomCheckboxView
+                  field={fields.displayCredit}
+                  errors={errors.displayCredit}
+                  label="Display credit information"
+                />
+              </Column>
+            </Columns>
+          </FieldLayoutVertical>
+        </Column>
+      </Columns>
+    </div>
+  );
+};
+
+const imageViewStyles = css`
   width: 100%;
 `;
 
@@ -200,7 +352,7 @@ const ImageView = ({
     <div>
       <Errors errors={errors.map((e) => e.error)} />
       <div>
-        <img css={imageViewStysles} src={imageSrc} />
+        <img css={imageViewStyles} src={imageSrc} />
       </div>
       <Button
         priority="secondary"

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -111,7 +111,10 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
                       SEO.
                     </p>
                     <p>
-                      <a href="https://docs.google.com/document/d/1oW542iCRyKfI4DS22QU7AH0TQRWLYMm7bTlhJlX5_Ng/edit?usp=sharing">
+                      <a
+                        href="https://docs.google.com/document/d/1oW542iCRyKfI4DS22QU7AH0TQRWLYMm7bTlhJlX5_Ng/edit?usp=sharing"
+                        target="_blank"
+                      >
                         Find out more
                       </a>
                     </p>

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -1,13 +1,13 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { brand, neutral, space } from "@guardian/src-foundations";
-import { SvgCamera, SvgInfo } from "@guardian/src-icons";
+import { space } from "@guardian/src-foundations";
+import { SvgCamera } from "@guardian/src-icons";
 import { Column, Columns } from "@guardian/src-layout";
-import React, { useMemo, useState } from "react";
-import { usePopper } from "react-popper";
+import React, { useMemo } from "react";
 import { Button } from "../../editorial-source-components/Button";
 import { Error } from "../../editorial-source-components/Error";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import { Tooltip } from "../../editorial-source-components/Tooltip";
 import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
 import type {
   FieldValidationErrors,
@@ -45,82 +45,6 @@ const AltText = styled.span`
   margin-right: ${space[2]}px;
 `;
 
-const infoIcon = css`
-  height: 22px;
-  width: 22px;
-  margin-right: 4px;
-  margin-left: -4px;
-  svg {
-    margin: -1px;
-  }
-  :hover {
-    cursor: pointer;
-  }
-`;
-
-const tooltip = css`
-  font-family: "Guardian Agate Sans";
-  background-color: ${neutral[10]};
-  color: ${neutral[97]};
-  width: 300px;
-  font-weight: 300;
-  border-radius: 4px;
-  line-height: 1.2rem;
-  font-family: "Guardian Agate Sans";
-  filter: drop-shadow(0 2px 4px rgb(0 0 0 / 30%));
-  z-index: 1;
-  p {
-    margin: 10px;
-  }
-  a {
-    color: ${brand[800]};
-  }
-  opacity: 0;
-  transition: opacity 0.3s;
-  /* transition: visibility 0.3s; */
-  transition: visibility 0s;
-  transition-delay: visibility 0s;
-
-  visibility: hidden;
-  &[data-show] {
-    transition-delay: visibility 1s;
-    transition-delay: transition-delay 1s;
-    visibility: visible;
-    opacity: 1;
-  }
-  [data-popper-reference-hidden] {
-    visibility: hidden;
-    pointer-events: none;
-  }
-`;
-
-const arrow = css`
-  position: absolute;
-  width: 8px;
-  height: 8px;
-  background: inherit;
-  visibility: hidden;
-  &[data-show] {
-    ::before {
-      visibility: visible;
-    }
-  }
-  &[data-popper-reference-hidden] {
-    ::before {
-      visibility: hidden;
-      pointer-events: none;
-    }
-  }
-  ::before {
-    position: absolute;
-    width: 8px;
-    height: 8px;
-    background: inherit;
-    content: "";
-    transform: translate(0px, -4px) rotate(45deg);
-  }
-`;
-
 export const ImageElementTestId = "ImageElement";
 
 const htmlLength = (text: string) => {
@@ -134,31 +58,6 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
   fields,
   fieldValues,
 }) => {
-  const [
-    referenceElement,
-    setReferenceElement,
-  ] = useState<HTMLDivElement | null>(null);
-  const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(
-    null
-  );
-  const [tooltipVisible, setTooltipVisible] = useState(false);
-  const [arrowElement, setArrowElement] = useState<HTMLDivElement | null>(null);
-  const { styles, attributes, update } = usePopper(
-    referenceElement,
-    popperElement,
-    {
-      placement: "top",
-      modifiers: [
-        { name: "arrow", options: { element: arrowElement } },
-        {
-          name: "offset",
-          options: {
-            offset: [0, 4],
-          },
-        },
-      ],
-    }
-  );
   return (
     <div data-cy={ImageElementTestId}>
       <Columns>
@@ -205,36 +104,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
               headingLabel={<AltText>Alt text</AltText>}
               headingContent={
                 <>
-                  <div
-                    css={infoIcon}
-                    ref={setReferenceElement}
-                    onMouseOver={() => {
-                      setTooltipVisible(true);
-                      if (update) void update();
-                    }}
-                    onMouseLeave={() => {
-                      setTooltipVisible(false);
-                      if (update) void update();
-                    }}
-                  >
-                    <SvgInfo />
-                  </div>
-
-                  <div
-                    ref={setPopperElement}
-                    style={styles.popper}
-                    css={tooltip}
-                    data-show={tooltipVisible ? tooltipVisible : null}
-                    {...attributes.popper}
-                    onMouseOver={() => {
-                      setTooltipVisible(true);
-                      if (update) void update();
-                    }}
-                    onMouseLeave={() => {
-                      setTooltipVisible(false);
-                      if (update) void update();
-                    }}
-                  >
+                  <Tooltip>
                     <p>
                       'Alt text' describes what's in an image. It helps users of
                       screen readers understand our images, and improves our
@@ -243,14 +113,7 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
                     <p>
                       <a href="https://example.com">Find out more</a>
                     </p>
-
-                    <div
-                      ref={setArrowElement}
-                      style={styles.arrow}
-                      css={arrow}
-                      data-show={tooltipVisible ? tooltipVisible : null}
-                    />
-                  </div>
+                  </Tooltip>
                   <Button
                     priority="secondary"
                     size="xsmall"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4978,7 +4978,7 @@ loglevel@^1.6.8:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
   integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -5775,15 +5775,6 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.7.2:
-  version "15.7.2"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
-  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
-  dependencies:
-    loose-envify "^1.4.0"
-    object-assign "^4.1.1"
-    react-is "^16.8.1"
-
 prosemirror-collab@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz#8d2c0e82779cfef5d051154bd0836428bd6d9c4a"
@@ -6017,7 +6008,7 @@ react-fast-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -6034,14 +6025,6 @@ react-popper@^2.2.5:
   dependencies:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
-
-react-tooltip@^4.2.21:
-  version "4.2.21"
-  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.21.tgz#840123ed86cf33d50ddde8ec8813b2960bfded7f"
-  integrity sha512-zSLprMymBDowknr0KVDiJ05IjZn9mQhhg4PRsqln0OZtURAJ1snt1xi5daZfagsh6vfsziZrc9pErPTDY1ACig==
-  dependencies:
-    prop-types "^15.7.2"
-    uuid "^7.0.3"
 
 react@^17.0.1:
   version "17.0.2"
@@ -7280,11 +7263,6 @@ uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 uuid@^8.3.0:
   version "8.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5775,7 +5775,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -6003,15 +6003,14 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-react-dom@^16.4.1:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
+react-dom@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "^0.20.2"
 
 react-fast-compare@^3.0.1:
   version "3.2.0"
@@ -6044,14 +6043,13 @@ react-tooltip@^4.2.21:
     prop-types "^15.7.2"
     uuid "^7.0.3"
 
-react@^16.4.1:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
+react@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 read-pkg-up@^2.0.0:
   version "2.0.0"
@@ -6342,10 +6340,10 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -857,6 +857,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@popperjs/core@^2.10.2":
+  version "2.10.2"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.10.2.tgz#0798c03351f0dea1a5a4cabddf26a55a7cbee590"
+  integrity sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==
+
 "@sideway/address@^4.1.0":
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.2.tgz#811b84333a335739d3969cfc434736268170cad1"
@@ -4973,7 +4978,7 @@ loglevel@^1.6.8:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
   integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
 
-loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -5770,6 +5775,15 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
+prop-types@^15.6.2, prop-types@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 prosemirror-collab@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz#8d2c0e82779cfef5d051154bd0836428bd6d9c4a"
@@ -5989,16 +6003,22 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-react-dom@^17.0.1:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+react-dom@^16.4.1:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
+  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    scheduler "^0.20.2"
+    prop-types "^15.6.2"
+    scheduler "^0.19.1"
 
-react-is@^16.7.0:
+react-fast-compare@^3.0.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
+react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -6008,13 +6028,30 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react@^17.0.1:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react-popper@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.5.tgz#1214ef3cec86330a171671a4fbcbeeb65ee58e96"
+  integrity sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==
+  dependencies:
+    react-fast-compare "^3.0.1"
+    warning "^4.0.2"
+
+react-tooltip@^4.2.21:
+  version "4.2.21"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.21.tgz#840123ed86cf33d50ddde8ec8813b2960bfded7f"
+  integrity sha512-zSLprMymBDowknr0KVDiJ05IjZn9mQhhg4PRsqln0OZtURAJ1snt1xi5daZfagsh6vfsziZrc9pErPTDY1ACig==
+  dependencies:
+    prop-types "^15.7.2"
+    uuid "^7.0.3"
+
+react@^16.4.1:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
+  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+    prop-types "^15.6.2"
 
 read-pkg-up@^2.0.0:
   version "2.0.0"
@@ -6305,10 +6342,10 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
-  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
+scheduler@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
+  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -7246,6 +7283,11 @@ uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+uuid@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
+
 uuid@^8.3.0:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
@@ -7323,6 +7365,13 @@ walker@^1.0.7, walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
+
+warning@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
 
 watchpack@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## What does this change?
This PR adds a tooltip to the image element which explains the purpose of alt text. It also links to an external document that goes into more detail about writing good alt text, with examples.

![2021-12-01 10 39 28](https://user-images.githubusercontent.com/34686302/144219776-e9994ec1-e2b5-4155-ac4d-e7a0d43e64e5.gif)

### Why?
A user noticed an article (of mostly images) had a '.' for all its alt text fields - a user circumventing the minimum character rule for alt text in Composer.

Any minimum character rule can be worked around, so it was decided that adding a tooltip explaining that alt text is valuable for users of assistive technology would be a good behavioural nudge, and useful to users of Composer who might want a refresher on its purpose.

I ran a query on our database and found that, of 1,499,519 images used in articles, 16,050 had alt text of less than 5 characters (which are unlikely to be good image descriptions) - just over 1%. I felt that this was a significant enough proportion to justify trying the tooltip.

The Production team also thought it was a sensible addition.

### Where did the guidance come from?
The guidance can be found [here](https://docs.google.com/document/d/1oW542iCRyKfI4DS22QU7AH0TQRWLYMm7bTlhJlX5_Ng/edit). The guidance is a collaboration between Kirsten Broomhall and I, based on existing guidance given to journalists, and my input on accessibility. We ran it past Jonathan Casson (Head of production) who thought it was sensible guidance.

### Why a google doc?
It turns out that most guidance shared with journalists is done via Google docs, so I stuck with that for the sake of using a familiar medium. Subeditors have edit rights.

(N.B. I wonder if an internal microsite with information for journalists would be a good idea - but there doesn't seem to be anything like this at the moment).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run `yarn start` locally in the repository root, and add an image element. Try hovering over the 'i' icon and using the link.