### PR TITLE
fix: Use correct name for 'safeEmbedCode' field

### DIFF
--- a/src/elements/embed/embedComponents/__tests__/embedDataTransformer.spec.ts
+++ b/src/elements/embed/embedComponents/__tests__/embedDataTransformer.spec.ts
@@ -37,7 +37,7 @@ const externalElement = (data: Partial<ExternalEmbedFields> = {}) => {
     fields: {
       html: "",
       isMandatory: "false",
-      isSafe: "false",
+      safeEmbedCode: "false",
       role: undefined,
       ...data,
     },

--- a/src/elements/embed/embedDataTransformer.ts
+++ b/src/elements/embed/embedDataTransformer.ts
@@ -12,7 +12,7 @@ export type ExternalEmbedFields = {
   isMandatory: string;
   url?: string;
   role: string | undefined;
-  isSafe: string;
+  safeEmbedCode: string;
 };
 
 export type ExternalEmbedData = {
@@ -67,7 +67,7 @@ export const transformElementOut: TransformOut<
     fields: {
       html,
       isMandatory: isMandatory.toString(),
-      isSafe: isSafe.toString(),
+      safeEmbedCode: isSafe.toString(),
       role: role === undefinedDropdownValue ? undefined : role,
       ...optionalFields,
     },


### PR DESCRIPTION
## What does this change?
After the embed feature switch was turned on by default, [problems were reported with email newsletter embeds.](https://github.com/guardian/flexible-content/pull/3994). 

We deduced that this was due to a misnamed field - the `safeEmbedCode` field, which was instead called `isSafe`. This led to areas of the frontend wrapping iframe embeds in an additional iframe, leading to styling problems.

This PR gives that field the correct name.

## How to test
Run the application and its tests according to the instructions in the readme.