### PR TITLE
feat: Update image alt text placeholder to prompt for accessible text

### DIFF
--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -64,7 +64,7 @@ export const createImageFields = ({
     alt: createTextField({
       rows: 2,
       validators: [htmlMaxLength(1000), htmlRequired()],
-      placeholder: "Enter some alt text…",
+      placeholder: "Describe the image for visually impaired readers",
       isResizeable: true,
       attrs: useTyperighterAttrs,
     }),


### PR DESCRIPTION
## What does this change?
This PR updates the placeholder text for the image element's alt text field - giving a more direct prompt to the user, based on a suggestion by @pradasa.

| Before | After |
| --- | --- |
| `Enter some alt text…` | `Describe the image for visually impaired readers` |
