### PR TITLE
fix: Update selection manually when nested text fields are focused

### DIFF
--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -59,6 +59,9 @@ export const getElementMenuButton = (fieldName: string, buttonTitle: string) =>
     )} .ProseMirror-menubar [title="${buttonTitle}"]`
   );
 
+export const focusElementField = (fieldName: string) =>
+  getElementRichTextField(fieldName).focus();
+
 // If we don't focus the nested RTE we're typing into before type() is called,
 // Cypress tends to type into the parent RTE instead.
 export const typeIntoElementField = (fieldName: string, content: string) =>
@@ -79,6 +82,13 @@ export const assertDocHtml = (expectedHtml: string) =>
   cy.window().then((win: WindowType) => {
     const actualHtml = win.PM_ELEMENTS.docToHtml();
     expect(trimHtml(expectedHtml)).to.equal(actualHtml);
+  });
+
+export const assertDocSelection = (from: number, to: number) =>
+  cy.window().then((win: WindowType) => {
+    const { from: docFrom, to: docTo } = win.PM_ELEMENTS.view.state.selection;
+    expect(docFrom).equals(from);
+    expect(docTo).equals(to);
   });
 
 export const changeTestDecoString = (newTestString: string) => {

--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -84,11 +84,10 @@ export const assertDocHtml = (expectedHtml: string) =>
     expect(trimHtml(expectedHtml)).to.equal(actualHtml);
   });
 
-export const assertDocSelection = (from: number, to: number) =>
+export const getDocSelection = () =>
   cy.window().then((win: WindowType) => {
     const { from: docFrom, to: docTo } = win.PM_ELEMENTS.view.state.selection;
-    expect(docFrom).equals(from);
-    expect(docTo).equals(to);
+    return [docFrom, docTo];
   });
 
 export const changeTestDecoString = (newTestString: string) => {

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -52,10 +52,15 @@ describe("ImageElement", () => {
         focusElementField("caption");
         focusElementField("src");
 
+        getDocSelection().then(([from]) => {
+          // The selection should have moved from the field
+          expect(from).to.not.equal(12);
+        });
+
         // We click to ensure we select the end of the text, where the cursor would have previously been
         getElementRichTextField("caption").click();
         getDocSelection().then(([from, to]) => {
-          // The selection should be at the first field of the element
+          // The selection should be at the end of the field
           expect(from).to.equal(12);
           expect(to).to.equal(12);
         });

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -49,7 +49,7 @@ describe("ImageElement", () => {
         getElementRichTextField("caption").should("have.text", text);
       });
 
-      it.only(`caption – should allow mark shortcuts in an element`, () => {
+      it(`caption – should allow mark shortcuts in an element`, () => {
         addImageElement();
         const text = `text with ${boldShortcut()}bold and ${boldShortcut()}${italicShortcut()}italic`;
         typeIntoElementField("caption", text);

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -31,7 +31,7 @@ describe("ImageElement", () => {
     describe("Rich text field", () => {
       it("should update the document selection when the user focuses on the field", () => {
         addImageElement();
-        assertDocSelection(19, 19); // The selection immediately after the inserted element
+        assertDocSelection(21, 21); // The selection immediately after the inserted element
         focusElementField("caption");
         assertDocSelection(5, 5);
       });

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -2,10 +2,10 @@ import { UpdateAltTextButtonId } from "../../src/elements/demo-image/DemoImageEl
 import {
   addImageElement,
   assertDocHtml,
-  assertDocSelection,
   boldShortcut,
   changeTestDecoString,
   focusElementField,
+  getDocSelection,
   getElementField,
   getElementMenuButton,
   getElementRichTextField,
@@ -31,9 +31,16 @@ describe("ImageElement", () => {
     describe("Rich text field", () => {
       it("should update the document selection when the user focuses on the field", () => {
         addImageElement();
-        assertDocSelection(21, 21); // The selection immediately after the inserted element
+        getDocSelection().then(([from]) => {
+          // The selection should be just after the inserted element
+          expect(from).to.be.greaterThan(5);
+        });
         focusElementField("caption");
-        assertDocSelection(5, 5);
+        getDocSelection().then(([from, to]) => {
+          // The selection should be at the first field of the element
+          expect(from).to.equal(5);
+          expect(to).to.equal(5);
+        });
       });
       it(`caption – should have a placeholder`, () => {
         addImageElement();

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -42,6 +42,24 @@ describe("ImageElement", () => {
           expect(to).to.equal(5);
         });
       });
+      it("should update the document selection when the user focuses on the field and it contains content, even if the inner field's selection has not changed", () => {
+        addImageElement();
+        getDocSelection().then(([from]) => {
+          // The selection should be just after the inserted element
+          expect(from).to.be.greaterThan(13);
+        });
+        typeIntoElementField("caption", "Example");
+        focusElementField("caption");
+        focusElementField("src");
+
+        // We click to ensure we select the end of the text, where the cursor would have previously been
+        getElementRichTextField("caption").click();
+        getDocSelection().then(([from, to]) => {
+          // The selection should be at the first field of the element
+          expect(from).to.equal(12);
+          expect(to).to.equal(12);
+        });
+      });
       it("should update the document selection when the user focuses on the field – subsequent field", () => {
         addImageElement();
         getDocSelection().then(([from]) => {

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -2,8 +2,10 @@ import { UpdateAltTextButtonId } from "../../src/elements/demo-image/DemoImageEl
 import {
   addImageElement,
   assertDocHtml,
+  assertDocSelection,
   boldShortcut,
   changeTestDecoString,
+  focusElementField,
   getElementField,
   getElementMenuButton,
   getElementRichTextField,
@@ -27,6 +29,12 @@ describe("ImageElement", () => {
 
   describe("Fields", () => {
     describe("Rich text field", () => {
+      it("should update the document selection when the user focuses on the field", () => {
+        addImageElement();
+        assertDocSelection(19, 19); // The selection immediately after the inserted element
+        focusElementField("caption");
+        assertDocSelection(5, 5);
+      });
       it(`caption – should have a placeholder`, () => {
         addImageElement();
         getElementRichTextFieldPlaceholder("caption").should(

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -29,7 +29,7 @@ describe("ImageElement", () => {
 
   describe("Fields", () => {
     describe("Rich text field", () => {
-      it("should update the document selection when the user focuses on the field", () => {
+      it("should update the document selection when the user focuses on the field – initial field", () => {
         addImageElement();
         getDocSelection().then(([from]) => {
           // The selection should be just after the inserted element
@@ -40,6 +40,19 @@ describe("ImageElement", () => {
           // The selection should be at the first field of the element
           expect(from).to.equal(5);
           expect(to).to.equal(5);
+        });
+      });
+      it("should update the document selection when the user focuses on the field – subsequent field", () => {
+        addImageElement();
+        getDocSelection().then(([from]) => {
+          // The selection should be just after the inserted element
+          expect(from).to.be.greaterThan(13);
+        });
+        focusElementField("src");
+        getDocSelection().then(([from, to]) => {
+          // The selection should be at the first field of the element
+          expect(from).to.equal(17);
+          expect(to).to.equal(17);
         });
       });
       it(`caption – should have a placeholder`, () => {

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -49,13 +49,13 @@ describe("ImageElement", () => {
         getElementRichTextField("caption").should("have.text", text);
       });
 
-      it(`caption – should allow mark shortcuts in an element`, () => {
+      it.only(`caption – should allow mark shortcuts in an element`, () => {
         addImageElement();
-        const text = `${boldShortcut()}bold caption text${boldShortcut()}${italicShortcut()}italic caption text`;
+        const text = `text with ${boldShortcut()}bold and ${boldShortcut()}${italicShortcut()}italic`;
         typeIntoElementField("caption", text);
         getElementRichTextField("caption").should(
           "have.html",
-          "<p><strong>bold caption text</strong><em>italic caption text</em></p>"
+          "<p>text with <strong>bold and </strong><em>italic</em></p>"
         );
       });
 

--- a/src/plugin/fieldViews/FieldView.ts
+++ b/src/plugin/fieldViews/FieldView.ts
@@ -29,7 +29,7 @@ export abstract class FieldView<NodeValue> {
   public abstract fieldViewElement?: HTMLElement;
 
   /**
-   * Called when the fieldView is updated.
+   * Called when the fieldView is updated from the parent editor.
    */
   public abstract onUpdate(
     node: Node,
@@ -43,7 +43,7 @@ export abstract class FieldView<NodeValue> {
   public abstract update(value: NodeValue): void;
 
   /**
-   * Called when the fieldView is destroyed.
+   * Destroy this fieldView, cleaning up any resources it has instantiated.
    */
   public abstract destroy(): void;
 

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -332,7 +332,7 @@ export abstract class ProseMirrorFieldView implements FieldView<string> {
       // so we must add them to the transaction explicitly.
       tr.setStoredMarks(this.innerEditorView.state.storedMarks ?? []);
 
-      this.dispatchTransaction(tr);
+      this.updateOuterEditor(tr, this.innerEditorView.state, [tr]);
     });
   }
 

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -1,7 +1,7 @@
 import type { AttributeSpec, Node } from "prosemirror-model";
 import { DOMParser, DOMSerializer } from "prosemirror-model";
 import type { Plugin, Transaction } from "prosemirror-state";
-import { EditorState, TextSelection } from "prosemirror-state";
+import { EditorState } from "prosemirror-state";
 import { Mapping, StepMap } from "prosemirror-transform";
 import type { Decoration } from "prosemirror-view";
 import { DecorationSet, EditorView } from "prosemirror-view";
@@ -323,16 +323,14 @@ export abstract class ProseMirrorFieldView implements FieldView<string> {
       if (!this.innerEditorView) {
         return;
       }
-      if (this.innerEditorView.state.doc.textContent.length !== 0) {
-        return;
-      }
-      const { tr, doc } = this.innerEditorView.state;
-      tr.setSelection(TextSelection.create(doc, 0));
+
+      const { tr } = this.innerEditorView.state;
+      tr.setSelection(this.innerEditorView.state.selection);
       // Setting a text selection seems to clear out our stored marks,
       // so we must add them to the transaction explicitly.
       tr.setStoredMarks(this.innerEditorView.state.storedMarks ?? []);
 
-      this.updateOuterEditor(tr, this.innerEditorView.state, [tr]);
+      this.dispatchTransaction(tr);
     });
   }
 

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -314,9 +314,16 @@ export abstract class ProseMirrorFieldView implements FieldView<string> {
   }
 
   /**
-   * We need to set the appropriate selection in the parent editor when this field is focused.
-   * Prosemirror does not dispatch a transaction when it receives focus on an empty document,
-   * so in that case we do this manually.
+   * We need to set the appropriate selection in the parent editor when this
+   * field is focused. ProseMirror does not dispatch a transaction when it
+   * receives focus on a document and the selection state doesn't change, so in
+   * that case we do this manually.
+   *
+   * This can result in two selection transactions being dispatched in quick
+   * succession when users focus this field and the selection state _has_
+   * changed. This is difficult to work around, because we cannot know what the
+   * user selection is until ProseMirror has resolved it. We haven't observed
+   * any problems as a result of this behaviour yet, but it's worth noting.
    */
   private setupFocusHandler() {
     this.fieldViewElement.addEventListener("focusin", () => {

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -328,6 +328,10 @@ export abstract class ProseMirrorFieldView implements FieldView<string> {
       }
       const { tr, doc } = this.innerEditorView.state;
       tr.setSelection(TextSelection.create(doc, 0));
+      // Setting a text selection seems to clear out our stored marks,
+      // so we must add them to the transaction explicitly.
+      tr.setStoredMarks(this.innerEditorView.state.storedMarks ?? []);
+
       this.dispatchTransaction(tr);
     });
   }


### PR DESCRIPTION
## What does this change?

Updates the editor selection when the user focuses empty Prosemirror-based fields.

We must do this manually, because Prosemirror does not dispatch a transaction when this occurs in an empty editor. This makes sense for a root editor, because it's effectively a no-op from a state point of view – but for nested editors, this does result in a change of state!

## How to test

- The new integration test should pass, and you should be convinced it reflects the correct behaviour.
- Open the demo page, create an element with a text field, open the dev tools, and click into empty text fields. You should see the selection update.