### PR TITLE
feat: Create rich-link element 

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -13,7 +13,6 @@ import {
   createEmbedElement,
   createImageElement,
   pullquoteElement,
-  richlinkElement,
 } from "../src";
 import type { MediaPayload } from "../src/elements/image/ImageElement";
 import { buildElementPlugin } from "../src/plugin/element";
@@ -32,43 +31,21 @@ import type { WindowType } from "./types";
 // they click a text field.
 FocusStyleManager.onlyShowFocusOnTabs();
 const embedElementName = "embedElement";
-<<<<<<< HEAD
-<<<<<<< HEAD
 const imageElementName = "imageElement";
 const demoImageElementName = "demo-image-element";
-=======
-const imageElementName = "image-Element";
-const demoImageElementName = "demoImageElement";
->>>>>>> e559baa... create initial convert functions and test with image-element
-=======
-const imageElementName = "imageElement";
-const demoImageElementName = "demo-image-element";
->>>>>>> beeebdb... Add tests
 const codeElementName = "codeElement";
 const pullquoteElementName = "pullquoteElement";
-const richlinkElementName = "richlinkElement";
 
 type Name =
   | typeof embedElementName
   | typeof imageElementName
   | typeof demoImageElementName
   | typeof codeElementName
-  | typeof pullquoteElementName
-  | typeof richlinkElementName;
+  | typeof pullquoteElementName;
 
 const { plugin: elementPlugin, insertElement, nodeSpec } = buildElementPlugin({
-<<<<<<< HEAD
-<<<<<<< HEAD
   "demo-image-element": createDemoImageElement(onSelectImage, onDemoCropImage),
   imageElement: createImageElement({
-=======
-  demoImageElement: createDemoImageElement(onSelectImage, onDemoCropImage),
-  "image-Element": createImageElement({
->>>>>>> e559baa... create initial convert functions and test with image-element
-=======
-  "demo-image-element": createDemoImageElement(onSelectImage, onDemoCropImage),
-  imageElement: createImageElement({
->>>>>>> beeebdb... Add tests
     openImageSelector: onCropImage,
     createCaptionPlugins: (schema) => exampleSetup({ schema }),
   }),
@@ -93,7 +70,6 @@ const { plugin: elementPlugin, insertElement, nodeSpec } = buildElementPlugin({
   }),
   codeElement,
   pullquoteElement,
-  richlinkElement,
 });
 
 const strike: MarkSpec = {
@@ -201,14 +177,6 @@ const createEditor = (server: CollabServer) => {
       altText: "",
       caption: "",
       useSrc: { value: false },
-    })
-  );
-
-  editorElement.appendChild(
-    createElementButton("Add demo rich-link element", richlinkElementName, {
-      linkText: "example",
-      url: "https://example.com",
-      weighting: "",
     })
   );
 

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -13,6 +13,7 @@ import {
   createEmbedElement,
   createImageElement,
   pullquoteElement,
+  richlinkElement,
 } from "../src";
 import type { MediaPayload } from "../src/elements/image/ImageElement";
 import { buildElementPlugin } from "../src/plugin/element";
@@ -35,13 +36,15 @@ const imageElementName = "imageElement";
 const demoImageElementName = "demo-image-element";
 const codeElementName = "codeElement";
 const pullquoteElementName = "pullquoteElement";
+const richlinkElementName = "richlinkElement";
 
 type Name =
   | typeof embedElementName
   | typeof imageElementName
   | typeof demoImageElementName
   | typeof codeElementName
-  | typeof pullquoteElementName;
+  | typeof pullquoteElementName
+  | typeof richlinkElementName;
 
 const { plugin: elementPlugin, insertElement, nodeSpec } = buildElementPlugin({
   "demo-image-element": createDemoImageElement(onSelectImage, onDemoCropImage),
@@ -70,6 +73,7 @@ const { plugin: elementPlugin, insertElement, nodeSpec } = buildElementPlugin({
   }),
   codeElement,
   pullquoteElement,
+  richlinkElement,
 });
 
 const strike: MarkSpec = {
@@ -177,6 +181,14 @@ const createEditor = (server: CollabServer) => {
       altText: "",
       caption: "",
       useSrc: { value: false },
+    })
+  );
+
+  editorElement.appendChild(
+    createElementButton("Add demo rich-link element", richlinkElementName, {
+      linkText: "example",
+      url: "https://example.com",
+      weighting: "",
     })
   );
 

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -185,7 +185,7 @@ const createEditor = (server: CollabServer) => {
   );
 
   editorElement.appendChild(
-    createElementButton("Add demo rich-link element", richlinkElementName, {
+    createElementButton("Add rich-link element", richlinkElementName, {
       linkText: "example",
       url: "https://example.com",
       weighting: "",

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -31,8 +31,13 @@ import type { WindowType } from "./types";
 // they click a text field.
 FocusStyleManager.onlyShowFocusOnTabs();
 const embedElementName = "embedElement";
+<<<<<<< HEAD
 const imageElementName = "imageElement";
 const demoImageElementName = "demo-image-element";
+=======
+const imageElementName = "image-Element";
+const demoImageElementName = "demoImageElement";
+>>>>>>> e559baa... create initial convert functions and test with image-element
 const codeElementName = "codeElement";
 const pullquoteElementName = "pullquoteElement";
 
@@ -44,8 +49,13 @@ type Name =
   | typeof pullquoteElementName;
 
 const { plugin: elementPlugin, insertElement, nodeSpec } = buildElementPlugin({
+<<<<<<< HEAD
   "demo-image-element": createDemoImageElement(onSelectImage, onDemoCropImage),
   imageElement: createImageElement({
+=======
+  demoImageElement: createDemoImageElement(onSelectImage, onDemoCropImage),
+  "image-Element": createImageElement({
+>>>>>>> e559baa... create initial convert functions and test with image-element
     openImageSelector: onCropImage,
     createCaptionPlugins: (schema) => exampleSetup({ schema }),
   }),

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -32,12 +32,17 @@ import type { WindowType } from "./types";
 FocusStyleManager.onlyShowFocusOnTabs();
 const embedElementName = "embedElement";
 <<<<<<< HEAD
+<<<<<<< HEAD
 const imageElementName = "imageElement";
 const demoImageElementName = "demo-image-element";
 =======
 const imageElementName = "image-Element";
 const demoImageElementName = "demoImageElement";
 >>>>>>> e559baa... create initial convert functions and test with image-element
+=======
+const imageElementName = "imageElement";
+const demoImageElementName = "demo-image-element";
+>>>>>>> beeebdb... Add tests
 const codeElementName = "codeElement";
 const pullquoteElementName = "pullquoteElement";
 
@@ -50,12 +55,17 @@ type Name =
 
 const { plugin: elementPlugin, insertElement, nodeSpec } = buildElementPlugin({
 <<<<<<< HEAD
+<<<<<<< HEAD
   "demo-image-element": createDemoImageElement(onSelectImage, onDemoCropImage),
   imageElement: createImageElement({
 =======
   demoImageElement: createDemoImageElement(onSelectImage, onDemoCropImage),
   "image-Element": createImageElement({
 >>>>>>> e559baa... create initial convert functions and test with image-element
+=======
+  "demo-image-element": createDemoImageElement(onSelectImage, onDemoCropImage),
+  imageElement: createImageElement({
+>>>>>>> beeebdb... Add tests
     openImageSelector: onCropImage,
     createCaptionPlugins: (schema) => exampleSetup({ schema }),
   }),

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -13,6 +13,7 @@ import {
   createEmbedElement,
   createImageElement,
   pullquoteElement,
+  richlinkElement,
 } from "../src";
 import type { MediaPayload } from "../src/elements/image/ImageElement";
 import { buildElementPlugin } from "../src/plugin/element";
@@ -45,13 +46,15 @@ const demoImageElementName = "demo-image-element";
 >>>>>>> beeebdb... Add tests
 const codeElementName = "codeElement";
 const pullquoteElementName = "pullquoteElement";
+const richlinkElementName = "richlinkElement";
 
 type Name =
   | typeof embedElementName
   | typeof imageElementName
   | typeof demoImageElementName
   | typeof codeElementName
-  | typeof pullquoteElementName;
+  | typeof pullquoteElementName
+  | typeof richlinkElementName;
 
 const { plugin: elementPlugin, insertElement, nodeSpec } = buildElementPlugin({
 <<<<<<< HEAD
@@ -90,6 +93,7 @@ const { plugin: elementPlugin, insertElement, nodeSpec } = buildElementPlugin({
   }),
   codeElement,
   pullquoteElement,
+  richlinkElement,
 });
 
 const strike: MarkSpec = {
@@ -197,6 +201,14 @@ const createEditor = (server: CollabServer) => {
       altText: "",
       caption: "",
       useSrc: { value: false },
+    })
+  );
+
+  editorElement.appendChild(
+    createElementButton("Add demo rich-link element", richlinkElementName, {
+      linkText: "example",
+      url: "https://example.com",
+      weighting: "",
     })
   );
 

--- a/src/elements/helpers/transform.ts
+++ b/src/elements/helpers/transform.ts
@@ -2,6 +2,7 @@ import type { codeFields } from "../code/CodeElementSpec";
 import { transformElement as embedElementTransform } from "../embed/embedDataTransformer";
 import { transformElement as imageElementTransform } from "../image/imageElementDataTransformer";
 import type { pullquoteFields } from "../pullquote/PullquoteSpec";
+import type { richlinkFields } from "../rich-link/RichlinkSpec";
 import { transformElement as defaultElementTransform } from "./defaultTransform";
 
 const transformMap = {
@@ -9,6 +10,7 @@ const transformMap = {
   embed: embedElementTransform,
   image: imageElementTransform,
   pullquote: defaultElementTransform<typeof pullquoteFields>(),
+  "rich-link": defaultElementTransform<typeof richlinkFields>(),
 } as const;
 
 type TransformMap = typeof transformMap;

--- a/src/elements/rich-link/RichlinkForm.tsx
+++ b/src/elements/rich-link/RichlinkForm.tsx
@@ -12,14 +12,12 @@ type Props = {
   fields: FieldNameToField<typeof richlinkFields>;
 };
 
-export const RichlinkElementTestId = "RichlinkElement";
-
 export const RichlinkElementForm: React.FunctionComponent<Props> = ({
   errors,
   fields,
   fieldValues,
 }) => (
-  <FieldLayoutVertical data-cy={RichlinkElementTestId}>
+  <FieldLayoutVertical>
     <div>
       Related: <a href={fieldValues.url}>{fieldValues.linkText}</a>
     </div>

--- a/src/elements/rich-link/RichlinkForm.tsx
+++ b/src/elements/rich-link/RichlinkForm.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
+import type { FieldValidationErrors } from "../../plugin/elementSpec";
+import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
+import type { FieldNameToField } from "../../plugin/types/Element";
+import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
+import type { richlinkFields } from "./RichlinkSpec";
+
+type Props = {
+  fieldValues: FieldNameToValueMap<typeof richlinkFields>;
+  errors: FieldValidationErrors;
+  fields: FieldNameToField<typeof richlinkFields>;
+};
+
+export const RichlinkElementTestId = "RichlinkElement";
+
+export const RichlinkElementForm: React.FunctionComponent<Props> = ({
+  errors,
+  fields,
+  fieldValues,
+}) => (
+  <FieldLayoutVertical data-cy={RichlinkElementTestId}>
+    <CustomDropdownView
+      field={fields.weighting}
+      label="Weighting"
+      errors={errors.weighting}
+    />
+    <a href={fieldValues.url}>{fieldValues.linkText}</a>
+  </FieldLayoutVertical>
+);

--- a/src/elements/rich-link/RichlinkForm.tsx
+++ b/src/elements/rich-link/RichlinkForm.tsx
@@ -20,11 +20,14 @@ export const RichlinkElementForm: React.FunctionComponent<Props> = ({
   fieldValues,
 }) => (
   <FieldLayoutVertical data-cy={RichlinkElementTestId}>
+    <div>
+      Related: <a href={fieldValues.url}>{fieldValues.linkText}</a>
+    </div>
     <CustomDropdownView
       field={fields.weighting}
       label="Weighting"
       errors={errors.weighting}
+      display="inline"
     />
-    <a href={fieldValues.url}>{fieldValues.linkText}</a>
   </FieldLayoutVertical>
 );

--- a/src/elements/rich-link/RichlinkSpec.tsx
+++ b/src/elements/rich-link/RichlinkSpec.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { createCustomDropdownField } from "../../plugin/fieldViews/CustomFieldView";
+import { createTextField } from "../../plugin/fieldViews/TextFieldView";
+import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+import { RichlinkElementForm } from "./RichlinkForm";
+
+export const richlinkFields = {
+  linkText: createTextField(),
+  weighting: createCustomDropdownField("thumbnail", [
+    { text: "inline (default)", value: "inline" },
+    { text: "supporting", value: "supporting" },
+  ]),
+  role: createTextField(),
+  url: createTextField(),
+  originalUrl: createTextField(),
+  linkPrefix: createTextField(),
+};
+
+export const richlinkElement = createReactElementSpec(
+  richlinkFields,
+  ({ fields, errors, fieldValues }) => {
+    return (
+      <RichlinkElementForm
+        fields={fields}
+        errors={errors}
+        fieldValues={fieldValues}
+      />
+    );
+  }
+);
+
+// {
+//     "elementType": "rich-link",
+//     "fields": {
+//     "linkText": "thfthfdghfghfghfghfghfgh",
+//     "isMandatory": "true",
+//     "role": "supporting",
+//     "url": "http://www.code.dev-theguardian.com/test/2021/oct/13/thfthfdghfghfghfghfghfgh",
+//     "originalUrl": "https://m.code.dev-theguardian.com/test/2021/oct/13/thfthfdghfghfghfghfghfgh",
+//     "linkPrefix": "Related: "
+//     },
+//     "assets": []
+//     },

--- a/src/elements/rich-link/RichlinkSpec.tsx
+++ b/src/elements/rich-link/RichlinkSpec.tsx
@@ -28,16 +28,3 @@ export const richlinkElement = createReactElementSpec(
     );
   }
 );
-
-// {
-//     "elementType": "rich-link",
-//     "fields": {
-//     "linkText": "thfthfdghfghfghfghfghfgh",
-//     "isMandatory": "true",
-//     "role": "supporting",
-//     "url": "http://www.code.dev-theguardian.com/test/2021/oct/13/thfthfdghfghfghfghfghfgh",
-//     "originalUrl": "https://m.code.dev-theguardian.com/test/2021/oct/13/thfthfdghfghfghfghfghfgh",
-//     "linkPrefix": "Related: "
-//     },
-//     "assets": []
-//     },

--- a/src/elements/rich-link/RichlinkSpec.tsx
+++ b/src/elements/rich-link/RichlinkSpec.tsx
@@ -7,7 +7,7 @@ import { RichlinkElementForm } from "./RichlinkForm";
 export const richlinkFields = {
   linkText: createTextField(),
   weighting: createCustomDropdownField("thumbnail", [
-    { text: "inline (default)", value: "inline" },
+    { text: "thumbnail", value: "thumbnail" },
     { text: "supporting", value: "supporting" },
   ]),
   role: createTextField(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { createEmbedElement } from "./elements/embed/EmbedSpec";
 export { pullquoteElement } from "./elements/pullquote/PullquoteSpec";
 export { codeElement } from "./elements/code/CodeElementSpec";
 export { createImageElement } from "./elements/image/ImageElement";
+export { richlinkElement } from "./elements/rich-link/RichlinkSpec";
 export {
   transformElementIn,
   transformElementOut,

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -32,6 +32,7 @@ const Body = styled("div")`
       opacity: 1;
     }
   }
+  min-height: 134px;
 `;
 
 const Panel = styled("div")`


### PR DESCRIPTION
## What does this change?
This PR adds a `rich-link` element replicating the existing element in Composer PROD. 

This PR also:
- adds "rich-link" as a string as a defaultElementTransform 
- creates demo rich-link element for sandbox with button, generating example text for link to article
- add `min-height` styling to ElementWrapper to ensure grey body gives enough space to arrow/controls to be shown clearly

### Images - Element in Composer CODE (tested in flexible-content)
<img alt="Screenshot 2021-08-06 at 16 05 00" src="https://user-images.githubusercontent.com/49187886/144258008-7792eff7-4830-4221-8541-554bc7e2f9f3.png" width="1300px"/> 

## How to test in flexible-content
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run `yarn start` locally and add an rich-link element.

To test this with `flexible-content` locally, I used [`yalc`](https://github.com/wclr/yalc). If you want to do the same: 
1. Install `yalc` globally with `npm i yalc -g` or `yarn global add yalc`
2. Run `yarn build` in your local `prosemirror-elements` from this branch
3. Run `yalc publish` in the same directory
4. Run `yalc add @guardian/prosemirror-elements` from the `composer` directory of your local `flexible-content`

When pasting the article in composer ensure the article is listed in `/live/` CODE ensure the article is available as part of https://capi-proxy.local.dev-gutools.co.uk/live/
## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [ ] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [ ] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)


