### PR TITLE
feat: Include interactive in transform.ts

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -12,12 +12,12 @@ import {
   createDemoImageElement,
   createEmbedElement,
   createImageElement,
+  createInteractiveElement,
   pullquoteElement,
   richlinkElement,
 } from "../src";
 import { undefinedDropdownValue } from "../src/elements/helpers/transform";
 import type { MediaPayload } from "../src/elements/image/ImageElement";
-import { createInteractiveElement } from "../src/elements/interactive/InteractiveSpec";
 import { createVideoElement } from "../src/elements/video/VideoSpec";
 import { buildElementPlugin } from "../src/plugin/element";
 import {

--- a/src/elements/helpers/transform.ts
+++ b/src/elements/helpers/transform.ts
@@ -1,6 +1,7 @@
 import type { codeFields } from "../code/CodeElementSpec";
 import { transformElement as embedElementTransform } from "../embed/embedDataTransformer";
 import { transformElement as imageElementTransform } from "../image/imageElementDataTransformer";
+import { transformElement as interactiveElementTransform } from "../interactive/interactiveDataTransformer";
 import type { pullquoteFields } from "../pullquote/PullquoteSpec";
 import type { richlinkFields } from "../rich-link/RichlinkSpec";
 import { transformElement as videoElementTransform } from "../video/videoDataTransformer";
@@ -13,6 +14,7 @@ const transformMap = {
   code: defaultElementTransform<typeof codeFields>(),
   embed: embedElementTransform,
   image: imageElementTransform,
+  interactive: interactiveElementTransform,
   pullquote: defaultElementTransform<typeof pullquoteFields>(),
   "rich-link": defaultElementTransform<typeof richlinkFields>(true),
   video: videoElementTransform,

--- a/src/elements/interactive/InteractiveSpec.tsx
+++ b/src/elements/interactive/InteractiveSpec.tsx
@@ -43,6 +43,7 @@ export const createInteractiveFields = ({
     }),
     html: createTextField(),
     scriptUrl: createTextField(),
+    scriptName: createTextField(),
     iframeUrl: createTextField(),
     originalUrl: createTextField(),
     source: createTextField(),

--- a/src/elements/interactive/__tests__/interactiveDataTransformer.spec.ts
+++ b/src/elements/interactive/__tests__/interactiveDataTransformer.spec.ts
@@ -1,0 +1,169 @@
+import type { FieldNameToValueMap } from "../../../plugin/helpers/fieldView";
+import { undefinedDropdownValue } from "../../helpers/transform";
+import type { ExternalInteractiveFields } from "../interactiveDataTransformer";
+import { transformElement } from "../interactiveDataTransformer";
+import type { createInteractiveFields } from "../InteractiveSpec";
+
+const partialPmeElement = (
+  data: Partial<
+    FieldNameToValueMap<ReturnType<typeof createInteractiveFields>>
+  > = {}
+): Partial<FieldNameToValueMap<ReturnType<typeof createInteractiveFields>>> => {
+  return {
+    html: undefined,
+    isMandatory: false,
+    scriptUrl: undefined,
+    iframeUrl: undefined,
+    originalUrl: undefined,
+    scriptName: undefined,
+    source: undefined,
+    alt: undefined,
+    caption: undefined,
+    role: "none-selected",
+    ...data,
+  };
+};
+
+const fullPmeElement = (
+  data: Partial<
+    FieldNameToValueMap<ReturnType<typeof createInteractiveFields>>
+  > = {}
+): FieldNameToValueMap<ReturnType<typeof createInteractiveFields>> => {
+  return {
+    html: "",
+    isMandatory: false,
+    scriptUrl: "",
+    iframeUrl: "",
+    originalUrl: "",
+    scriptName: "",
+    source: "",
+    alt: "",
+    caption: "",
+    role: "none-selected",
+    ...data,
+  };
+};
+
+const externalElement = (data: Partial<ExternalInteractiveFields> = {}) => {
+  return {
+    fields: {
+      html: "",
+      isMandatory: "false",
+      scriptUrl: "",
+      iframeUrl: "",
+      originalUrl: "",
+      scriptName: "",
+      role: undefined,
+      source: "",
+      ...data,
+    },
+  };
+};
+
+describe("interactive element transform", () => {
+  describe("transformIn", () => {
+    it("should not allow elements which are the wrong type", () => {
+      // @ts-expect-error -- we should not be able to transform a malformed element
+      expect(() => transformElement.in({})).toThrow;
+      expect(() =>
+        transformElement.in({
+          // @ts-expect-error -- we should not be able to transform a malformed element
+          fields: { nonExistantField: "123" },
+        })
+      ).toThrow;
+    });
+    it("should partially transform elements with no fields", () => {
+      const element = { fields: {} };
+      const result = transformElement.in(element);
+      expect(result).toEqual(partialPmeElement());
+    });
+
+    it("should partially transform elements with some fields", () => {
+      const altText = "alt text";
+      const element = {
+        fields: { alt: altText, isMandatory: "true" },
+      };
+      const result = transformElement.in(element);
+      expect(result).toEqual(
+        partialPmeElement({ alt: altText, isMandatory: true })
+      );
+    });
+    it("should convert undefined dropdown to undefined string", () => {
+      const element = {
+        fields: { role: undefined },
+      };
+      const result = transformElement.in(element);
+      expect(result).toEqual(
+        partialPmeElement({ role: undefinedDropdownValue })
+      );
+    });
+    it("should not convert regular dropdown strings", () => {
+      const element = {
+        fields: { role: "showcase" },
+      };
+      const result = transformElement.in(element);
+      expect(result).toEqual(partialPmeElement({ role: "showcase" }));
+    });
+    it("should convert isMandatory to boolean", () => {
+      const element = {
+        fields: { isMandatory: "false" },
+      };
+      const result = transformElement.in(element);
+      expect(result).toEqual(partialPmeElement({ isMandatory: false }));
+    });
+  });
+
+  describe("transformOut", () => {
+    it("should not allow elements which are the wrong type", () => {
+      // @ts-expect-error -- we should not be able to transform a malformed element
+      expect(() => transformElement.out({})).toThrow;
+      expect(() =>
+        transformElement.out({
+          // @ts-expect-error -- we should not be able to transform a malformed element
+          nonExistantField: "123",
+        })
+      ).toThrow;
+    });
+    it("should completely transform elements with all fields", () => {
+      const element = fullPmeElement();
+      const result = transformElement.out(element);
+      expect(result).toEqual(externalElement());
+    });
+    it("should convert undefined dropdown string to undefined", () => {
+      const element = fullPmeElement({ role: undefinedDropdownValue });
+      const result = transformElement.out(element);
+      expect(result).toEqual(externalElement({ role: undefined }));
+    });
+    it("should not convert regular dropdown strings", () => {
+      const element = fullPmeElement({ role: "showcase" });
+      const result = transformElement.out(element);
+      expect(result).toEqual(externalElement({ role: "showcase" }));
+    });
+    it("should convert isMandatory to string", () => {
+      const element = fullPmeElement({ isMandatory: false });
+      const result = transformElement.out(element);
+      expect(result).toEqual(externalElement({ isMandatory: "false" }));
+    });
+    it("should include optional fields when specified", () => {
+      const element = fullPmeElement({
+        alt: "Alt text",
+        caption: "caption",
+      });
+      const result = transformElement.out(element);
+      expect(result).toEqual(
+        externalElement({
+          alt: "Alt text",
+          caption: "caption",
+        })
+      );
+    });
+    it("should not include optional fields when they are empty", () => {
+      const element = fullPmeElement({
+        alt: "",
+        caption: "",
+      });
+      const result = transformElement.out(element);
+      expect(result).toEqual(externalElement());
+    });
+  });
+});

--- a/src/elements/interactive/interactiveDataTransformer.ts
+++ b/src/elements/interactive/interactiveDataTransformer.ts
@@ -4,14 +4,16 @@ import type { TransformIn, TransformOut } from "../helpers/types/Transform";
 import type { createInteractiveFields } from "./InteractiveSpec";
 
 export type ExternalInteractiveFields = {
-  alt: string;
-  caption: string;
   html: string;
   isMandatory: string;
-  role: string | undefined;
   scriptUrl: string;
   iframeUrl: string;
+  originalUrl: string;
+  scriptName: string;
   source: string;
+  alt?: string;
+  caption?: string;
+  role: string | undefined;
 };
 
 export type ExternalInteractiveData = {

--- a/src/elements/interactive/interactiveDataTransformer.ts
+++ b/src/elements/interactive/interactiveDataTransformer.ts
@@ -1,3 +1,4 @@
+import { pickBy } from "lodash";
 import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
 import { undefinedDropdownValue } from "../helpers/transform";
 import type { TransformIn, TransformOut } from "../helpers/types/Transform";
@@ -43,14 +44,25 @@ export const transformElementOut: TransformOut<
 > = ({
   isMandatory,
   role,
+  alt,
+  caption,
   ...rest
 }: FieldNameToValueMap<
   ReturnType<typeof createInteractiveFields>
 >): ExternalInteractiveData => {
+  const optionalFields = pickBy(
+    {
+      alt,
+      caption,
+    },
+    (field) => field.length > 0
+  );
+
   return {
     fields: {
       isMandatory: isMandatory.toString(),
       role: role === undefinedDropdownValue ? undefined : role,
+      ...optionalFields,
       ...rest,
     },
   };


### PR DESCRIPTION
## What does this change?
This PR includes the interactive element in `transform.ts`, which means it can properly interact with `flexible-content`.

It also:
- updates its fields to better reflect the data fields of the existing interactive element, which reduces the risk of problems downstream of `flexible-content` 
- updates the demo element to import the interactive more consistently with the other elements.
- Includes tests for the `interactiveDataTransformer`

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This should not affect the running of `prosemirror-elements`, only update its API - though you can run the application and test the demo locally following the instructions in the readme, or run the tests with `yarn test:unit` or `yarn test:integration`.
