### PR TITLE
feat: Resize embed preview on content height change, allow manual resize over 100px

### DIFF
--- a/src/elements/embed/embedComponents/Preview.tsx
+++ b/src/elements/embed/embedComponents/Preview.tsx
@@ -1,9 +1,9 @@
 import { css } from "@emotion/react";
-import { useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import { Label } from "../../../editorial-source-components/Label";
 import { unescapeHtml } from "./embedUtils";
 
-export const Preview = ({ html }: { html: string }) => {
+export const Preview = React.memo(({ html }: { html: string }) => {
   const [height, setHeight] = useState("0px");
   const [resize, setResize] = useState(false);
   const ref = useRef<HTMLIFrameElement>(null);
@@ -40,4 +40,4 @@ export const Preview = ({ html }: { html: string }) => {
       />
     </div>
   );
-};
+});

--- a/src/elements/embed/embedComponents/Preview.tsx
+++ b/src/elements/embed/embedComponents/Preview.tsx
@@ -1,17 +1,43 @@
 import { css } from "@emotion/react";
+import { useRef, useState } from "react";
 import { Label } from "../../../editorial-source-components/Label";
 import { unescapeHtml } from "./embedUtils";
 
-const iframe = css`
-  background-color: white;
-  width: 100%;
-`;
-
 export const Preview = ({ html }: { html: string }) => {
+  const [height, setHeight] = useState("0px");
+  const [resize, setResize] = useState(false);
+  const ref = useRef<HTMLIFrameElement>(null);
+  const maxHeight = 100; // In px
+  const onLoad = () => {
+    const heightOfContent =
+      ref.current?.contentWindow?.document.body.scrollHeight;
+    if (heightOfContent && heightOfContent < maxHeight) {
+      setHeight((heightOfContent + 20).toString() + "px");
+    } else if (heightOfContent && heightOfContent > maxHeight) {
+      setHeight((maxHeight + 20).toString() + "px");
+      setResize(true);
+    } else setResize(false);
+  };
+
+  const iframe = css`
+    resize: ${resize ? "vertical" : "none"};
+    background-color: white;
+    width: 100%;
+    font-family: sans-serif;
+  `;
+
   return (
     <div>
       <Label>Preview</Label>
-      <iframe srcDoc={unescapeHtml(html)} css={iframe} />
+      <iframe
+        srcDoc={unescapeHtml(html)}
+        css={iframe}
+        ref={ref}
+        onLoad={onLoad}
+        id="myFrame"
+        src="http://demo_iframe.htm"
+        height={height}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## What does this change?
This PR changes the height of the preview in the embed element.

Instead of having a fixed size, the preview dynamically resizes based on its content, up to a size of 100px. After reaching that cap, the preview can be manually resized further. (It will remain in resizeable mode until the page is refreshed)

![2021-12-13 14 29 16](https://user-images.githubusercontent.com/34686302/145838280-cf448deb-5fe7-4128-86d3-f6a7ca6134c5.gif)

## How to test
Run `yarn start` from this repository locally. Add some html to the `embed code` field. Does the preview appropriately resize?