### PR TITLE
feat: Remove Preview height limit

### DIFF
--- a/src/elements/helpers/Preview.tsx
+++ b/src/elements/helpers/Preview.tsx
@@ -33,18 +33,13 @@ export const Preview = ({
   ...rest
 }: PreviewProps) => {
   const [height, setHeight] = useState("0px");
-  const [resize, setResize] = useState(false);
   const ref = useRef<HTMLIFrameElement>(null);
-  const maxHeight = 120; // In px
 
   const updateIframeHeight = () => {
     const heightOfContent = getDocHeight(ref.current?.contentWindow?.document);
-    if (heightOfContent && heightOfContent < maxHeight) {
+    if (heightOfContent) {
       setHeight((heightOfContent + 4).toString() + "px");
-    } else if (heightOfContent && heightOfContent > maxHeight) {
-      setHeight(maxHeight.toString() + "px");
-      setResize(true);
-    } else setResize(false);
+    }
   };
 
   const onLoad = () => {
@@ -55,7 +50,6 @@ export const Preview = ({
   };
 
   const iframe = css`
-    resize: ${resize || iframeUrl ? "vertical" : "none"};
     background-color: white;
     width: 100%;
     font-family: sans-serif;

--- a/src/elements/helpers/Preview.tsx
+++ b/src/elements/helpers/Preview.tsx
@@ -17,8 +17,6 @@ const getDocHeight = (doc: Document | undefined) => {
     const height = Math.max(
       body.scrollHeight,
       body.offsetHeight,
-      html.clientHeight,
-      html.scrollHeight,
       html.offsetHeight
     );
     return height;


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
The Preview used by Embed element had a max height set, after which the Preview could be manually resized, but would not automatically expand.

However, we have decided to remove the limit in order to be consistent with the existing element. The height taken up by embed previews has not been raised as a problem by our users, so we feel it is probably not worth adding the functionality.

| Before | After |
|---|---|
| ![2022-01-25 15 15 13](https://user-images.githubusercontent.com/34686302/151004354-10677277-acc6-44a1-b1fe-d636b12cd3ce.gif) | ![2022-01-25 15 14 17](https://user-images.githubusercontent.com/34686302/151004374-3cf4d5b8-790d-4da9-b55b-4ffbf7b3b373.gif) |

(n.b. Other differences here are down to differences between Composer CODE (left) and the `prosemirror-elements` demo (right)).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Run this project locally via `yarn start` and test the embed element in the demo.