### PR TITLE
fix: Element validation delay bug by reversing ternary

### DIFF
--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -1,4 +1,5 @@
 import type { WindowType } from "../../demo/types";
+import { getFieldHeadingTestId } from "../../src/editorial-source-components/InputHeading";
 import { placeholderTestAttribute } from "../../src/plugin/helpers/placeholder";
 import {
   ChangeTestDecoStringAction,
@@ -46,6 +47,9 @@ export const getElementRichTextFieldPlaceholder = (fieldName: string) =>
 
 export const getElementField = (fieldName: string) =>
   cy.get(`div${selectDataCy(getFieldViewTestId(fieldName))}`);
+
+export const getElementHeading = (fieldName: string) =>
+  cy.get(`div${selectDataCy(getFieldHeadingTestId(fieldName))}`);
 
 export const getElementMenu = (fieldName: string) =>
   cy.get(

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -7,6 +7,7 @@ import {
   focusElementField,
   getDocSelection,
   getElementField,
+  getElementHeading,
   getElementMenuButton,
   getElementRichTextField,
   getElementRichTextFieldPlaceholder,
@@ -515,6 +516,30 @@ describe("ImageElement", () => {
           "have.text",
           "Default alt text"
         );
+      });
+    });
+
+    describe("Validation behaviour", () => {
+      it("should display the alt text as required", () => {
+        addImageElement();
+        getElementHeading("altText").should("exist");
+      });
+      it("should remove the alt text required warning", () => {
+        addImageElement();
+        typeIntoElementField("altText", "text");
+        getElementHeading("altText").contains("Required").should("not.exist");
+      });
+      it("should display the alt text as too long", () => {
+        addImageElement();
+        typeIntoElementField("altText", "text ".repeat(25));
+        getElementHeading("altText").contains("Too long").should("exist");
+      });
+      it("should update the alt text validation", () => {
+        addImageElement();
+        typeIntoElementField("altText", "a");
+        getElementHeading("altText").contains("Required").should("not.exist");
+        typeIntoElementField("altText", "{backspace}");
+        getElementHeading("altText").contains("Required").should("exist");
       });
     });
   });

--- a/src/editorial-source-components/FieldWrapper.tsx
+++ b/src/editorial-source-components/FieldWrapper.tsx
@@ -23,6 +23,7 @@ export const FieldWrapper = <F extends Field<TFieldView<unknown>>>({
 }: Props<F>) => (
   <div className={className}>
     <InputHeading
+      name={field.name}
       headingLabel={headingLabel}
       headingContent={headingContent}
       description={description}

--- a/src/editorial-source-components/InputHeading.tsx
+++ b/src/editorial-source-components/InputHeading.tsx
@@ -18,11 +18,14 @@ const Heading = styled.div`
 const Errors = ({ errors }: { errors: string[] }) =>
   !errors.length ? null : <Error>{errors.join(", ")}</Error>;
 
+export const getFieldHeadingTestId = (name: string) => `FieldHeading-${name}`;
+
 type Props = {
   headingLabel: React.ReactNode;
   headingContent: React.ReactNode;
   description?: React.ReactNode;
   errors: string[];
+  name: string;
 };
 
 export const InputHeading = ({
@@ -30,8 +33,9 @@ export const InputHeading = ({
   headingContent,
   description,
   errors,
+  name,
 }: Props) => (
-  <InputHeadingContainer>
+  <InputHeadingContainer data-cy={getFieldHeadingTestId(name)}>
     <Heading>
       <Label>{headingLabel}</Label>
       {headingContent}

--- a/src/plugin/__tests__/plugin.spec.tsx
+++ b/src/plugin/__tests__/plugin.spec.tsx
@@ -82,17 +82,17 @@ describe("createPlugin", () => {
       );
     });
 
-    it("should update the consumer and FieldView and when the element content has changed", () => {
+    it("should call the consumer and FieldView when the element content has changed", () => {
       const { view, exampleText } = createEditorWithSingleElementPresent();
 
       const initialConsumerUpdateCount = consumerRenderSpy.mock.calls.length;
       const initialFieldViewUpdateCount = fieldViewRenderSpy.mock.calls.length;
 
       // This edit falls inside of the element, replacing its content
-      const positionInsideElement = 5;
+      const positionInsideElement = 2;
       const tr = view.state.tr.replaceWith(
         positionInsideElement,
-        positionInsideElement,
+        positionInsideElement + 15,
         exampleText
       );
       view.dispatch(tr);
@@ -103,6 +103,23 @@ describe("createPlugin", () => {
       expect(fieldViewRenderSpy.mock.calls.length).toBe(
         initialFieldViewUpdateCount + 1
       );
+    });
+
+    it("the consumer should receive the new field values when element content has changed", () => {
+      const { view, exampleText } = createEditorWithSingleElementPresent();
+
+      // This edit falls inside of the element, replacing its content
+      const positionInsideElement = 2;
+      const tr = view.state.tr.replaceWith(
+        positionInsideElement,
+        positionInsideElement + 15,
+        exampleText
+      );
+      view.dispatch(tr);
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access -- waive type for mock
+      const newFieldValues = consumerRenderSpy.mock.calls.pop()[0];
+      expect(newFieldValues).toEqual({ field1: "New content" });
     });
   });
 

--- a/src/plugin/__tests__/plugin.spec.tsx
+++ b/src/plugin/__tests__/plugin.spec.tsx
@@ -88,11 +88,11 @@ describe("createPlugin", () => {
       const initialConsumerUpdateCount = consumerRenderSpy.mock.calls.length;
       const initialFieldViewUpdateCount = fieldViewRenderSpy.mock.calls.length;
 
-      // This edit falls inside of the element, replacing its content
-      const positionInsideElement = 2;
+      // This edit falls inside of the element, inserting new content
+      const positionInsideElement = 5;
       const tr = view.state.tr.replaceWith(
         positionInsideElement,
-        positionInsideElement + 15,
+        positionInsideElement,
         exampleText
       );
       view.dispatch(tr);
@@ -105,10 +105,10 @@ describe("createPlugin", () => {
       );
     });
 
-    it("the consumer should receive the new field values when element content has changed", () => {
+    it("should provide the consumer with new field values when element content has changed", () => {
       const { view, exampleText } = createEditorWithSingleElementPresent();
 
-      // This edit falls inside of the element, replacing its content
+      // This edit covers the whole of the element field, replacing its content
       const positionInsideElement = 2;
       const tr = view.state.tr.replaceWith(
         positionInsideElement,

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -173,8 +173,8 @@ const createNodeView = <
 
         // Only recalculate our field values if our node content has changed.
         const newFieldValues = fieldValuesChanged
-          ? currentValues
-          : getFieldValuesFromNode(fields, node);
+          ? getFieldValuesFromNode(fields, node)
+          : currentValues;
 
         // Only update our FieldViews if their content or decorations have changed.
         if (fieldValuesChanged || innerDecosChanged) {


### PR DESCRIPTION
## What does this change?
This PR fixes a small bug which was causing sub-optimal performance and also a validation bug. The validation bug would manifest as a delay between changes being made to content and the validation updating. I.e. in a required field adding a single character wouldn't set the state to valid, you would then have to make an additional edit to the element.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Make changes to elements which would cause it to be come valid or invalid, ensure that these validation warnings displayed when intended.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

![image](https://user-images.githubusercontent.com/4633246/149493974-220de074-dfd2-4cfa-988f-0212ee3a304c.png)

