### PR TITLE
add prepare command for transpiling

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test:unit": "jest",
     "ci": "yarn lint && yarn test:unit && (webpack serve & (wait-on http://localhost:7890 && cypress run))",
     "postci": "kill $(lsof -t -i:7890)",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "prepare": "tsc"
   },
   "dependencies": {
     "@emotion/core": "^11.0.0",

--- a/src/elements/rich-link/RichlinkForm.tsx
+++ b/src/elements/rich-link/RichlinkForm.tsx
@@ -19,7 +19,8 @@ export const RichlinkElementForm: React.FunctionComponent<Props> = ({
 }) => (
   <FieldLayoutVertical>
     <div>
-      Related: <a href={fieldValues.url}>{fieldValues.linkText}</a>
+      Related Prepare Spike:{" "}
+      <a href={fieldValues.url}>{fieldValues.linkText}</a>
     </div>
     <CustomDropdownView
       field={fields.weighting}


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This is a test branch to Spike out npm prepare script
## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [ ] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [ ] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
