### PR TITLE
fix: Make alt, caption and url optional for embed, add isSafe field

### DIFF
--- a/src/elements/embed/embedComponents/__tests__/embedDataTransformer.spec.ts
+++ b/src/elements/embed/embedComponents/__tests__/embedDataTransformer.spec.ts
@@ -1,0 +1,156 @@
+import type { FieldNameToValueMap } from "../../../../plugin/helpers/fieldView";
+import { undefinedDropdownValue } from "../../../helpers/transform";
+import type { ExternalEmbedFields } from "../../embedDataTransformer";
+import { transformElement } from "../../embedDataTransformer";
+import type { createEmbedFields } from "../../EmbedSpec";
+
+const partialPmeElement = (
+  data: Partial<FieldNameToValueMap<ReturnType<typeof createEmbedFields>>> = {}
+): Partial<FieldNameToValueMap<ReturnType<typeof createEmbedFields>>> => {
+  return {
+    alt: undefined,
+    caption: undefined,
+    role: "none-selected",
+    html: undefined,
+    url: undefined,
+    isMandatory: false,
+    ...data,
+  };
+};
+
+const fullPmeElement = (
+  data: Partial<FieldNameToValueMap<ReturnType<typeof createEmbedFields>>> = {}
+): FieldNameToValueMap<ReturnType<typeof createEmbedFields>> => {
+  return {
+    alt: "",
+    caption: "",
+    role: "none-selected",
+    html: "",
+    url: "",
+    isMandatory: false,
+    ...data,
+  };
+};
+
+const externalElement = (data: Partial<ExternalEmbedFields> = {}) => {
+  return {
+    fields: {
+      html: "",
+      isMandatory: "false",
+      isSafe: "false",
+      role: undefined,
+      ...data,
+    },
+  };
+};
+
+describe("embed element transform", () => {
+  describe("transformIn", () => {
+    it("should not allow elements which are the wrong type", () => {
+      // @ts-expect-error -- we should not be able to transform a malformed element
+      expect(() => transformElement.in({})).toThrow;
+      expect(() =>
+        transformElement.in({
+          // @ts-expect-error -- we should not be able to transform a malformed element
+          fields: { nonExistantField: "123" },
+        })
+      ).toThrow;
+    });
+    it("should partially transform elements with no fields", () => {
+      const element = { fields: {} };
+      const result = transformElement.in(element);
+      expect(result).toEqual(partialPmeElement());
+    });
+
+    it("should partially transform elements with some fields", () => {
+      const altText = "alt text";
+      const element = {
+        fields: { alt: altText, isMandatory: "true" },
+      };
+      const result = transformElement.in(element);
+      expect(result).toEqual(
+        partialPmeElement({ alt: altText, isMandatory: true })
+      );
+    });
+    it("should convert undefined dropdown to undefined string", () => {
+      const element = {
+        fields: { role: undefined },
+      };
+      const result = transformElement.in(element);
+      expect(result).toEqual(
+        partialPmeElement({ role: undefinedDropdownValue })
+      );
+    });
+    it("should not convert regular dropdown strings", () => {
+      const element = {
+        fields: { role: "showcase" },
+      };
+      const result = transformElement.in(element);
+      expect(result).toEqual(partialPmeElement({ role: "showcase" }));
+    });
+    it("should convert isMandatory to boolean", () => {
+      const element = {
+        fields: { isMandatory: "false" },
+      };
+      const result = transformElement.in(element);
+      expect(result).toEqual(partialPmeElement({ isMandatory: false }));
+    });
+  });
+
+  describe("transformOut", () => {
+    it("should not allow elements which are the wrong type", () => {
+      // @ts-expect-error -- we should not be able to transform a malformed element
+      expect(() => transformElement.out({})).toThrow;
+      expect(() =>
+        transformElement.out({
+          // @ts-expect-error -- we should not be able to transform a malformed element
+          nonExistantField: "123",
+        })
+      ).toThrow;
+    });
+    it("should completely transform elements with all fields", () => {
+      const element = fullPmeElement();
+      const result = transformElement.out(element);
+      expect(result).toEqual(externalElement());
+    });
+    it("should convert undefined dropdown string to undefined", () => {
+      const element = fullPmeElement({ role: undefinedDropdownValue });
+      const result = transformElement.out(element);
+      expect(result).toEqual(externalElement({ role: undefined }));
+    });
+    it("should not convert regular dropdown strings", () => {
+      const element = fullPmeElement({ role: "showcase" });
+      const result = transformElement.out(element);
+      expect(result).toEqual(externalElement({ role: "showcase" }));
+    });
+    it("should convert isMandatory to string", () => {
+      const element = fullPmeElement({ isMandatory: false });
+      const result = transformElement.out(element);
+      expect(result).toEqual(externalElement({ isMandatory: "false" }));
+    });
+    it("should include optional fields when specified", () => {
+      const element = fullPmeElement({
+        alt: "Alt text",
+        caption: "caption",
+        url: "https://example.com/",
+      });
+      const result = transformElement.out(element);
+      expect(result).toEqual(
+        externalElement({
+          alt: "Alt text",
+          caption: "caption",
+          url: "https://example.com/",
+        })
+      );
+    });
+    it("should not include optional fields when they are empty", () => {
+      const element = fullPmeElement({
+        alt: "",
+        caption: "",
+        url: "",
+      });
+      const result = transformElement.out(element);
+      expect(result).toEqual(externalElement());
+    });
+  });
+});

--- a/src/elements/embed/embedDataTransformer.ts
+++ b/src/elements/embed/embedDataTransformer.ts
@@ -1,15 +1,18 @@
+import pickBy from "lodash/pickBy";
 import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
+import { isHtmlSafe } from "../helpers/html";
 import { undefinedDropdownValue } from "../helpers/transform";
 import type { TransformIn, TransformOut } from "../helpers/types/Transform";
 import type { createEmbedFields } from "./EmbedSpec";
 
 export type ExternalEmbedFields = {
-  alt: string;
-  caption: string;
+  alt?: string;
+  caption?: string;
   html: string;
   isMandatory: string;
-  url: string;
+  url?: string;
   role: string | undefined;
+  isSafe: string;
 };
 
 export type ExternalEmbedData = {
@@ -49,14 +52,24 @@ export const transformElementOut: TransformOut<
 }: FieldNameToValueMap<
   ReturnType<typeof createEmbedFields>
 >): ExternalEmbedData => {
-  return {
-    fields: {
+  const optionalFields = pickBy(
+    {
       alt,
       caption,
+      url,
+    },
+    (field) => field.length > 0
+  );
+
+  const isSafe = isHtmlSafe(html);
+
+  return {
+    fields: {
       html,
       isMandatory: isMandatory.toString(),
-      url,
+      isSafe: isSafe.toString(),
       role: role === undefinedDropdownValue ? undefined : role,
+      ...optionalFields,
     },
   };
 };

--- a/src/elements/embed/embedDataTransformer.ts
+++ b/src/elements/embed/embedDataTransformer.ts
@@ -1,6 +1,6 @@
 import pickBy from "lodash/pickBy";
 import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
-import { isHtmlSafe } from "../helpers/html";
+import { htmlContainsSingleIframe } from "../helpers/html";
 import { undefinedDropdownValue } from "../helpers/transform";
 import type { TransformIn, TransformOut } from "../helpers/types/Transform";
 import type { createEmbedFields } from "./EmbedSpec";
@@ -61,7 +61,7 @@ export const transformElementOut: TransformOut<
     (field) => field.length > 0
   );
 
-  const isSafe = isHtmlSafe(html);
+  const isSafe = htmlContainsSingleIframe(html);
 
   return {
     fields: {

--- a/src/elements/helpers/__tests__/html.spec.ts
+++ b/src/elements/helpers/__tests__/html.spec.ts
@@ -1,4 +1,4 @@
-import { parseHtml, unescapeHtml } from "../html";
+import { htmlContainsSingleIframe, parseHtml, unescapeHtml } from "../html";
 
 describe("unescapeHtml", () => {
   it("should unescape HTML", () => {
@@ -24,5 +24,30 @@ describe("parseHtml", () => {
     const parsedHtml = parseHtml(escapedHtml);
 
     expect(parsedHtml).toEqual(identicalElement);
+  });
+});
+
+describe("htmlContainsSingleIframe", () => {
+  it("should return true for a single iframe", () => {
+    const iframeHtml = "<iframe srcdoc='<div>Hello world</div>'></iframe>";
+
+    const containsSingleIframe = htmlContainsSingleIframe(iframeHtml);
+
+    expect(containsSingleIframe).toEqual(true);
+  });
+  it("should return false for a single iframe alongside another element", () => {
+    const iframeHtml =
+      "<iframe srcdoc='<div>Hello world</div>'></iframe><p>Not an iframe<p>";
+
+    const containsSingleIframe = htmlContainsSingleIframe(iframeHtml);
+
+    expect(containsSingleIframe).toEqual(false);
+  });
+  it("should return false for a single non-iframe element", () => {
+    const iframeHtml = "<p>Not an iframe<p>";
+
+    const containsSingleIframe = htmlContainsSingleIframe(iframeHtml);
+
+    expect(containsSingleIframe).toEqual(false);
   });
 });

--- a/src/elements/helpers/html.ts
+++ b/src/elements/helpers/html.ts
@@ -14,7 +14,7 @@ export const parseHtml = (html: string) => {
   return parsedHtml.body.firstElementChild;
 };
 
-export const isHtmlSafe = (html: string) => {
+export const htmlContainsSingleIframe = (html: string) => {
   const holder = document.createElement("div");
   holder.innerHTML = (html || "").trim();
   const element = holder.firstElementChild;

--- a/src/elements/helpers/html.ts
+++ b/src/elements/helpers/html.ts
@@ -17,8 +17,8 @@ export const parseHtml = (html: string) => {
 export const isHtmlSafe = (html: string) => {
   const holder = document.createElement("div");
   holder.innerHTML = (html || "").trim();
-  const element = holder.children[0];
-  const isIframe = element.tagName === "IFRAME";
-  const singleChild = !element.nextSibling;
+  const element = holder.firstElementChild;
+  const isIframe = !!element && element.tagName === "IFRAME";
+  const singleChild = !!element && !element.nextSibling;
   return isIframe && singleChild;
 };

--- a/src/elements/helpers/html.ts
+++ b/src/elements/helpers/html.ts
@@ -13,3 +13,12 @@ export const parseHtml = (html: string) => {
   );
   return parsedHtml.body.firstElementChild;
 };
+
+export const isHtmlSafe = (html: string) => {
+  const holder = document.createElement("div");
+  holder.innerHTML = (html || "").trim();
+  const element = holder.children[0];
+  const isIframe = element.tagName === "IFRAME";
+  const singleChild = !element.nextSibling;
+  return isIframe && singleChild;
+};


### PR DESCRIPTION
## What does this change?
This PR alters the embed's output, to more closely match the pre-existing setup. The intention is to reduce the chance of downstream bugs caused by a change in behaviour.

The following elements are now optional:
- `alt`
- `caption`
- `url`

There is now also an `isSafe` field. This checks if the html is for a single iframe, replicating a check that came from our [fence](https://github.com/guardian/fence/blob/9448f9a059d3264dfe0b3f3465cbacb498b3ffe9/fence.js#L139) package.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run the unit tests locally with `yarn:test-unit`
