### PR TITLE
fix: Reintroduce deserialisation to HTML for required or length checks

### DIFF
--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -66,8 +66,10 @@ export const htmlMaxLength = (
       },
     ];
   }
-  const strWithoutHtml = removeHTMLFromStr(value);
-  const length = strWithoutHtml.length;
+
+  const el = document.createElement("div");
+  el.innerHTML = value ?? "";
+  const length = el.innerText.length;
   if (length > maxLength) {
     return [
       {
@@ -124,8 +126,9 @@ export const htmlRequired = (
       },
     ];
   }
-  const strWithoutHtml = removeHTMLFromStr(value);
-  if (!strWithoutHtml.length) {
+  const el = document.createElement("div");
+  el.innerHTML = value ?? "";
+  if (!el.innerText.length) {
     return [
       {
         error: "Required",
@@ -162,11 +165,4 @@ export const required = (
     ];
   }
   return [];
-};
-
-const removeHTMLFromStr = (str: string | undefined) => {
-  // At the moment, we don't remove HTML – it's proved too costly to strip
-  // html with .innerHTML parsing on the fly in large documents. If we find
-  // a fast solution, we can revisit this.
-  return str ?? "";
 };


### PR DESCRIPTION
## What does this change?

This PR Reverts guardian/prosemirror-elements#148. This is because we now perform our validation more [efficiently within Composer](https://github.com/guardian/flexible-content/pull/3929), this should allow us to include the original less performant deserialising HTML checks without compromising our application.

## How to test

Does the validation still work as expected? Does linking the package to Composer result in performance issues?

