### PR TITLE
fix: Fixes small crop, role setting bug

### DIFF
--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import { space } from "@guardian/src-foundations";
 import { SvgCamera } from "@guardian/src-icons";
 import { Column, Columns } from "@guardian/src-layout";
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import { Button } from "../../editorial-source-components/Button";
 import { Error } from "../../editorial-source-components/Error";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
@@ -187,9 +187,7 @@ const ImageView = ({
       assets,
       suppliersReference,
     });
-    if (minAssetValidation({ assets }, "").length) {
-      updateRole(thumbnailOption.value);
-    }
+
     if (previousMediaId && previousMediaId !== mediaId) {
       updateFields(mediaPayload);
     }
@@ -214,6 +212,12 @@ const ImageView = ({
       .sort(sortByWidthDifference);
 
     return sortedAssets.length > 0 ? sortedAssets[0].url : undefined;
+  }, [imageFields.assets]);
+
+  useEffect(() => {
+    if (minAssetValidation({ assets: imageFields.assets }, "").length) {
+      updateRole(thumbnailOption.value);
+    }
   }, [imageFields.assets]);
 
   return (


### PR DESCRIPTION
## What does this change?
This PR fixes an issue with the "role" filed not being correctly set for images with small assets. Prior to this PR, the role setting would remain as the default until the element crop was changed. This meant if you added an image with small assets, the role would be incorrectly set but still display the weighting as "thumbnail". 

This PR fixes the issues by checking asset changes (including when a new image element is added) and sets the role to "thumbnail" if they are too small. This is done by using a `useEffect` in the `ImageView` component. 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Add an image with dimensions less than 460 pixel to the sandbox environment. Use the ProseMirror dev tools to confirm the role is correct set to "thumbnail".