### PR TITLE
feat: add target _blank behaviour to open in new tab

### DIFF
--- a/src/elements/rich-link/RichlinkForm.tsx
+++ b/src/elements/rich-link/RichlinkForm.tsx
@@ -19,7 +19,10 @@ export const RichlinkElementForm: React.FunctionComponent<Props> = ({
 }) => (
   <FieldLayoutVertical>
     <div>
-      Related: <a href={fieldValues.url}>{fieldValues.linkText}</a>
+      Related:{" "}
+      <a target="_blank" href={fieldValues.url}>
+        {fieldValues.linkText}
+      </a>
     </div>
     <CustomDropdownView
       field={fields.weighting}


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
At the moment the rich-link element does not open the depressed hyperlink in a new tab/window.
This simple PR adds the behaviour to open the selected hyperlink to replicate the current rich-link element in Composer
## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run locally or in code and add a rich-link - trying to click on the link to see the behaviour
