### PR TITLE
feat: Add state management and UI for selected Elements

### DIFF
--- a/src/editorial-source-components/Button.tsx
+++ b/src/editorial-source-components/Button.tsx
@@ -6,6 +6,7 @@ import React from "react";
 export const buttonStyles = css`
   font-family: "Guardian Agate Sans";
   line-height: normal;
+  user-select: none;
 `;
 
 export const Button: React.FunctionComponent<ButtonProps> = ({

--- a/src/editorial-source-components/Description.tsx
+++ b/src/editorial-source-components/Description.tsx
@@ -6,6 +6,7 @@ export const descriptionStyles = css`
   ${textSans.small({ lineHeight: "loose" })}
   font-family: "Guardian Agate Sans";
   display: block;
+  user-select: none;
 `;
 
 export const Description = styled.div`

--- a/src/editorial-source-components/Error.tsx
+++ b/src/editorial-source-components/Error.tsx
@@ -8,6 +8,7 @@ export const errorStyles = css`
   font-family: "Guardian Agate Sans";
   display: block;
   color: ${text.error};
+  user-select: none;
 `;
 
 export const Error = styled.div`

--- a/src/editorial-source-components/Label.tsx
+++ b/src/editorial-source-components/Label.tsx
@@ -6,6 +6,7 @@ export const labelStyles = css`
   ${textSans.small({ fontWeight: "bold", lineHeight: "loose" })}
   font-family: "Guardian Agate Sans";
   display: block;
+  user-select: none;
 `;
 
 export const Label = styled.label`

--- a/src/editorial-source-components/Label.tsx
+++ b/src/editorial-source-components/Label.tsx
@@ -6,7 +6,6 @@ export const labelStyles = css`
   ${textSans.small({ fontWeight: "bold", lineHeight: "loose" })}
   font-family: "Guardian Agate Sans";
   display: block;
-  user-select: none;
 `;
 
 export const Label = styled.label`

--- a/src/plugin/elementSpec.ts
+++ b/src/plugin/elementSpec.ts
@@ -9,7 +9,8 @@ import type {
 
 type Subscriber<FDesc extends FieldDescriptions<string>> = (
   fields: FieldNameToValueMap<FDesc>,
-  commands: ReturnType<CommandCreator>
+  commands: ReturnType<CommandCreator>,
+  isSelected: boolean
 ) => void;
 
 type Updater<FDesc extends FieldDescriptions<string>> = {
@@ -25,7 +26,7 @@ const createUpdater = <
     subscribe: (fn) => {
       sub = fn;
     },
-    update: (fields, commands) => sub(fields, commands),
+    update: (fields, commands, isSelected) => sub(fields, commands, isSelected),
   };
 };
 
@@ -58,12 +59,7 @@ export type Renderer<FDesc extends FieldDescriptions<string>> = (
   updateState: (fields: FieldNameToValueMap<FDesc>) => void,
   fieldValues: FieldNameToValueMap<FDesc>,
   commands: Commands,
-  subscribe: (
-    fn: (
-      fields: FieldNameToValueMap<FDesc>,
-      commands: ReturnType<CommandCreator>
-    ) => void
-  ) => void
+  subscribe: (fn: Subscriber<FDesc>) => void
 ) => void;
 
 export const createElementSpec = <FDesc extends FieldDescriptions<string>>(

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -7,8 +7,10 @@ import type { FieldDescription, FieldDescriptions } from "./types/Element";
 
 // An attribute added to Element nodes to identify them as such.
 export const elementNodeAttr = "isProseMirrorElement";
+export const elementSelectedNodeAttr = "isSelected";
 
 export const elementTypeAttr = "pme-element-type";
+export const elementSelectedAttr = "pme-element-selected";
 export const fieldNameAttr = "pme-field-name";
 
 export const getNodeSpecFromFieldDescriptions = <
@@ -45,6 +47,7 @@ const getNodeSpecForElement = (
     ).join(" "),
     attrs: {
       [elementNodeAttr]: { default: true },
+      [elementSelectedNodeAttr]: { default: false },
       type: nodeName,
       // Used to determine which nodes should receive update decorations, which force them to update when the document changes. See `createUpdateDecorations` in prosemirror.ts.
       addUpdateDecoration: { default: true },
@@ -305,3 +308,6 @@ export const getElementNameFromNode = (node: Node) =>
 
 export const isProseMirrorElement = (node: Node): boolean =>
   node.attrs[elementNodeAttr] === true;
+
+export const isProseMirrorElementSelected = (node: Node): boolean =>
+  node.attrs[elementSelectedNodeAttr] === true;

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -71,24 +71,18 @@ export const createPlugin = <
         }
       );
 
+      // Update every relevant node with the new selection state.
       newState.doc.descendants((node, pos) => {
-        // Update nodes representing any elements that are no longer selected.
-        if (isProseMirrorElementSelected(node) && !elementNodeToPos.get(node)) {
+        const isCurrentlySelected = elementNodeToPos.get(node) !== undefined;
+        const shouldUpdateNode =
+          (isProseMirrorElementSelected(node) && !isCurrentlySelected) ||
+          (!isProseMirrorElementSelected(node) && isCurrentlySelected);
+
+        if (shouldUpdateNode) {
           tr.setNodeMarkup(pos, undefined, {
             ...node.attrs,
-            [elementSelectedNodeAttr]: false,
+            [elementSelectedNodeAttr]: isCurrentlySelected,
           });
-
-          return false;
-        }
-
-        // Update nodes representing any elements that are now selected.
-        if (elementNodeToPos.get(node) !== undefined) {
-          const newAttrs = {
-            ...node.attrs,
-            [elementSelectedNodeAttr]: true,
-          };
-          tr.setNodeMarkup(pos, undefined, newAttrs);
 
           return false;
         }

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -72,21 +72,25 @@ export const createPlugin = <
       );
 
       newState.doc.descendants((node, pos) => {
+        // Update nodes representing any elements that are no longer selected.
         if (isProseMirrorElementSelected(node) && !elementNodeToPos.get(node)) {
-          // Update nodes representing any elements that are no longer selected.
           tr.setNodeMarkup(pos, undefined, {
             ...node.attrs,
             [elementSelectedNodeAttr]: false,
           });
 
           return false;
-        } else if (elementNodeToPos.get(node)) {
-          // Update nodes representing any elements that are now selected.
+        }
+
+        // Update nodes representing any elements that are now selected.
+        if (elementNodeToPos.get(node) !== undefined) {
           const newAttrs = {
             ...node.attrs,
             [elementSelectedNodeAttr]: true,
           };
           tr.setNodeMarkup(pos, undefined, newAttrs);
+
+          return false;
         }
       });
 

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -83,7 +83,10 @@ export const createPlugin = <
             ...node.attrs,
             [elementSelectedNodeAttr]: isCurrentlySelected,
           });
+        }
 
+        // Do not descend into element nodes.
+        if (isProseMirrorElement(node)) {
           return false;
         }
       });

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -74,12 +74,11 @@ export const createPlugin = <
       // Update nodes representing any elements that are no longer selected.
       newState.doc.descendants((node, pos) => {
         if (isProseMirrorElementSelected(node) && !elementNodeToPos.get(node)) {
-          if (node.attrs[elementSelectedNodeAttr] === true) {
-            tr.setNodeMarkup(pos, undefined, {
-              ...node.attrs,
-              [elementSelectedNodeAttr]: false,
-            });
-          }
+          tr.setNodeMarkup(pos, undefined, {
+            ...node.attrs,
+            [elementSelectedNodeAttr]: false,
+          });
+
           return false;
         }
       });

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -71,28 +71,23 @@ export const createPlugin = <
         }
       );
 
-      // Update nodes representing any elements that are no longer selected.
       newState.doc.descendants((node, pos) => {
         if (isProseMirrorElementSelected(node) && !elementNodeToPos.get(node)) {
+          // Update nodes representing any elements that are no longer selected.
           tr.setNodeMarkup(pos, undefined, {
             ...node.attrs,
             [elementSelectedNodeAttr]: false,
           });
 
           return false;
+        } else if (elementNodeToPos.get(node)) {
+          // Update nodes representing any elements that are now selected.
+          const newAttrs = {
+            ...node.attrs,
+            [elementSelectedNodeAttr]: true,
+          };
+          tr.setNodeMarkup(pos, undefined, newAttrs);
         }
-      });
-
-      // Update nodes representing any elements that are now selected.
-      elementNodeToPos.forEach((pos, node) => {
-        if (node.attrs[elementSelectedNodeAttr] === true) {
-          return;
-        }
-        const newAttrs = {
-          ...node.attrs,
-          [elementSelectedNodeAttr]: true,
-        };
-        tr.setNodeMarkup(pos, undefined, newAttrs);
       });
 
       return tr;

--- a/src/plugin/types/Element.ts
+++ b/src/plugin/types/Element.ts
@@ -88,7 +88,8 @@ export type ElementSpec<FDesc extends FieldDescriptions<string>> = {
     commands: ReturnType<CommandCreator>
   ) => (
     fields: FieldNameToValueMap<FDesc>,
-    commands: ReturnType<CommandCreator>
+    commands: ReturnType<CommandCreator>,
+    isSelected: boolean
   ) => void;
 };
 

--- a/src/renderers/react/ElementProvider.tsx
+++ b/src/renderers/react/ElementProvider.tsx
@@ -27,7 +27,11 @@ const fieldErrors = <FDesc extends FieldDescriptions<string>>(
 
 type IProps<FDesc extends FieldDescriptions<string>> = {
   subscribe: (
-    fn: (fields: FieldNameToValueMap<FDesc>, commands: Commands) => void
+    fn: (
+      fields: FieldNameToValueMap<FDesc>,
+      commands: Commands,
+      isSelected: boolean
+    ) => void
   ) => void;
   commands: Commands;
   fieldValues: FieldNameToValueMap<FDesc>;
@@ -40,6 +44,7 @@ type IProps<FDesc extends FieldDescriptions<string>> = {
 type IState<FDesc extends FieldDescriptions<string>> = {
   commands: Commands;
   fieldValues: FieldNameToValueMap<FDesc>;
+  isSelected: boolean;
 };
 
 export class ElementProvider<
@@ -53,15 +58,17 @@ export class ElementProvider<
     this.state = {
       commands: this.props.commands,
       fieldValues: this.props.fieldValues,
+      isSelected: false,
     };
   }
 
   public componentDidMount() {
-    this.props.subscribe((fieldValues, commands) =>
+    this.props.subscribe((fieldValues, commands, isSelected) =>
       this.updateState(
         {
           commands,
           fieldValues,
+          isSelected,
         },
         false
       )
@@ -93,7 +100,10 @@ export class ElementProvider<
 
   public render() {
     return (
-      <ElementWrapper {...this.state.commands}>
+      <ElementWrapper
+        {...this.state.commands}
+        isSelected={this.state.isSelected}
+      >
         <this.Element
           fields={this.props.fields}
           fieldValues={this.state.fieldValues}

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { space } from "@guardian/src-foundations";
 import { focusHalo } from "@guardian/src-foundations/accessibility";
-import { border, neutral } from "@guardian/src-foundations/palette";
+import { background, border, neutral } from "@guardian/src-foundations/palette";
 import {
   SvgArrowDownStraight,
   SvgArrowUpStraight,
@@ -35,8 +35,9 @@ const Body = styled("div")`
   min-height: 134px;
 `;
 
-const Panel = styled("div")`
-  background: ${neutral[97]};
+const Panel = styled("div")<{ isSelected: boolean }>`
+  background-color: ${({ isSelected }) =>
+    isSelected ? background.ctaSecondary : neutral[97]};
   flex-grow: 1;
   overflow: hidden;
   padding: ${space[3]}px;
@@ -158,6 +159,7 @@ const LeftActions = styled(Actions)`
 
 type Props = {
   children?: ReactElement;
+  isSelected: boolean;
 } & ReturnType<CommandCreator>;
 
 export const elementWrapperTestId = "ElementWrapper";
@@ -173,6 +175,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
   moveTop,
   moveBottom,
   remove,
+  isSelected,
   children,
 }) => {
   const [closeClickedOnce, setCloseClickedOnce] = useState(false);
@@ -203,7 +206,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
             {closeClickedOnce && <Tooltip>Click again to confirm</Tooltip>}
           </SeriousButton>
         </LeftActions>
-        <Panel>{children}</Panel>
+        <Panel isSelected={isSelected}>{children}</Panel>
         <RightActions className="actions">
           <Button
             type="button"

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { space } from "@guardian/src-foundations";
 import { focusHalo } from "@guardian/src-foundations/accessibility";
-import { background, border, neutral } from "@guardian/src-foundations/palette";
+import { border, neutral } from "@guardian/src-foundations/palette";
 import {
   SvgArrowDownStraight,
   SvgArrowUpStraight,
@@ -37,7 +37,7 @@ const Body = styled("div")`
 
 const Panel = styled("div")<{ isSelected: boolean }>`
   background-color: ${({ isSelected }) =>
-    isSelected ? background.ctaSecondary : neutral[97]};
+    isSelected ? "#b3d7fe" : neutral[97]};
   flex-grow: 1;
   overflow: hidden;
   padding: ${space[3]}px;


### PR DESCRIPTION
## What does this change?

Adds a selected state to the element node attributes, and surfaces this state in our renderer to allow the UI to respond.

Before:

https://user-images.githubusercontent.com/7767575/150793398-c17e6c17-ec19-4366-a7ab-7cb22d9f6b07.mov

After (updated to reflect `user-select: none`):

https://user-images.githubusercontent.com/7767575/151000747-2ec0b7d8-b4e4-4e46-8b1c-29e54b0daa44.mov

### Why is that hardcoded highlight colour not in Source?

I've based it on the Chrome and Firefox selection colour for now 😅 we could pass it in on element creation if we really wanted to provide a way to customise, or perhaps there's another way to do it.

Incidentally, Chrome will automagically change the highlight colour when there's no contrast with the background colour, hence selection outlines showing in the labels and validation. We _could_ remove those with `user-select: none` for aesthetic reasons, but that means people can't copy/paste these labels/validation warnings, and I'm reluctant to restrict that unless there's a good reason – maybe there is!

## Developer notes.

There's a decision to make as to where to store the state that marks a node as selected:

 1. **Storing state in the nodes directly** gives us a single source of truth, but means we must check the document each time a selection changes and update nodes accordingly.
 2. **Storing state in the PME plugin** makes it easier to keep track of which nodes are selected in a way which doesn't require us to recurse through the document to check, but also gives us an opportunity to introduce bugs if that state became our of sync with our document.

I tried 1. first, and it turned out to be pretty quick, so I don't think there's a concern. Because we can short-circuit our evaluation of the document tree every time we encounter an element node, even very large documents don't present a problem. I profiled the `appendTransaction` function with a document containing 150 elements (far more than we'd be likely to experience in an actual document, there are almost a thousand fields being managed here). The iteration count is the number of times we're calling into callbacks passed into `descendants` or similar:

<img width="283" alt="Screenshot 2022-01-24 at 08 33 12" src="https://user-images.githubusercontent.com/7767575/150793615-fa12e75a-161c-45f2-b204-da88b14bb874.png">


## How to test

- The automated tests should pass, and they should be reasonably comprehensive. I've tried to cover a few edge cases WRT rerenders.
- Try this locally. Does it behave itself with content and elements of different kinds?

## How can we measure success?

A clearer indication that an element is part of a user selection.
