### PR TITLE
feat: `focus` editor after element removal

### DIFF
--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -113,6 +113,13 @@ export const addImageElement = (values: Record<string, unknown> = {}) => {
   });
 };
 
+export const assertEditorFocus = (shouldBeFocused: boolean) => {
+  cy.window().then((win: WindowType) => {
+    const { view } = win.PM_ELEMENTS;
+    expect(view.hasFocus()).to.equal(shouldBeFocused);
+  });
+};
+
 type ElementFields = {
   altTextValue?: string;
   captionValue?: string;

--- a/cypress/tests/ElementWrapper.spec.ts
+++ b/cypress/tests/ElementWrapper.spec.ts
@@ -8,6 +8,7 @@ import {
 } from "../../src/renderers/react/ElementWrapper";
 import {
   addImageElement,
+  assertEditorFocus,
   getArrayOfBlockElementTypes,
   selectDataCy,
   visitRoot,
@@ -62,6 +63,13 @@ describe("ElementWrapper", () => {
       cy.get(selectDataCy(removeTestId)).click();
       const elementTypes = await getArrayOfBlockElementTypes();
       expect(elementTypes).to.deep.equal(["paragraph", "paragraph"]);
+    });
+
+    it("should focus the editor after element removal", () => {
+      addImageElement();
+      cy.get(selectDataCy(removeTestId)).click();
+      cy.get(selectDataCy(removeTestId)).click();
+      assertEditorFocus(true);
     });
   });
 });

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -158,7 +158,8 @@ const buildMoveCommands = (predicate: Predicate) => (
 
 const removeNode = (getPos: () => number | undefined) => (
   state: EditorState,
-  dispatch: ((tr: Transaction) => void) | false
+  dispatch: ((tr: Transaction) => void) | false,
+  focusEditor: () => void
 ) => {
   if (!dispatch) {
     return true;
@@ -171,6 +172,7 @@ const removeNode = (getPos: () => number | undefined) => (
   const to = node ? pos + node.nodeSize : pos;
 
   dispatch(state.tr.deleteRange(pos, to));
+  focusEditor();
 };
 
 const buildCommands = (predicate: Predicate) => (
@@ -178,7 +180,8 @@ const buildCommands = (predicate: Predicate) => (
   view: EditorView
 ) => ({
   ...buildMoveCommands(predicate)(getPos, view),
-  remove: (run = true) => removeNode(getPos)(view.state, run && view.dispatch),
+  remove: (run = true) =>
+    removeNode(getPos)(view.state, run && view.dispatch, () => view.focus()),
 });
 
 // this forces our view to update every time an edit is made by inserting

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -156,10 +156,13 @@ const buildMoveCommands = (predicate: Predicate) => (
   moveBottom: (run = true) => moveNodeBottom(predicate)(getPos)(view, run),
 });
 
+/**
+ * Remove a node. If the view is passed, focus the editor after removal.
+ */
 const removeNode = (getPos: () => number | undefined) => (
   state: EditorState,
   dispatch: ((tr: Transaction) => void) | false,
-  focusEditor: () => void
+  view?: EditorView
 ) => {
   if (!dispatch) {
     return true;
@@ -172,7 +175,7 @@ const removeNode = (getPos: () => number | undefined) => (
   const to = node ? pos + node.nodeSize : pos;
 
   dispatch(state.tr.deleteRange(pos, to));
-  focusEditor();
+  view?.focus();
 };
 
 const buildCommands = (predicate: Predicate) => (
@@ -181,7 +184,7 @@ const buildCommands = (predicate: Predicate) => (
 ) => ({
   ...buildMoveCommands(predicate)(getPos, view),
   remove: (run = true) =>
-    removeNode(getPos)(view.state, run && view.dispatch, () => view.focus()),
+    removeNode(getPos)(view.state, run && view.dispatch, view),
 });
 
 // this forces our view to update every time an edit is made by inserting


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Currently when an element is deleted in the document the `focus` is `blurred`; the document/view is no longer active.
Therefore pressing `ctrl+z` to undo the delete and re add the element does not do the trick as we are no longer 'in the doc'.

The `focus` upon deletion moves away from (it is `blurred`) the document `view`, the editable part of the document/editor is no longer selected. 
Therefore the undo only works if you manually click where the element was in the document/editor first, which is less than desirable.

This PR therefore aims to automatically add focus to the editor once the element is deleted allowing for the undo to re add the element. 

## Additional information
- we have added integration tests with Cypress to check for succesful re focussing within the document `view` upon deletion.
## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
1. Tested in prosemirror-elelments sandbox with `yarn start`

2. Tested in flexible-content:
From **prosemirror-elements**: > `yarn yalc`
From **flexible-content**: `> yalc add @guardian/prosemirror-elements`
Go to: `https://composer.local.dev-gutools.co.uk/` adding an element, deleting, then instantly pressing `ctrl+z`. 
At which point the element should reappear.

3. Testing the integration tests: `yarn test:integration`
## Images
#### Deleting and pressing ctrl+z
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![2022-02-01 17 24 20](https://user-images.githubusercontent.com/49187886/152018646-1d44081b-1db3-45bf-9251-3cffecb3d163.gif)

## Measuring success
- All integration tests for `ElementWrapper` should pass
- Element deleted and re added with ctrl+z instantly 
- Element shoiuld otherwise work as previously

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [ ] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [ ] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
