### PR TITLE
chore: Remove engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/declaration/index.d.ts",
-  "engines": {
-    "node": "16.13"
-  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## What does this change?

Removes the `engines` field – this was added to ensure, along with `.nvmrc`, that we were developing in consistent environments, but this field is also used by `npm` module consumers to [ensure our code is run in the correct node environment](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#engines). That's something that our output, which is built for client side consumption, doesn't have an opinion about.
