### PR TITLE
feat: Add element select button

### DIFF
--- a/cypress/tests/ElementWrapper.spec.ts
+++ b/cypress/tests/ElementWrapper.spec.ts
@@ -10,11 +10,7 @@ import {
 import {
   addImageElement,
   assertEditorFocus,
-  copyShortcut,
-  cutShortcut,
   getArrayOfBlockElementTypes,
-  pasteShortcut,
-  selectAllShortcut,
   selectDataCy,
   visitRoot,
 } from "../helpers/editor";
@@ -78,7 +74,18 @@ describe("ElementWrapper", () => {
     });
   });
 
-  describe.only("Element selection", () => {
+  describe("Element selection", () => {
+    it("should delete the element after selecting and typing", async () => {
+      addImageElement();
+      cy.wait(100).get(selectDataCy(selectTestId)).click().type(`text`);
+      const elementTypes = await getArrayOfBlockElementTypes();
+      expect(elementTypes).to.deep.equal([
+        "paragraph",
+        "paragraph",
+        "paragraph",
+      ]);
+    });
+
     it("should delete the element after selecting and using backsapce", async () => {
       addImageElement();
       cy.wait(100).get(selectDataCy(selectTestId)).click().type(`{del}`);

--- a/cypress/tests/ElementWrapper.spec.ts
+++ b/cypress/tests/ElementWrapper.spec.ts
@@ -5,11 +5,16 @@ import {
   moveTopTestId,
   moveUpTestId,
   removeTestId,
+  selectTestId,
 } from "../../src/renderers/react/ElementWrapper";
 import {
   addImageElement,
   assertEditorFocus,
+  copyShortcut,
+  cutShortcut,
   getArrayOfBlockElementTypes,
+  pasteShortcut,
+  selectAllShortcut,
   selectDataCy,
   visitRoot,
 } from "../helpers/editor";
@@ -70,6 +75,15 @@ describe("ElementWrapper", () => {
       cy.get(selectDataCy(removeTestId)).click();
       cy.get(selectDataCy(removeTestId)).click();
       assertEditorFocus(true);
+    });
+  });
+
+  describe.only("Element selection", () => {
+    it("should delete the element after selecting and using backsapce", async () => {
+      addImageElement();
+      cy.wait(100).get(selectDataCy(selectTestId)).click().type(`{del}`);
+      const elementTypes = await getArrayOfBlockElementTypes();
+      expect(elementTypes).to.deep.equal(["paragraph", "paragraph"]);
     });
   });
 });

--- a/demo/style.css
+++ b/demo/style.css
@@ -385,3 +385,7 @@ h6 {
 .ProseMirror .ProseMirror {
   padding: 4px 8px;
 }
+
+.ProseMirror-selectednode {
+  outline: unset;
+}

--- a/src/editorial-source-components/SvgHighlightAlt.tsx
+++ b/src/editorial-source-components/SvgHighlightAlt.tsx
@@ -1,0 +1,14 @@
+export const SvgHighlightAlt = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height="24px"
+      viewBox="0 0 24 24"
+      width="24px"
+      fill="#000000"
+    >
+      <path d="M0 0h24v24H0z" fill="none" />
+      <path d="M17 5h-2V3h2v2zm-2 16h2v-2.59L19.59 21 21 19.59 18.41 17H21v-2h-6v6zm4-12h2V7h-2v2zm0 4h2v-2h-2v2zm-8 8h2v-2h-2v2zM7 5h2V3H7v2zM3 17h2v-2H3v2zm2 4v-2H3c0 1.1.9 2 2 2zM19 3v2h2c0-1.1-.9-2-2-2zm-8 2h2V3h-2v2zM3 9h2V7H3v2zm4 12h2v-2H7v2zm-4-8h2v-2H3v2zm0-8h2V3c-1.1 0-2 .9-2 2z" />
+    </svg>
+  );
+};

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -180,8 +180,9 @@ const removeNode = (getPos: () => number | undefined) => (
 };
 
 const selectNode = (getPos: () => number | undefined) => (
-  view: EditorView,
-  dispatch: ((tr: Transaction) => void) | false
+  state: EditorState,
+  dispatch: ((tr: Transaction) => void) | false,
+  view: EditorView
 ) => {
   if (!dispatch) {
     return true;
@@ -191,7 +192,6 @@ const selectNode = (getPos: () => number | undefined) => (
     return;
   }
 
-  const state = view.state;
   const tr = state.tr;
   const { node } = state.doc.childAfter(pos);
 
@@ -216,7 +216,8 @@ const buildCommands = (predicate: Predicate) => (
   ...buildMoveCommands(predicate)(getPos, view),
   remove: (run = true) =>
     removeNode(getPos)(view.state, run && view.dispatch, view),
-  select: (run = true) => selectNode(getPos)(view, run && view.dispatch),
+  select: (run = true) =>
+    selectNode(getPos)(view.state, run && view.dispatch, view),
 });
 
 // this forces our view to update every time an edit is made by inserting

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -1,7 +1,7 @@
 import type { Node, Schema } from "prosemirror-model";
 import { DOMParser, DOMSerializer } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
-import { AllSelection, NodeSelection } from "prosemirror-state";
+import { AllSelection, NodeSelection, TextSelection } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 import { Decoration, DecorationSet } from "prosemirror-view";
 import { elementSelectedNodeAttr } from "../nodeSpec";
@@ -202,7 +202,9 @@ const selectNode = (getPos: () => number | undefined) => (
         ...node.attrs,
         [elementSelectedNodeAttr]: true,
       })
-      .setSelection(NodeSelection.create(tr.doc, nodeSelection.from));
+      .setSelection(
+        TextSelection.create(tr.doc, nodeSelection.anchor, nodeSelection.head)
+      );
 
     dispatch(newTr);
     view.focus();

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -1,9 +1,13 @@
 import type { Node, Schema } from "prosemirror-model";
 import { DOMParser, DOMSerializer } from "prosemirror-model";
-import { EditorState, NodeSelection, Transaction } from "prosemirror-state";
-import { AllSelection } from "prosemirror-state";
+import type { EditorState, Transaction } from "prosemirror-state";
+import { AllSelection, NodeSelection, TextSelection } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 import { Decoration, DecorationSet } from "prosemirror-view";
+import {
+  elementSelectedNodeAttr,
+  isProseMirrorElementSelected,
+} from "../nodeSpec";
 
 type NodesBetweenArgs = [Node, number, Node, number];
 export type Commands = ReturnType<typeof buildCommands>;
@@ -179,7 +183,7 @@ const removeNode = (getPos: () => number | undefined) => (
 };
 
 const selectNode = (getPos: () => number | undefined) => (
-  state: EditorState,
+  view: EditorView,
   dispatch: ((tr: Transaction) => void) | false
 ) => {
   if (!dispatch) {
@@ -189,12 +193,23 @@ const selectNode = (getPos: () => number | undefined) => (
   if (pos === undefined) {
     return;
   }
-  // const { node } = state.doc.childAfter(pos);
-  const newSelection = NodeSelection.create(state.doc, pos);
-  const newTr = state.tr.setSelection(newSelection);
-  // const to = node ? pos + node.nodeSize : pos;
 
-  dispatch(newTr);
+  const state = view.state;
+  const tr = state.tr;
+  const { node } = state.doc.childAfter(pos);
+
+  if (node) {
+    const nodeSelection = NodeSelection.create(state.doc, pos);
+    const newTr = tr
+      .setNodeMarkup(pos, undefined, {
+        ...node.attrs,
+        [elementSelectedNodeAttr]: true,
+      })
+      .setSelection(NodeSelection.create(tr.doc, nodeSelection.from));
+
+    dispatch(newTr);
+    view.focus();
+  }
 };
 
 const buildCommands = (predicate: Predicate) => (
@@ -204,7 +219,7 @@ const buildCommands = (predicate: Predicate) => (
   ...buildMoveCommands(predicate)(getPos, view),
   remove: (run = true) =>
     removeNode(getPos)(view.state, run && view.dispatch, view),
-  select: (run = true) => selectNode(getPos)(view.state, run && view.dispatch),
+  select: (run = true) => selectNode(getPos)(view, run && view.dispatch),
 });
 
 // this forces our view to update every time an edit is made by inserting

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -1,13 +1,10 @@
 import type { Node, Schema } from "prosemirror-model";
 import { DOMParser, DOMSerializer } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
-import { AllSelection, NodeSelection, TextSelection } from "prosemirror-state";
+import { AllSelection, NodeSelection } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 import { Decoration, DecorationSet } from "prosemirror-view";
-import {
-  elementSelectedNodeAttr,
-  isProseMirrorElementSelected,
-} from "../nodeSpec";
+import { elementSelectedNodeAttr } from "../nodeSpec";
 
 type NodesBetweenArgs = [Node, number, Node, number];
 export type Commands = ReturnType<typeof buildCommands>;

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -1,10 +1,9 @@
 import type { Node, Schema } from "prosemirror-model";
 import { DOMParser, DOMSerializer } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
-import { AllSelection, NodeSelection, TextSelection } from "prosemirror-state";
+import { AllSelection, NodeSelection } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 import { Decoration, DecorationSet } from "prosemirror-view";
-import { elementSelectedNodeAttr } from "../nodeSpec";
 
 type NodesBetweenArgs = [Node, number, Node, number];
 export type Commands = ReturnType<typeof buildCommands>;
@@ -193,22 +192,8 @@ const selectNode = (getPos: () => number | undefined) => (
   }
 
   const tr = state.tr;
-  const { node } = state.doc.childAfter(pos);
-
-  if (node) {
-    const nodeSelection = NodeSelection.create(state.doc, pos);
-    const newTr = tr
-      .setNodeMarkup(pos, undefined, {
-        ...node.attrs,
-        [elementSelectedNodeAttr]: true,
-      })
-      .setSelection(
-        TextSelection.create(tr.doc, nodeSelection.anchor, nodeSelection.head)
-      );
-
-    dispatch(newTr);
-    view.focus();
-  }
+  dispatch(tr.setSelection(NodeSelection.create(tr.doc, pos)));
+  view.focus();
 };
 
 const buildCommands = (predicate: Predicate) => (

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -1,6 +1,6 @@
 import type { Node, Schema } from "prosemirror-model";
 import { DOMParser, DOMSerializer } from "prosemirror-model";
-import type { EditorState, Transaction } from "prosemirror-state";
+import { EditorState, NodeSelection, Transaction } from "prosemirror-state";
 import { AllSelection } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 import { Decoration, DecorationSet } from "prosemirror-view";
@@ -178,6 +178,25 @@ const removeNode = (getPos: () => number | undefined) => (
   view?.focus();
 };
 
+const selectNode = (getPos: () => number | undefined) => (
+  state: EditorState,
+  dispatch: ((tr: Transaction) => void) | false
+) => {
+  if (!dispatch) {
+    return true;
+  }
+  const pos = getPos();
+  if (pos === undefined) {
+    return;
+  }
+  // const { node } = state.doc.childAfter(pos);
+  const newSelection = NodeSelection.create(state.doc, pos);
+  const newTr = state.tr.setSelection(newSelection);
+  // const to = node ? pos + node.nodeSize : pos;
+
+  dispatch(newTr);
+};
+
 const buildCommands = (predicate: Predicate) => (
   getPos: () => number | undefined,
   view: EditorView
@@ -185,6 +204,7 @@ const buildCommands = (predicate: Predicate) => (
   ...buildMoveCommands(predicate)(getPos, view),
   remove: (run = true) =>
     removeNode(getPos)(view.state, run && view.dispatch, view),
+  select: (run = true) => selectNode(getPos)(view.state, run && view.dispatch),
 });
 
 // this forces our view to update every time an edit is made by inserting

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -52,7 +52,7 @@ const getNodeSpecForElement = (
       // Used to determine which nodes should receive update decorations, which force them to update when the document changes. See `createUpdateDecorations` in prosemirror.ts.
       addUpdateDecoration: { default: true },
     },
-    draggable: true,
+    draggable: false,
     toDOM: (node: Node) => [
       "div",
       {

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -52,7 +52,7 @@ const getNodeSpecForElement = (
       // Used to determine which nodes should receive update decorations, which force them to update when the document changes. See `createUpdateDecorations` in prosemirror.ts.
       addUpdateDecoration: { default: true },
     },
-    draggable: false,
+    draggable: true,
     toDOM: (node: Node) => [
       "div",
       {

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -261,7 +261,7 @@ const createNodeView = <
       }
       return false;
     },
-    stopEvent: () => true,
+    stopEvent: () => false,
     destroy: () => {
       Object.values(fields).map((field) => field.view.destroy());
     },

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -1,5 +1,5 @@
 import type { Node, Schema } from "prosemirror-model";
-import type { EditorState, Transaction } from "prosemirror-state";
+import type { EditorState } from "prosemirror-state";
 import { NodeSelection, Plugin, PluginKey } from "prosemirror-state";
 import type { EditorProps } from "prosemirror-view";
 import type {
@@ -94,6 +94,7 @@ export const createPlugin = <
         }
       });
 
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- it's not always falsy.
       if (preserveNodeSelection && selection instanceof NodeSelection) {
         tr.setSelection(NodeSelection.create(tr.doc, selection.anchor));
       }

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -261,7 +261,7 @@ const createNodeView = <
       }
       return false;
     },
-    stopEvent: () => false,
+    stopEvent: () => true,
     destroy: () => {
       Object.values(fields).map((field) => field.view.destroy());
     },

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -1,6 +1,6 @@
 import type { Node, Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
-import { Plugin, PluginKey, TextSelection } from "prosemirror-state";
+import { NodeSelection, Plugin, PluginKey } from "prosemirror-state";
 import type { EditorProps } from "prosemirror-view";
 import type {
   ElementSpec,
@@ -80,14 +80,16 @@ export const createPlugin = <
           (!isProseMirrorElementSelected(node) && isCurrentlySelected);
 
         if (shouldUpdateNode) {
-          tr = tr
-            .setNodeMarkup(pos, undefined, {
-              ...node.attrs,
-              [elementSelectedNodeAttr]: isCurrentlySelected,
-            })
-            .setSelection(
-              TextSelection.create(tr.doc, selection.anchor, selection.head)
+          tr.setNodeMarkup(pos, undefined, {
+            ...node.attrs,
+            [elementSelectedNodeAttr]: isCurrentlySelected,
+          });
+
+          if (selection instanceof NodeSelection) {
+            tr = tr.setSelection(
+              NodeSelection.create(tr.doc, selection.anchor)
             ) as Transaction<Schema>;
+          }
         }
 
         // Do not descend into element nodes.

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -52,9 +52,10 @@ export const createPlugin = <
         return;
       }
 
-      let tr = newState.tr;
+      const tr = newState.tr;
       const selection = tr.selection;
       const elementNodeToPos = new Map<Node, number>();
+      let preserveNodeSelection = false;
 
       // Find all the nodes within the current selection.
       newState.doc.nodesBetween(
@@ -80,16 +81,11 @@ export const createPlugin = <
           (!isProseMirrorElementSelected(node) && isCurrentlySelected);
 
         if (shouldUpdateNode) {
+          preserveNodeSelection = true;
           tr.setNodeMarkup(pos, undefined, {
             ...node.attrs,
             [elementSelectedNodeAttr]: isCurrentlySelected,
           });
-
-          if (selection instanceof NodeSelection) {
-            tr = tr.setSelection(
-              NodeSelection.create(tr.doc, selection.anchor)
-            ) as Transaction<Schema>;
-          }
         }
 
         // Do not descend into element nodes.
@@ -97,6 +93,10 @@ export const createPlugin = <
           return false;
         }
       });
+
+      if (preserveNodeSelection && selection instanceof NodeSelection) {
+        tr.setSelection(NodeSelection.create(tr.doc, selection.anchor));
+      }
 
       return tr;
     },

--- a/src/plugin/types/Commands.ts
+++ b/src/plugin/types/Commands.ts
@@ -1,16 +1,15 @@
 import type { EditorState, Transaction } from "prosemirror-state";
 
 export type CommandCreator = (
-  pos: number,
   state: EditorState,
   dispatch: (tr: Transaction) => void
 ) => {
   remove: (run?: boolean) => true | void;
+  select: (run?: boolean) => true | void;
   moveUp: (run?: boolean) => boolean | void;
   moveDown: (run?: boolean) => boolean | void;
   moveTop: (run?: boolean) => boolean | void;
   moveBottom: (run?: boolean) => boolean | void;
-  pos?: number;
 };
 
 export type Commands = ReturnType<CommandCreator>;

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -195,6 +195,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
             data-cy={selectTestId}
             disabled={!select(false)}
             onClick={() => select(true)}
+            aria-label="Select element"
           >
             <SvgHighlightAlt />
           </SeriousButton>
@@ -212,6 +213,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
                 }, 5000);
               }
             }}
+            aria-label="Delete element"
           >
             <SvgBin />
             {closeClickedOnce && <Tooltip>Click again to confirm</Tooltip>}

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -38,10 +38,25 @@ const Body = styled("div")`
 
 const Panel = styled("div")<{ isSelected: boolean }>`
   background-color: ${({ isSelected }) =>
-    isSelected ? "#b3d7fe" : neutral[97]};
+    isSelected ? "#b3d7fe !important" : neutral[97]};
   flex-grow: 1;
   overflow: hidden;
   padding: ${space[3]}px;
+
+  * {
+    background-color: ${({ isSelected }) =>
+      isSelected ? "#b3d7fe !important" : undefined};
+
+    ::selection {
+      background: ${({ isSelected }) =>
+        isSelected ? "#b3d7fe !important" : undefined};
+    }
+
+    ::-moz-selection {
+      background: ${({ isSelected }) =>
+        isSelected ? "#b3d7fe !important" : undefined};
+    }
+  }
 `;
 
 const Button = styled("button")<{ expanded?: boolean }>`

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -37,26 +37,33 @@ const Body = styled("div")`
 `;
 
 const Panel = styled("div")<{ isSelected: boolean }>`
-  background-color: ${({ isSelected }) =>
-    isSelected ? "#b3d7fe !important" : neutral[97]};
+  background-color: ${neutral[97]};
   flex-grow: 1;
   overflow: hidden;
   padding: ${space[3]}px;
+  postion: relative;
 
   * {
-    background-color: ${({ isSelected }) =>
-      isSelected ? "#b3d7fe !important" : undefined};
-
     ::selection {
-      background: ${({ isSelected }) =>
-        isSelected ? "#b3d7fe !important" : undefined};
+      background: ${({ isSelected }) => (isSelected ? "#ffffffff" : undefined)};
     }
 
     ::-moz-selection {
-      background: ${({ isSelected }) =>
-        isSelected ? "#b3d7fe !important" : undefined};
+      background: ${({ isSelected }) => (isSelected ? "#ffffffff" : undefined)};
     }
   }
+`;
+
+const Overlay = styled("div")<{ isSelected: boolean }>`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  z-index: 15;
+  pointer-events: none;
+  background-color: ${({ isSelected }) =>
+    isSelected ? "#b3d7fe8a" : undefined};
 `;
 
 const Button = styled("button")<{ expanded?: boolean }>`
@@ -234,7 +241,10 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
             {closeClickedOnce && <Tooltip>Click again to confirm</Tooltip>}
           </SeriousButton>
         </LeftActions>
-        <Panel isSelected={isSelected}>{children}</Panel>
+        <Panel isSelected={isSelected}>
+          <Overlay isSelected={isSelected} />
+          {children}
+        </Panel>
         <RightActions className="actions">
           <Button
             type="button"

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -36,7 +36,7 @@ const Body = styled("div")`
   min-height: 134px;
 `;
 
-const Panel = styled("div") <{ isSelected: boolean }>`
+const Panel = styled("div")<{ isSelected: boolean }>`
   background-color: ${({ isSelected }) =>
     isSelected ? "#b3d7fe" : neutral[97]};
   flex-grow: 1;
@@ -44,7 +44,7 @@ const Panel = styled("div") <{ isSelected: boolean }>`
   padding: ${space[3]}px;
 `;
 
-const Button = styled("button") <{ expanded?: boolean }>`
+const Button = styled("button")<{ expanded?: boolean }>`
   appearance: none;
   background: ${neutral[93]};
   border: none;
@@ -89,7 +89,7 @@ const Button = styled("button") <{ expanded?: boolean }>`
   }
 `;
 
-const SeriousButton = styled(Button) <{ activated?: boolean }>`
+const SeriousButton = styled(Button)<{ activated?: boolean }>`
   background-color: ${({ activated }) =>
     activated ? border.error : neutral[93]};
   div {
@@ -100,7 +100,7 @@ const SeriousButton = styled(Button) <{ activated?: boolean }>`
   }
   :hover {
     background-color: ${({ activated }) =>
-    activated ? neutral[0] : neutral[86]};
+      activated ? neutral[0] : neutral[86]};
     svg {
       fill: ${({ activated }) => (activated ? neutral[100] : neutral[20])};
     }

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -7,11 +7,11 @@ import {
   SvgArrowDownStraight,
   SvgArrowUpStraight,
   SvgChevronRightDouble,
-  SvgExternal,
 } from "@guardian/src-icons";
 import type { ReactElement } from "react";
 import React, { useState } from "react";
 import { SvgBin } from "../../editorial-source-components/SvgBin";
+import { SvgHighlightAlt } from "../../editorial-source-components/SvgHighlightAlt";
 import type { CommandCreator } from "../../plugin/types/Commands";
 
 const buttonWidth = 32;
@@ -154,8 +154,8 @@ const RightActions = styled(Actions)`
 `;
 
 const LeftActions = styled(Actions)`
-  flex-direction: column-reverse;
   left: -${buttonWidth + 1}px;
+  justify-content: space-between;
 `;
 
 type Props = {
@@ -192,6 +192,14 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
         <LeftActions className="actions">
           <SeriousButton
             type="button"
+            data-cy={selectTestId}
+            disabled={!select(false)}
+            onClick={() => select(true)}
+          >
+            <SvgHighlightAlt />
+          </SeriousButton>
+          <SeriousButton
+            type="button"
             activated={closeClickedOnce}
             data-cy={removeTestId}
             disabled={!remove(false)}
@@ -207,14 +215,6 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
           >
             <SvgBin />
             {closeClickedOnce && <Tooltip>Click again to confirm</Tooltip>}
-          </SeriousButton>
-          <SeriousButton
-            type="button"
-            data-cy={selectTestId}
-            disabled={!select(false)}
-            onClick={() => select(true)}
-          >
-            <SvgExternal />
           </SeriousButton>
         </LeftActions>
         <Panel isSelected={isSelected}>{children}</Panel>

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -100,9 +100,9 @@ const SeriousButton = styled(Button)<{ activated?: boolean }>`
   }
   :hover {
     background-color: ${({ activated }) =>
-      activated ? neutral[0] : neutral[86]};
+      activated ? border.error : neutral[46]};
     svg {
-      fill: ${({ activated }) => (activated ? neutral[100] : neutral[20])};
+      fill: ${neutral[100]};
     }
     div {
       opacity: 1;

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -7,6 +7,7 @@ import {
   SvgArrowDownStraight,
   SvgArrowUpStraight,
   SvgChevronRightDouble,
+  SvgExternal,
 } from "@guardian/src-icons";
 import type { ReactElement } from "react";
 import React, { useState } from "react";
@@ -35,7 +36,7 @@ const Body = styled("div")`
   min-height: 134px;
 `;
 
-const Panel = styled("div")<{ isSelected: boolean }>`
+const Panel = styled("div") <{ isSelected: boolean }>`
   background-color: ${({ isSelected }) =>
     isSelected ? "#b3d7fe" : neutral[97]};
   flex-grow: 1;
@@ -43,7 +44,7 @@ const Panel = styled("div")<{ isSelected: boolean }>`
   padding: ${space[3]}px;
 `;
 
-const Button = styled("button")<{ expanded?: boolean }>`
+const Button = styled("button") <{ expanded?: boolean }>`
   appearance: none;
   background: ${neutral[93]};
   border: none;
@@ -88,7 +89,7 @@ const Button = styled("button")<{ expanded?: boolean }>`
   }
 `;
 
-const SeriousButton = styled(Button)<{ activated?: boolean }>`
+const SeriousButton = styled(Button) <{ activated?: boolean }>`
   background-color: ${({ activated }) =>
     activated ? border.error : neutral[93]};
   div {
@@ -99,7 +100,7 @@ const SeriousButton = styled(Button)<{ activated?: boolean }>`
   }
   :hover {
     background-color: ${({ activated }) =>
-      activated ? neutral[0] : neutral[86]};
+    activated ? neutral[0] : neutral[86]};
     svg {
       fill: ${({ activated }) => (activated ? neutral[100] : neutral[20])};
     }
@@ -168,6 +169,7 @@ export const moveBottomTestId = "ElementWrapper__moveBottom";
 export const moveUpTestId = "ElementWrapper__moveUp";
 export const moveDownTestId = "ElementWrapper__moveDown";
 export const removeTestId = "ElementWrapper__remove";
+export const selectTestId = "ElementWrapper__select";
 
 export const ElementWrapper: React.FunctionComponent<Props> = ({
   moveUp,
@@ -175,6 +177,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
   moveTop,
   moveBottom,
   remove,
+  select,
   isSelected,
   children,
 }) => {
@@ -204,6 +207,14 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
           >
             <SvgBin />
             {closeClickedOnce && <Tooltip>Click again to confirm</Tooltip>}
+          </SeriousButton>
+          <SeriousButton
+            type="button"
+            data-cy={selectTestId}
+            disabled={!select(false)}
+            onClick={() => select(true)}
+          >
+            <SvgExternal />
           </SeriousButton>
         </LeftActions>
         <Panel isSelected={isSelected}>{children}</Panel>

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -56,7 +56,7 @@ const Panel = styled("div")<{ isSelected: boolean }>`
   }
 `;
 
-const Overlay = styled("div")<{ isSelected: boolean }>`
+const Overlay = styled("div")`
   position: absolute;
   width: 100%;
   height: 100%;
@@ -65,8 +65,7 @@ const Overlay = styled("div")<{ isSelected: boolean }>`
   z-index: 15;
   pointer-events: none;
   mix-blend-mode: multiply;
-  background-color: ${({ isSelected }) =>
-    isSelected ? "#b3d7fe82" : undefined};
+  background-color: #b3d7fe82;
 `;
 
 const Button = styled("button")<{ expanded?: boolean }>`
@@ -245,7 +244,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
           </SeriousButton>
         </LeftActions>
         <Panel isSelected={isSelected}>
-          <Overlay isSelected={isSelected} />
+          {isSelected && <Overlay />}
           {children}
         </Panel>
         <RightActions className="actions">

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -45,11 +45,13 @@ const Panel = styled("div")<{ isSelected: boolean }>`
 
   * {
     ::selection {
-      background: ${({ isSelected }) => (isSelected ? "#ffffffff" : undefined)};
+      background: ${({ isSelected }) =>
+        isSelected ? "transparent" : undefined};
     }
 
     ::-moz-selection {
-      background: ${({ isSelected }) => (isSelected ? "#ffffffff" : undefined)};
+      background: ${({ isSelected }) =>
+        isSelected ? "transparent" : undefined};
     }
   }
 `;
@@ -62,8 +64,9 @@ const Overlay = styled("div")<{ isSelected: boolean }>`
   left: 0;
   z-index: 15;
   pointer-events: none;
+  mix-blend-mode: multiply;
   background-color: ${({ isSelected }) =>
-    isSelected ? "#b3d7fe8a" : undefined};
+    isSelected ? "#b3d7fe82" : undefined};
 `;
 
 const Button = styled("button")<{ expanded?: boolean }>`


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This attempts to improve the select-ability of elements by providing a convenient button which will select the element. This should make working with them much simpler, improving the workflows for copying, cutting and deleting elements. It should also improve how intuitive it is for changes to be undone and redone. See the video for an illustration of these effects.

https://user-images.githubusercontent.com/4633246/152768970-1034d24c-9714-48b2-b607-f984eed89d9a.mov

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This PR can be tested in the sandbox environment using this branch. I have also created a [branch in Composer](https://github.com/guardian/flexible-content/compare/pme-selectable-elements-beta?expand=1) using a beta release to see the finished product. 

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

It provides a new and intuitive way to interact with elements.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

This may causes confusion in Composer during the transition from old to new element types.

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [x] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [x] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [x] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [x] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
