### PR TITLE
feat: add default to text fields for rich-link

### DIFF
--- a/src/elements/helpers/defaultTransform.ts
+++ b/src/elements/helpers/defaultTransform.ts
@@ -4,7 +4,7 @@ import type { TransformIn, TransformOut } from "./types/Transform";
 
 type FlexibleModelElement<FDesc extends FieldDescriptions<string>> = {
   fields: Partial<Omit<FieldNameToValueMap<FDesc>, "assets">> & {
-    isMandatory?: boolean;
+    isMandatory?: string;
   };
   assets?: string[];
 };
@@ -34,13 +34,15 @@ export const transformElementDataOut = <
 
   return {
     ...baseFields,
-    fields: { ...fields, isMandatory },
+    fields: { ...fields, isMandatory: isMandatory ? "true" : "false" },
   };
 };
 
-export const transformElement = <FDesc extends FieldDescriptions<string>>() => {
+export const transformElement = <FDesc extends FieldDescriptions<string>>(
+  isMandatory?: boolean
+) => {
   return {
     in: transformElementDataIn<FDesc>(),
-    out: transformElementDataOut<FDesc>(),
+    out: transformElementDataOut<FDesc>(isMandatory),
   };
 };

--- a/src/elements/helpers/transform.ts
+++ b/src/elements/helpers/transform.ts
@@ -10,7 +10,7 @@ const transformMap = {
   embed: embedElementTransform,
   image: imageElementTransform,
   pullquote: defaultElementTransform<typeof pullquoteFields>(),
-  "rich-link": defaultElementTransform<typeof richlinkFields>(),
+  "rich-link": defaultElementTransform<typeof richlinkFields>(true),
 } as const;
 
 type TransformMap = typeof transformMap;

--- a/src/elements/rich-link/RichlinkForm.tsx
+++ b/src/elements/rich-link/RichlinkForm.tsx
@@ -25,7 +25,7 @@ export const RichlinkElementForm: React.FunctionComponent<Props> = ({
       </a>
     </div>
     <CustomDropdownView
-      field={fields.weighting}
+      field={fields.role}
       label="Weighting"
       errors={errors.weighting}
       display="inline"

--- a/src/elements/rich-link/RichlinkSpec.tsx
+++ b/src/elements/rich-link/RichlinkSpec.tsx
@@ -6,11 +6,10 @@ import { RichlinkElementForm } from "./RichlinkForm";
 
 export const richlinkFields = {
   linkText: createTextField(),
-  weighting: createCustomDropdownField("thumbnail", [
+  role: createCustomDropdownField("thumbnail", [
     { text: "thumbnail", value: "thumbnail" },
     { text: "supporting", value: "supporting" },
   ]),
-  role: createTextField(),
   url: createTextField(),
   originalUrl: createTextField(),
   linkPrefix: createTextField(),


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR is specifically concerned with ensuring the JSON API for the rich-link element fields are in line with the original/old element. 
We have chosen to add the `isMandatory: "true"` as part of the default transform step as opposed to the `RichLinkSpec`.

In addition a minor change for Weighting to be processed as the field `role` but to remain with the label weighting in the UI. 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Best tested using the `yarn yalc` command and then updating flexible-content with the command `yalc add @guardian/prosemirror-elements`

Check: `https://composer.local.dev-gutools.co.uk/` and try switching the Feature Switch on/off to create the rich-link element

For an adequete rich link to work in Local/code use : `http://www.code.dev-theguardian.com/football/blog/2017/nov/16/world-cup-russia-power-rankings-32-qualifiers`
## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Checking the Network response of the `devMode=true` to check the fields include the appropriate shape and values:
```json
fields: {linkPrefix: "Related: ",…}
isMandatory: "true"
linkPrefix: "Related: "
linkText: "World Cup power rankings: how the 32 qualifiers for Russia shape up | Ed Aarons"
originalUrl: "http://www.code.dev-theguardian.com/football/blog/2017/nov/16/world-cup-russia-power-rankings-32-qualifiers"
role: ""
url: "http://www.code.dev-theguardian.com/football/blog/2017/nov/16/world-cup-russia-power-rankings-32-qualifiers"
```
## Images
Before Fix:
![image](https://user-images.githubusercontent.com/49187886/150790051-0850705c-8ed7-4b45-8e40-8ab4b24b8a1c.png)

After Fix:
![image](https://user-images.githubusercontent.com/49187886/150791685-69585a6a-954f-479d-8d1d-5ef239c3b588.png)

