### PR TITLE
feat: Uses "crop" icon for image re-crop button instead of "camera" icon

### DIFF
--- a/src/editorial-source-components/SvgCrop.tsx
+++ b/src/editorial-source-components/SvgCrop.tsx
@@ -1,0 +1,14 @@
+export const SvgCrop = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height="24px"
+      viewBox="0 0 24 24"
+      width="24px"
+      fill="#000000"
+    >
+      <path d="M0 0h24v24H0z" fill="none" />
+      <path d="M17 15h2V7c0-1.1-.9-2-2-2H9v2h8v8zM7 17V1H5v4H1v2h4v10c0 1.1.9 2 2 2h10v4h2v-4h4v-2H7z" />
+    </svg>
+  );
+};

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -1,12 +1,12 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { space } from "@guardian/src-foundations";
-import { SvgCamera } from "@guardian/src-icons";
 import { Column, Columns } from "@guardian/src-layout";
 import React, { useEffect, useMemo } from "react";
 import { Button } from "../../editorial-source-components/Button";
 import { Error } from "../../editorial-source-components/Error";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import { SvgCrop } from "../../editorial-source-components/SvgCrop";
 import { Tooltip } from "../../editorial-source-components/Tooltip";
 import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
 import type {
@@ -278,7 +278,7 @@ const ImageView = ({ field, updateFields, errors }: ImageViewProps) => {
       <Button
         priority="secondary"
         size="xsmall"
-        icon={<SvgCamera />}
+        icon={<SvgCrop />}
         iconSide="left"
         onClick={() => {
           field.description.props.openImageSelector(


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR updates the image element re-crop icon from a camera to a conventional crop icon.

Before:

![image](https://user-images.githubusercontent.com/4633246/152785129-0767f2e1-70b2-4fd9-a48e-df654e66b4b6.png)

After:

![image](https://user-images.githubusercontent.com/4633246/152784994-7e43fa8c-9962-4cc9-a767-5a00353e589e.png)


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Checkout this branch, does the icon display correctly?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Users have a clear, more intuitive understanding of what the button does.


