### PR TITLE
feat: Adds Yalc package script

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,8 @@ We've found yalc useful in testing local changes to prosemirror-elements in appl
 Setup: 
 
 1. Install `yalc` globally with `npm i yalc -g` or `yarn global add yalc`
-2. Run `yarn build` in your local project from your current branch
-3. Run `yalc publish` in the same directory
-4. Run `yalc add @guardian/<project>`  of your local project.
+2. Run `yarn yalc` in your local project from your current branch
+3. Run `yalc add @guardian/<project>`  of your local project.
 
 Note: any changes you make to your local prosemirror-elements branch must be republished (step 3). 
 Dont forget to run `yarn build`!

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:unit": "jest",
     "ci": "yarn lint && yarn test:unit && (webpack serve & (wait-on http://localhost:7890 && cypress run))",
     "postci": "kill $(lsof -t -i:7890)",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "yalc": "yarn build && yalc push"
   },
   "dependencies": {
     "@emotion/core": "^11.0.0",


### PR DESCRIPTION
## What does this change?
This PR adds a convenience script for creating a new build and distributing it locally via `yalc`. This should make it easier to work. 

I decided this would be a useful addition after being caught-out by publishing the package without first creating a local build meaning my changes weren't reflected in the consuming project.

## How to test
Does running `yarn yalc` create a new build of the package and distribute it via yalc?
