### PR TITLE
feat: Add resizeable property to text and richText fields, and apply to image altText

### DIFF
--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -153,6 +153,7 @@ export const getSerialisedHtml = ({
     <div pme-field-name="demo_image_element__customDropdown" fields="&quot;${customDropdownValue}&quot;"></div>
     <div pme-field-name="demo_image_element__mainImage" fields="{${mainImageFields}}"></div>
     <div pme-field-name="demo_image_element__optionDropdown" fields="&quot;${optionValue}&quot;"></div>
+    <div pme-field-name="demo_image_element__resizeable"></div>
     <div pme-field-name="demo_image_element__restrictedTextField">${restrictedTextValue}</div>
     <div pme-field-name="demo_image_element__src">${srcValue}</div>
     <div pme-field-name="demo_image_element__useSrc" fields="${useSrcValue}"></div>

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -318,6 +318,21 @@ describe("ImageElement", () => {
           );
       });
 
+      it("should visually extend no more than the number of lines specified by `rows` when resizeable", () => {
+        addImageElement();
+        typeIntoElementField(
+          "resizeable",
+          "{Enter}{Enter}{Enter}{Enter}{Enter}"
+        );
+        getElementRichTextField("resizeable")
+          .invoke("css", "height")
+          .then((height) => {
+            const heightAsNumber = parseInt((height as unknown) as string, 10);
+            // Proxy: height should be less than the five lines we've entered above
+            expect(heightAsNumber).to.be.lessThan(50);
+          });
+      });
+
       it("should serialise content as HTML within the appropriate nodes in the document", () => {
         addImageElement();
         typeIntoElementField("src", "Src text");

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -318,19 +318,33 @@ describe("ImageElement", () => {
           );
       });
 
-      it("should visually extend no more than the number of lines specified by `rows` when resizeable", () => {
-        addImageElement();
-        typeIntoElementField(
-          "resizeable",
-          "{Enter}{Enter}{Enter}{Enter}{Enter}"
-        );
-        getElementRichTextField("resizeable")
-          .invoke("css", "height")
-          .then((height) => {
-            const heightAsNumber = parseInt((height as unknown) as string, 10);
-            // Proxy: height should be less than the five lines we've entered above
-            expect(heightAsNumber).to.be.lessThan(50);
-          });
+      describe("Resizeable fields", () => {
+        it("should be resizeable", () => {
+          addImageElement();
+          getElementRichTextField("resizeable")
+            .invoke("css", "resize")
+            .then((resize) => {
+              expect(resize).to.be.equal("vertical");
+            });
+        });
+
+        it("should visually extend no more than the number of lines specified by `rows` when resizeable", () => {
+          addImageElement();
+          typeIntoElementField(
+            "resizeable",
+            "{Enter}{Enter}{Enter}{Enter}{Enter}"
+          );
+          getElementRichTextField("resizeable")
+            .invoke("css", "height")
+            .then((height) => {
+              const heightAsNumber = parseInt(
+                (height as unknown) as string,
+                10
+              );
+              // Proxy: height should be less than the five lines we've entered above
+              expect(heightAsNumber).to.be.lessThan(50);
+            });
+        });
       });
 
       it("should serialise content as HTML within the appropriate nodes in the document", () => {

--- a/src/elements/code/CodeElementSpec.tsx
+++ b/src/elements/code/CodeElementSpec.tsx
@@ -8,6 +8,7 @@ import { CodeElementForm } from "./CodeElementForm";
 export const codeFields = {
   html: createTextField({
     rows: 4,
+    isResizeable: true,
     isCode: true,
     validators: [required("empty code field")],
     absentOnEmpty: true,

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -73,6 +73,7 @@ export const createImageFields = (
       placeholder: "Write code here",
       maxRows: 10,
     }),
+    resizeable: createTextField({ rows: 2, isResizeable: true }),
     mainImage: createCustomField<ImageField, ImageProps>(
       { mediaId: undefined, mediaApiUri: undefined, assets: [] },
       {

--- a/src/elements/demo-image/DemoImageElementForm.tsx
+++ b/src/elements/demo-image/DemoImageElementForm.tsx
@@ -42,6 +42,11 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
       Programmatically update alt text
     </button>
     <FieldWrapper
+      headingLabel="Resizeable Text Field"
+      field={fields.resizeable}
+      errors={errors.resizeable}
+    />
+    <FieldWrapper
       field={fields.restrictedTextField}
       headingLabel="Restricted Text Field"
       errors={errors.restrictedTextField}

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -37,6 +37,7 @@ export const createEmbedFields = ({ createCaptionPlugins }: MainEmbedProps) => {
       rows: 2,
       isCode: true,
       maxRows: 10,
+      isResizeable: true,
       isMultiline: true,
       validators: [htmlRequired(undefined, "WARN")],
       placeholder: "Paste in the embed code…",
@@ -49,6 +50,7 @@ export const createEmbedFields = ({ createCaptionPlugins }: MainEmbedProps) => {
     }),
     alt: createTextField({
       rows: 2,
+      isResizeable: true,
       validators: [htmlMaxLength(1000), htmlRequired()],
       placeholder: "Enter some alt text…",
     }),

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -61,7 +61,7 @@ export const createImageFields = ({
 }: MainImageProps) => {
   return {
     alt: createTextField({
-      rows: 4,
+      rows: 2,
       validators: [htmlMaxLength(1000), htmlRequired()],
       placeholder: "Enter some alt text…",
       isResizeable: true,

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -61,9 +61,10 @@ export const createImageFields = ({
 }: MainImageProps) => {
   return {
     alt: createTextField({
-      rows: 2,
+      rows: 4,
       validators: [htmlMaxLength(1000), htmlRequired()],
       placeholder: "Enter some alt text…",
+      isResizeable: true,
     }),
     caption: createFlatRichTextField({
       createPlugins: createCaptionPlugins,

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -18,6 +18,8 @@ export interface AbstractTextFieldDescription
   // If true, when this text field is empty, do not include it as a key-value pair
   // in the element data extracted with `getElementDataFromNode`.
   absentOnEmpty?: boolean;
+  // Can the user resize the input?
+  isResizeable?: boolean;
 }
 
 /**
@@ -64,7 +66,9 @@ export abstract class ProseMirrorFieldView implements FieldView<string> {
     // Plugins that the editor should use
     plugins?: Plugin[],
     // The field placeholder option
-    placeholder?: PlaceholderOption
+    placeholder?: PlaceholderOption,
+    // Is this text field resizeable?
+    isResizeable = false
   ) {
     this.applyDecorationsFromOuterEditor(decorations, node, offset);
     this.serialiser = DOMSerializer.fromSchema(node.type.schema);
@@ -74,6 +78,9 @@ export abstract class ProseMirrorFieldView implements FieldView<string> {
       ? [...(plugins ?? []), createPlaceholderPlugin(placeholder)]
       : plugins;
     this.innerEditorView = this.createInnerEditorView(localPlugins);
+    if (isResizeable) {
+      this.makeInputElementResizeable();
+    }
   }
 
   public getNodeValue(node: Node) {
@@ -295,6 +302,14 @@ export abstract class ProseMirrorFieldView implements FieldView<string> {
         this.innerEditorView.state.tr.setMeta("fromOutside", true)
       );
     }
+  }
+
+  private makeInputElementResizeable() {
+    if (!this.innerEditorView) {
+      return;
+    }
+    (this.innerEditorView.dom as HTMLDivElement).style.resize = "vertical";
+    (this.innerEditorView.dom as HTMLDivElement).style.overflow = "auto";
   }
 
   private close() {

--- a/src/plugin/fieldViews/RichTextFieldView.ts
+++ b/src/plugin/fieldViews/RichTextFieldView.ts
@@ -30,6 +30,7 @@ type RichTextOptions = {
   marks?: string;
   validators?: FieldValidator[];
   placeholder?: PlaceholderOption;
+  isResizeable?: boolean;
 };
 
 export const createRichTextField = ({
@@ -40,6 +41,7 @@ export const createRichTextField = ({
   marks,
   validators,
   placeholder,
+  isResizeable,
 }: RichTextOptions): RichTextFieldDescription => ({
   type: RichTextFieldView.fieldName,
   createPlugins,
@@ -49,6 +51,7 @@ export const createRichTextField = ({
   validators,
   absentOnEmpty,
   placeholder,
+  isResizeable,
 });
 
 type FlatRichTextOptions = RichTextOptions & {
@@ -121,7 +124,7 @@ export class RichTextFieldView extends ProseMirrorFieldView {
     offset: number,
     // The initial decorations for the FieldView.
     decorations: DecorationSet | Decoration[],
-    field: RichTextFieldDescription
+    { placeholder, isResizeable, createPlugins }: RichTextFieldDescription
   ) {
     super(
       node,
@@ -136,9 +139,10 @@ export class RichTextFieldView extends ProseMirrorFieldView {
           "Mod-y": () => redo(outerView.state, outerView.dispatch),
           ...filteredKeymap,
         }),
-        ...(field.createPlugins ? field.createPlugins(node.type.schema) : []),
+        ...(createPlugins ? createPlugins(node.type.schema) : []),
       ],
-      field.placeholder
+      placeholder,
+      isResizeable
     );
 
     this.fieldViewElement.classList.add("ProseMirrorElements__RichTextField");


### PR DESCRIPTION
## What does this change?

Adds an `isResizeable` property to text and richtext fields, to allow both sorts to be resizeable by users in the usual way. This PR also applies this to our image alt text, to reflect the current behaviour of the old image element:

![resize](https://user-images.githubusercontent.com/7767575/144462653-5b9c39a0-76eb-48c5-84f4-6646eca60dcc.gif)

There's one decision I've made here that's worth mentioning – when an input is resizeable, we default its initial size to the number of rows specified in the `rows` property. I thought this made a sort of heuristic sense, as whenever we make something resizeable, we're likely expecting lots of content in a limited space – but others may disagree! We can use `maxRows` to ensure that users can't expand inputs indefinitely if required.

Incidentally, I was dusting off the HTML5 drag and drop API docs before I found out this was possible with CSS – phew! 😅 

## How to test

- Drag is difficult to test in integration directly, so I've added integration tests to check the appropriate css property is set, and to check that the height behaviour above is working correctly.
- Try the image element shown in the GIF. Does it work as expected?