### PR TITLE
feat: Rename all tracking-related variables to use consistent naming

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -103,7 +103,7 @@ const { plugin: elementPlugin, insertElement, nodeSpec } = buildElementPlugin({
   richlinkElement,
   videoElement: createVideoElement({
     createCaptionPlugins,
-    checkEmbedTracking: mockThirdPartyTracking,
+    checkThirdPartyTracking: mockThirdPartyTracking,
   }),
 });
 

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -89,7 +89,7 @@ const { plugin: elementPlugin, insertElement, nodeSpec } = buildElementPlugin({
   "demo-image-element": createDemoImageElement(onSelectImage, onDemoCropImage),
   imageElement,
   embedElement: createEmbedElement({
-    checkEmbedTracking: mockThirdPartyTracking,
+    checkThirdPartyTracking: mockThirdPartyTracking,
     convertTwitter: (src) => console.log(`Add Twitter embed with src: ${src}`),
     convertYouTube: (src) => console.log(`Add youtube embed with src: ${src}`),
     createCaptionPlugins,

--- a/src/elements/embed/EmbedForm.tsx
+++ b/src/elements/embed/EmbedForm.tsx
@@ -7,8 +7,8 @@ import type { FieldNameToField } from "../../plugin/types/Element";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import { Preview } from "../helpers/Preview";
-import type { EmbedStatus } from "../helpers/ThirdPartyStatusChecks";
-import { EmbedStatusChecks } from "../helpers/ThirdPartyStatusChecks";
+import type { TrackingStatus } from "../helpers/ThirdPartyStatusChecks";
+import { TrackingStatusChecks } from "../helpers/ThirdPartyStatusChecks";
 import { EmbedRecommendation } from "./embedComponents/EmbedRecommendations";
 import type { TwitterUrl, YoutubeUrl } from "./embedComponents/embedUtils";
 import type { createEmbedFields } from "./EmbedSpec";
@@ -17,7 +17,7 @@ type Props = {
   fieldValues: FieldNameToValueMap<ReturnType<typeof createEmbedFields>>;
   errors: FieldValidationErrors;
   fields: FieldNameToField<ReturnType<typeof createEmbedFields>>;
-  checkEmbedTracking: (html: string) => Promise<EmbedStatus>;
+  checkThirdPartyTracking: (html: string) => Promise<TrackingStatus>;
   convertYouTube: (src: YoutubeUrl) => void;
   convertTwitter: (src: TwitterUrl) => void;
 };
@@ -28,7 +28,7 @@ export const EmbedElementForm: React.FunctionComponent<Props> = ({
   fieldValues,
   errors,
   fields,
-  checkEmbedTracking,
+  checkThirdPartyTracking,
   convertYouTube,
   convertTwitter,
 }) => (
@@ -69,10 +69,10 @@ export const EmbedElementForm: React.FunctionComponent<Props> = ({
       errors={errors.isMandatory}
       label="This element is required for publication"
     />
-    <EmbedStatusChecks
+    <TrackingStatusChecks
       html={fieldValues.html}
       isMandatory={fieldValues.isMandatory}
-      checkEmbedTracking={checkEmbedTracking}
+      checkThirdPartyTracking={checkThirdPartyTracking}
     />
   </FieldLayoutVertical>
 );

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -9,13 +9,13 @@ import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldVi
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
-import type { EmbedStatus } from "../helpers/ThirdPartyStatusChecks";
+import type { TrackingStatus } from "../helpers/ThirdPartyStatusChecks";
 import { undefinedDropdownValue } from "../helpers/transform";
 import type { TwitterUrl, YoutubeUrl } from "./embedComponents/embedUtils";
 import { EmbedElementForm } from "./EmbedForm";
 
 export type MainEmbedProps = {
-  checkEmbedTracking: (html: string) => Promise<EmbedStatus>;
+  checkThirdPartyTracking: (html: string) => Promise<TrackingStatus>;
   convertYouTube: (src: YoutubeUrl) => void;
   convertTwitter: (src: TwitterUrl) => void;
   createCaptionPlugins?: (schema: Schema) => Plugin[];
@@ -67,7 +67,7 @@ export const createEmbedElement = (props: MainEmbedProps) =>
           fields={fields}
           errors={errors}
           fieldValues={fieldValues}
-          checkEmbedTracking={props.checkEmbedTracking}
+          checkThirdPartyTracking={props.checkThirdPartyTracking}
           convertYouTube={props.convertYouTube}
           convertTwitter={props.convertTwitter}
         />

--- a/src/elements/helpers/ThirdPartyStatusChecks.tsx
+++ b/src/elements/helpers/ThirdPartyStatusChecks.tsx
@@ -9,7 +9,7 @@ import {
   warningColours,
 } from "./messagingStyles";
 
-export type EmbedStatus = {
+export type TrackingStatus = {
   tracking: {
     tracks: string;
   };
@@ -19,20 +19,20 @@ export type EmbedStatus = {
 };
 
 type StatusProps = {
-  embedStatus: EmbedStatus;
+  trackingStatus: TrackingStatus;
 };
 
 type PlatformProps = {
-  embedStatus: EmbedStatus;
+  trackingStatus: TrackingStatus;
   isMandatory: boolean;
 };
 
-const elementDoesTrack = (embedStatus: EmbedStatus): boolean =>
-  embedStatus.tracking.tracks !== "does-not-track";
+const elementDoesTrack = (trackingStatus: TrackingStatus): boolean =>
+  trackingStatus.tracking.tracks !== "does-not-track";
 
 const TrackingChecker = (props: StatusProps) => {
   const centralProduction = "mailto:central.production@guardian.co.uk";
-  return elementDoesTrack(props.embedStatus) ? (
+  return elementDoesTrack(props.trackingStatus) ? (
     <p css={[message, naughtyColours]}>
       <SvgAlertTriangle />
       This element tracks readers, so it may not be visible by default in
@@ -52,12 +52,12 @@ const TrackingChecker = (props: StatusProps) => {
   );
 };
 
-const getUnsupportedPlatforms = (embedStatus: EmbedStatus): string[] =>
-  embedStatus.reach.unsupportedPlatforms;
+const getUnsupportedPlatforms = (trackingStatus: TrackingStatus): string[] =>
+  trackingStatus.reach.unsupportedPlatforms;
 
 const UnsupportedPlatforms = (props: PlatformProps) => {
   const audience = "mailto:audience.global.all@theguardian.com";
-  const unsupportedPlatforms = getUnsupportedPlatforms(props.embedStatus);
+  const unsupportedPlatforms = getUnsupportedPlatforms(props.trackingStatus);
   if (unsupportedPlatforms.length > 0 && props.isMandatory) {
     return (
       <p css={[message, warningColours]}>
@@ -75,21 +75,21 @@ const UnsupportedPlatforms = (props: PlatformProps) => {
   return null;
 };
 
-export const EmbedStatusChecks = ({
+export const TrackingStatusChecks = ({
   html,
   isMandatory,
-  checkEmbedTracking,
+  checkThirdPartyTracking,
 }: {
   html: string;
   isMandatory: boolean;
-  checkEmbedTracking: (html: string) => Promise<EmbedStatus>;
+  checkThirdPartyTracking: (html: string) => Promise<TrackingStatus>;
 }) => {
-  const [embedStatus, updateEmbedStatus] = useState<EmbedStatus>();
+  const [trackingStatus, updateTrackingStatus] = useState<TrackingStatus>();
 
   const checkTrackingAndUpdate = (html: string) => {
-    checkEmbedTracking(unescapeHtml(html))
+    checkThirdPartyTracking(unescapeHtml(html))
       .then((response) => {
-        updateEmbedStatus(response);
+        updateTrackingStatus(response);
       })
       .catch((e) => console.log(e));
   };
@@ -107,12 +107,12 @@ export const EmbedStatusChecks = ({
     checkTrackingAndUpdate(html);
   }, []);
 
-  if (embedStatus != undefined) {
+  if (trackingStatus != undefined) {
     return (
       <>
-        <TrackingChecker embedStatus={embedStatus} />
+        <TrackingChecker trackingStatus={trackingStatus} />
         <UnsupportedPlatforms
-          embedStatus={embedStatus}
+          trackingStatus={trackingStatus}
           isMandatory={isMandatory}
         />
       </>

--- a/src/elements/interactive/InteractiveForm.tsx
+++ b/src/elements/interactive/InteractiveForm.tsx
@@ -8,15 +8,15 @@ import type { FieldNameToField } from "../../plugin/types/Element";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import { Preview } from "../helpers/Preview";
-import { EmbedStatusChecks } from "../helpers/ThirdPartyStatusChecks";
-import type { EmbedStatus } from "../helpers/ThirdPartyStatusChecks";
+import { TrackingStatusChecks } from "../helpers/ThirdPartyStatusChecks";
+import type { TrackingStatus } from "../helpers/ThirdPartyStatusChecks";
 import type { createInteractiveFields } from "./InteractiveSpec";
 
 type Props = {
   fieldValues: FieldNameToValueMap<ReturnType<typeof createInteractiveFields>>;
   errors: FieldValidationErrors;
   fields: FieldNameToField<ReturnType<typeof createInteractiveFields>>;
-  checkEmbedTracking: (html: string) => Promise<EmbedStatus>;
+  checkThirdPartyTracking: (html: string) => Promise<TrackingStatus>;
 };
 
 export const InteractiveElementTestId = "InteractiveElement";
@@ -25,7 +25,7 @@ export const InteractiveElementForm: React.FunctionComponent<Props> = ({
   fieldValues,
   errors,
   fields,
-  checkEmbedTracking,
+  checkThirdPartyTracking,
 }) => (
   <FieldLayoutVertical data-cy={InteractiveElementTestId}>
     <Preview
@@ -58,10 +58,10 @@ export const InteractiveElementForm: React.FunctionComponent<Props> = ({
       errors={errors.isMandatory}
       label="This element is required for publication"
     />
-    <EmbedStatusChecks
+    <TrackingStatusChecks
       html={fieldValues.html}
       isMandatory={fieldValues.isMandatory}
-      checkEmbedTracking={checkEmbedTracking}
+      checkThirdPartyTracking={checkThirdPartyTracking}
     />
   </FieldLayoutVertical>
 );

--- a/src/elements/interactive/InteractiveSpec.tsx
+++ b/src/elements/interactive/InteractiveSpec.tsx
@@ -9,12 +9,12 @@ import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldVi
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
-import type { EmbedStatus } from "../helpers/ThirdPartyStatusChecks";
+import type { TrackingStatus } from "../helpers/ThirdPartyStatusChecks";
 import { undefinedDropdownValue } from "../helpers/transform";
 import { InteractiveElementForm } from "./InteractiveForm";
 
 export type MainInteractiveProps = {
-  checkThirdPartyTracking: (html: string) => Promise<EmbedStatus>;
+  checkThirdPartyTracking: (html: string) => Promise<TrackingStatus>;
   createCaptionPlugins?: (schema: Schema) => Plugin[];
 };
 
@@ -59,7 +59,7 @@ export const createInteractiveElement = (props: MainInteractiveProps) =>
           fields={fields}
           errors={errors}
           fieldValues={fieldValues}
-          checkEmbedTracking={props.checkThirdPartyTracking}
+          checkThirdPartyTracking={props.checkThirdPartyTracking}
         />
       );
     }

--- a/src/elements/video/VideoForm.tsx
+++ b/src/elements/video/VideoForm.tsx
@@ -9,8 +9,8 @@ import type { FieldNameToField } from "../../plugin/types/Element";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import { unescapeHtml } from "../helpers/html";
-import type { EmbedStatus } from "../helpers/ThirdPartyStatusChecks";
-import { EmbedStatusChecks } from "../helpers/ThirdPartyStatusChecks";
+import type { TrackingStatus } from "../helpers/ThirdPartyStatusChecks";
+import { TrackingStatusChecks } from "../helpers/ThirdPartyStatusChecks";
 import { htmlLength } from "../helpers/validation";
 import type { createVideoFields } from "./VideoSpec";
 
@@ -18,7 +18,7 @@ type Props = {
   fieldValues: FieldNameToValueMap<ReturnType<typeof createVideoFields>>;
   errors: FieldValidationErrors;
   fields: FieldNameToField<ReturnType<typeof createVideoFields>>;
-  checkEmbedTracking: (html: string) => Promise<EmbedStatus>;
+  checkThirdPartyTracking: (html: string) => Promise<TrackingStatus>;
 };
 
 const IframeAspectRatioBox = styled.div<{
@@ -64,7 +64,7 @@ export const VideoForm: React.FunctionComponent<Props> = ({
   errors,
   fields,
   fieldValues,
-  checkEmbedTracking,
+  checkThirdPartyTracking,
 }) => (
   <div>
     <FieldLayoutVertical>
@@ -105,10 +105,10 @@ export const VideoForm: React.FunctionComponent<Props> = ({
         errors={errors.isMandatory}
         label="This element is required for publication"
       />
-      <EmbedStatusChecks
+      <TrackingStatusChecks
         html={fieldValues.html}
         isMandatory={fieldValues.isMandatory}
-        checkEmbedTracking={checkEmbedTracking}
+        checkThirdPartyTracking={checkThirdPartyTracking}
       />
     </FieldLayoutVertical>
   </div>

--- a/src/elements/video/VideoSpec.tsx
+++ b/src/elements/video/VideoSpec.tsx
@@ -9,7 +9,7 @@ import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldVi
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { htmlMaxLength } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
-import type { EmbedStatus } from "../helpers/ThirdPartyStatusChecks";
+import type { TrackingStatus } from "../helpers/ThirdPartyStatusChecks";
 import { undefinedDropdownValue } from "../helpers/transform";
 import { VideoForm } from "./VideoForm";
 
@@ -45,12 +45,12 @@ export const createVideoFields = (
 
 export type VideoElementOptions = {
   createCaptionPlugins: (schema: Schema) => Plugin[];
-  checkEmbedTracking: (html: string) => Promise<EmbedStatus>;
+  checkThirdPartyTracking: (html: string) => Promise<TrackingStatus>;
 };
 
 export const createVideoElement = ({
   createCaptionPlugins,
-  checkEmbedTracking,
+  checkThirdPartyTracking,
 }: VideoElementOptions) =>
   createReactElementSpec(
     createVideoFields(createCaptionPlugins),
@@ -60,7 +60,7 @@ export const createVideoElement = ({
           fields={fields}
           errors={errors}
           fieldValues={fieldValues}
-          checkEmbedTracking={checkEmbedTracking}
+          checkThirdPartyTracking={checkThirdPartyTracking}
         />
       );
     }


### PR DESCRIPTION
## What does this change?
There was a mixture of variable names related to third party tracking in the `EmbedElement` and `InteractiveElement`. This PR updates all the relevant variables to refer to `ThirdPartyTracking` rather than `EmbedTracking`.

This will change the interface of the object expected by the `createEmbedElement` and `createVideoElement` functions to require a `thirdPartyTracking` property rather than an `embedTracking` property. As this is the main interface for that element with outside consumers (e.g. flexible-content) this could be considered a breaking change.

However, the Embed and Video elements are still in testing, so perhaps we can avoid the major version bump on that basis. Interested in the thought of reviewers on this.

## How to test
Run the application locally with `yarn start`. Run the tests with `yarn test:unit` and `yarn test:integration`.
