### PR TITLE
feat: Type callback urls for automatic embed creation

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -7,6 +7,7 @@ import { Schema } from "prosemirror-model";
 import { schema as basicSchema, marks } from "prosemirror-schema-basic";
 import { EditorState } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
+import type { TwitterUrl, YoutubeUrl } from "../src";
 import {
   codeElement,
   createDemoImageElement,
@@ -15,7 +16,6 @@ import {
   pullquoteElement,
   richlinkElement,
 } from "../src";
-import type { TwitterUrl, YoutubeUrl } from "../src/elements/embed/EmbedSpec";
 import type { MediaPayload } from "../src/elements/image/ImageElement";
 import { buildElementPlugin } from "../src/plugin/element";
 import {

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -15,6 +15,7 @@ import {
   pullquoteElement,
   richlinkElement,
 } from "../src";
+import type { TwitterUrl, YoutubeUrl } from "../src/elements/embed/EmbedSpec";
 import type { MediaPayload } from "../src/elements/image/ImageElement";
 import { buildElementPlugin } from "../src/plugin/element";
 import {
@@ -67,8 +68,10 @@ const { plugin: elementPlugin, insertElement, nodeSpec } = buildElementPlugin({
             },
             reach: { unsupportedPlatforms: [] },
           }),
-    convertTwitter: (src) => console.log(`Add Twitter embed with src: ${src}`),
-    convertYouTube: (src) => console.log(`Add youtube embed with src: ${src}`),
+    convertTwitter: (src: TwitterUrl) =>
+      console.log(`Add Twitter embed with src: ${src}`),
+    convertYouTube: (src: YoutubeUrl) =>
+      console.log(`Add youtube embed with src: ${src}`),
     createCaptionPlugins: (schema) => exampleSetup({ schema }),
   }),
   codeElement,

--- a/src/elements/embed/EmbedForm.tsx
+++ b/src/elements/embed/EmbedForm.tsx
@@ -10,15 +10,15 @@ import { EmbedRecommendation } from "./embedComponents/EmbedRecommendations";
 import { EmbedStatusChecks } from "./embedComponents/EmbedStatusChecks";
 import type { EmbedStatus } from "./embedComponents/EmbedStatusChecks";
 import { Preview } from "./embedComponents/Preview";
-import type { createEmbedFields } from "./EmbedSpec";
+import type { createEmbedFields, TwitterUrl, YoutubeUrl } from "./EmbedSpec";
 
 type Props = {
   fieldValues: FieldNameToValueMap<ReturnType<typeof createEmbedFields>>;
   errors: FieldValidationErrors;
   fields: FieldNameToField<ReturnType<typeof createEmbedFields>>;
   checkEmbedTracking: (html: string) => Promise<EmbedStatus>;
-  convertYouTube: (src: string) => void;
-  convertTwitter: (src: string) => void;
+  convertYouTube: (src: YoutubeUrl) => void;
+  convertTwitter: (src: TwitterUrl) => void;
 };
 
 export const EmbedElementTestId = "EmbedElement";

--- a/src/elements/embed/EmbedForm.tsx
+++ b/src/elements/embed/EmbedForm.tsx
@@ -9,8 +9,9 @@ import { CustomDropdownView } from "../../renderers/react/customFieldViewCompone
 import { EmbedRecommendation } from "./embedComponents/EmbedRecommendations";
 import { EmbedStatusChecks } from "./embedComponents/EmbedStatusChecks";
 import type { EmbedStatus } from "./embedComponents/EmbedStatusChecks";
+import type { TwitterUrl, YoutubeUrl } from "./embedComponents/embedUtils";
 import { Preview } from "./embedComponents/Preview";
-import type { createEmbedFields, TwitterUrl, YoutubeUrl } from "./EmbedSpec";
+import type { createEmbedFields } from "./EmbedSpec";
 
 type Props = {
   fieldValues: FieldNameToValueMap<ReturnType<typeof createEmbedFields>>;

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -12,10 +12,13 @@ import { createReactElementSpec } from "../../renderers/react/createReactElement
 import type { EmbedStatus } from "./embedComponents/EmbedStatusChecks";
 import { EmbedElementForm } from "./EmbedForm";
 
+export type TwitterUrl = `https://twitter.com/${string}`;
+export type YoutubeUrl = `${string}https://www.youtube.com/embed/${string}`;
+
 export type MainEmbedProps = {
   checkEmbedTracking: (html: string) => Promise<EmbedStatus>;
-  convertYouTube: (src: string) => void;
-  convertTwitter: (src: string) => void;
+  convertYouTube: (src: YoutubeUrl) => void;
+  convertTwitter: (src: TwitterUrl) => void;
   createCaptionPlugins?: (schema: Schema) => Plugin[];
 };
 

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -10,10 +10,8 @@ import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import type { EmbedStatus } from "./embedComponents/EmbedStatusChecks";
+import type { TwitterUrl, YoutubeUrl } from "./embedComponents/embedUtils";
 import { EmbedElementForm } from "./EmbedForm";
-
-export type TwitterUrl = `https://twitter.com/${string}`;
-export type YoutubeUrl = `${string}https://www.youtube.com/embed/${string}`;
 
 export type MainEmbedProps = {
   checkEmbedTracking: (html: string) => Promise<EmbedStatus>;

--- a/src/elements/embed/embedComponents/EmbedRecommendations.tsx
+++ b/src/elements/embed/embedComponents/EmbedRecommendations.tsx
@@ -3,9 +3,14 @@ import { buttonBrandAlt } from "@guardian/src-button";
 import { debounce } from "lodash";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "../../../editorial-source-components/Button";
-import type { TwitterUrl, YoutubeUrl } from "../EmbedSpec";
 import { conversionMessage, message } from "./embedStyles";
-import { getEmbedSource, parseHtml } from "./embedUtils";
+import type { TwitterUrl, YoutubeUrl } from "./embedUtils";
+import {
+  getEmbedSource,
+  isTwitterUrl,
+  isYoutubeUrl,
+  parseHtml,
+} from "./embedUtils";
 
 export const EmbedRecommendation = ({
   html,
@@ -29,33 +34,27 @@ export const EmbedRecommendation = ({
 
   return (
     <>
-      {source.startsWith("https://twitter.com/") && (
+      {isTwitterUrl(source) && (
         <div css={[conversionMessage, message]}>
           <span>
             It is recommended to use a Twitter URL rather than pasting their
             embed code.{" "}
           </span>
           <ThemeProvider theme={buttonBrandAlt}>
-            <Button
-              priority="secondary"
-              onClick={() => convertTwitter(source as TwitterUrl)}
-            >
+            <Button priority="secondary" onClick={() => convertTwitter(source)}>
               Convert
             </Button>
           </ThemeProvider>
         </div>
       )}
-      {source.includes("https://www.youtube.com/embed/") && (
+      {isYoutubeUrl(source) && (
         <div css={[conversionMessage, message]}>
           <span>
             It is recommended to use a YouTube URL rather than pasting their
             embed code.{" "}
           </span>
           <ThemeProvider theme={buttonBrandAlt}>
-            <Button
-              priority="secondary"
-              onClick={() => convertYouTube(source as YoutubeUrl)}
-            >
+            <Button priority="secondary" onClick={() => convertYouTube(source)}>
               Convert
             </Button>
           </ThemeProvider>

--- a/src/elements/embed/embedComponents/EmbedRecommendations.tsx
+++ b/src/elements/embed/embedComponents/EmbedRecommendations.tsx
@@ -3,6 +3,7 @@ import { buttonBrandAlt } from "@guardian/src-button";
 import { debounce } from "lodash";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "../../../editorial-source-components/Button";
+import type { TwitterUrl, YoutubeUrl } from "../EmbedSpec";
 import { conversionMessage, message } from "./embedStyles";
 import { getEmbedSource, parseHtml } from "./embedUtils";
 
@@ -12,8 +13,8 @@ export const EmbedRecommendation = ({
   convertTwitter,
 }: {
   html: string;
-  convertYouTube: (src: string) => void;
-  convertTwitter: (src: string) => void;
+  convertYouTube: (src: YoutubeUrl) => void;
+  convertTwitter: (src: TwitterUrl) => void;
 }) => {
   const [source, setSource] = useState(getEmbedSource(parseHtml(html)));
 
@@ -35,7 +36,10 @@ export const EmbedRecommendation = ({
             embed code.{" "}
           </span>
           <ThemeProvider theme={buttonBrandAlt}>
-            <Button priority="secondary" onClick={() => convertTwitter(source)}>
+            <Button
+              priority="secondary"
+              onClick={() => convertTwitter(source as TwitterUrl)}
+            >
               Convert
             </Button>
           </ThemeProvider>
@@ -48,7 +52,10 @@ export const EmbedRecommendation = ({
             embed code.{" "}
           </span>
           <ThemeProvider theme={buttonBrandAlt}>
-            <Button priority="secondary" onClick={() => convertYouTube(source)}>
+            <Button
+              priority="secondary"
+              onClick={() => convertYouTube(source as YoutubeUrl)}
+            >
               Convert
             </Button>
           </ThemeProvider>

--- a/src/elements/embed/embedComponents/embedUtils.ts
+++ b/src/elements/embed/embedComponents/embedUtils.ts
@@ -27,3 +27,11 @@ export const getEmbedSource = (element: Element | null) => {
 
   return "";
 };
+
+export type TwitterUrl = `https://twitter.com/${string}`;
+export type YoutubeUrl = `${string}https://www.youtube.com/embed/${string}`;
+
+export const isTwitterUrl = (url: string): url is TwitterUrl =>
+  url.startsWith("https://twitter.com/");
+export const isYoutubeUrl = (url: string): url is YoutubeUrl =>
+  url.includes("https://www.youtube.com/embed/");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
 export { buildElementPlugin } from "./plugin/element";
 export { createDemoImageElement } from "./elements/demo-image/DemoImageElement";
-export { createEmbedElement } from "./elements/embed/EmbedSpec";
+export {
+  createEmbedElement,
+  YoutubeUrl,
+  TwitterUrl,
+} from "./elements/embed/EmbedSpec";
 export { pullquoteElement } from "./elements/pullquote/PullquoteSpec";
 export { codeElement } from "./elements/code/CodeElementSpec";
 export { createImageElement } from "./elements/image/ImageElement";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 export { buildElementPlugin } from "./plugin/element";
 export { createDemoImageElement } from "./elements/demo-image/DemoImageElement";
+export { createEmbedElement } from "./elements/embed/EmbedSpec";
 export {
-  createEmbedElement,
   YoutubeUrl,
   TwitterUrl,
-} from "./elements/embed/EmbedSpec";
+} from "./elements/embed/embedComponents/embedUtils";
 export { pullquoteElement } from "./elements/pullquote/PullquoteSpec";
 export { codeElement } from "./elements/code/CodeElementSpec";
 export { createImageElement } from "./elements/image/ImageElement";


### PR DESCRIPTION
## What does this change?

Types the embed callback conversion urls with template string literals, per @davidfurey's suggestion.

## How to test

Typechecking with these types in the consuming context (see `demo/index.ts` below) should not cause a compile error.

## NB

I can't see a way of refining on the string such that I can achieve this without coercing with `as` – is this possible?