### PR TITLE
fix: Fix the thumbnail update issue

### DIFF
--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import { space } from "@guardian/src-foundations";
 import { SvgCamera } from "@guardian/src-icons";
 import { Column, Columns } from "@guardian/src-layout";
-import React, { useEffect, useMemo } from "react";
+import React, { useMemo } from "react";
 import { Button } from "../../editorial-source-components/Button";
 import { Error } from "../../editorial-source-components/Error";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
@@ -188,6 +188,10 @@ const ImageView = ({
       suppliersReference,
     });
 
+    if (minAssetValidation({ assets }, "").length) {
+      updateRole(thumbnailOption.value);
+    }
+
     if (previousMediaId && previousMediaId !== mediaId) {
       updateFields(mediaPayload);
     }
@@ -212,12 +216,6 @@ const ImageView = ({
       .sort(sortByWidthDifference);
 
     return sortedAssets.length > 0 ? sortedAssets[0].url : undefined;
-  }, [imageFields.assets]);
-
-  useEffect(() => {
-    if (minAssetValidation({ assets: imageFields.assets }, "").length) {
-      updateRole(thumbnailOption.value);
-    }
   }, [imageFields.assets]);
 
   return (

--- a/src/elements/image/imageElementDataTransformer.ts
+++ b/src/elements/image/imageElementDataTransformer.ts
@@ -2,7 +2,11 @@ import pickBy from "lodash/pickBy";
 import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
 import type { TransformIn, TransformOut } from "../helpers/types/Transform";
 import type { Asset, createImageFields, MainImageData } from "./ImageElement";
-import { undefinedDropdownValue } from "./ImageElement";
+import {
+  minAssetValidation,
+  thumbnailOption,
+  undefinedDropdownValue,
+} from "./ImageElement";
 
 export type ImageFields = {
   alt?: string;
@@ -48,9 +52,15 @@ export const transformElementIn: TransformIn<
     mediaApiUri,
   };
 
+  let newRole = role;
+
+  if (minAssetValidation({ assets }, "").length) {
+    newRole = thumbnailOption.value;
+  }
+
   return {
     displayCredit: displayCredit === "true",
-    role: role ?? undefinedDropdownValue,
+    role: newRole ?? undefinedDropdownValue,
     mainImage,
     ...rest,
   };


### PR DESCRIPTION
_co-authored-by: @SHession_ 

## What does this change?

Our current implementation of the thumbnail constraint logic violates a lifecycle constraint under certain conditions in our rich text editor. This switches to another implementation that shouldn't be able to produce this bug.

## How to test

- Does the image addition/recrop behaviour behave as expected?
- Does the bug still exist in our CMS?

Tested w/ @SHession in Composer:

- initial image is too small
- recrop is too small
- regular image