### PR TITLE
docs: add yalc instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Setup:
 3. Run `yalc publish` in the same directory
 4. Run `yalc add @guardian/prosemirror-elements` from the `composer` directory of your local `flexible-content`
 
-note: any changes you make to your local prosemirror-elements branch must be republished (step 3). 
+Note: any changes you make to your local prosemirror-elements branch must be republished (step 3). 
 Dont forget to run `yarn build`!
 
 You will notice `.yalc` directory in the root of flexible-content which will be home to the local version of your guardian package.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const mySchema = new Schema({
   marks
 });
 ```
-### `Yalc`: An alternative to yarn link - Testing with flexible-content locally
+### Testing locally in applications using `prosemirror-elements`
 A very simple local repository for your locally developed packages that you want to share across your local environment.
 [Read more](https://github.com/wclr/yalc).
 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,7 @@ const mySchema = new Schema({
 });
 ```
 ### Testing locally in applications using `prosemirror-elements`
-A very simple local repository for your locally developed packages that you want to share across your local environment.
-[Read more](https://github.com/wclr/yalc).
-
-Setup is  straightforward but requires you to have both `prosemirror-elements` and the consimung project open and ready (In our case usually Composer in `flexible-content`).
-
-The advantage is you dont even need to add or commit your changes when publishing.
-You can make minor ammendments and simply republish!
+We've found yalc useful in testing local changes to prosemirror-elements in applications that use it.
 
 Setup: 
 

--- a/README.md
+++ b/README.md
@@ -72,13 +72,11 @@ We've found yalc useful in testing local changes to prosemirror-elements in appl
 Setup: 
 
 1. Install `yalc` globally with `npm i yalc -g` or `yarn global add yalc`
-2. Run `yarn build` in your local `prosemirror-elements` from your current branch
+2. Run `yarn build` in your local project from your current branch
 3. Run `yalc publish` in the same directory
-4. Run `yalc add @guardian/prosemirror-elements` from the `composer` directory of your local `flexible-content`
+4. Run `yalc add @guardian/<project>`  of your local project.
 
 Note: any changes you make to your local prosemirror-elements branch must be republished (step 3). 
 Dont forget to run `yarn build`!
 
-You will notice `.yalc` directory in the root of flexible-content which will be home to the local version of your guardian package.
-
-![image](https://user-images.githubusercontent.com/49187886/144407562-33286b25-1ec5-4c6d-a802-ce6e622ab357.png)
+You will notice `.yalc` directory in the root of your porject, which will be home to the local version of your guardian package.

--- a/README.md
+++ b/README.md
@@ -66,3 +66,25 @@ const mySchema = new Schema({
   marks
 });
 ```
+### `Yalc`: An alternative to yarn link - Testing with flexible-content locally
+A very simple local repository for your locally developed packages that you want to share across your local environment.
+[Read more](https://github.com/wclr/yalc).
+
+Setup is  straightforward but requires you to have both `prosemirror-elements` and the consimung project open and ready (In our case usually Composer in `flexible-content`).
+
+The advantage is you dont even need to add or commit your changes when publishing.
+You can make minor ammendments and simply republish!
+
+Setup: 
+
+1. Install `yalc` globally with `npm i yalc -g` or `yarn global add yalc`
+2. Run `yarn build` in your local `prosemirror-elements` from your current branch
+3. Run `yalc publish` in the same directory
+4. Run `yalc add @guardian/prosemirror-elements` from the `composer` directory of your local `flexible-content`
+
+note: any changes you make to your local prosemirror-elements branch must be republished (step 3). 
+Dont forget to run `yarn build`!
+
+You will notice `.yalc` directory in the root of flexible-content which will be home to the local version of your guardian package.
+
+![image](https://user-images.githubusercontent.com/49187886/144407562-33286b25-1ec5-4c6d-a802-ce6e622ab357.png)


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
A simple PR to add instructions for running and testing prosemirror-elements locally.

#### Yalc for local testing
This is especially useful for testing a local branch (pre `push`ing) within `flexible-content` and viewing your element in composer local `https://composer.local.dev-gutools.co.uk/`.

note: we may need want to remove the yarn link section of the readme