### PR TITLE
docs: Add data pane to show transformed element data

### DIFF
--- a/demo/helpers.ts
+++ b/demo/helpers.ts
@@ -1,3 +1,5 @@
+import type { EditorState, Transaction } from "prosemirror-state";
+import { Plugin } from "prosemirror-state";
 import type { DemoSetMedia } from "../src/elements/demo-image/DemoImageElement";
 import type { Asset, SetMedia } from "../src/elements/image/ImageElement";
 
@@ -156,3 +158,17 @@ export const onCropImage = (setMedia: SetMedia, mediaId?: string) => {
     { once: false }
   );
 };
+
+export type SideEffectCallback = (
+  tr: Transaction | null,
+  oldState: EditorState | null,
+  newState: EditorState
+) => void;
+
+export const sideEffectPlugin = (cb: SideEffectCallback): Plugin<void> =>
+  new Plugin({
+    state: {
+      init: (_, state) => cb(null, null, state),
+      apply: (tr, _, prev, state) => cb(tr, prev, state),
+    },
+  });

--- a/demo/index.html
+++ b/demo/index.html
@@ -21,7 +21,6 @@
     </div>
   </div>
 
-
   <div id="content-template" style="display: none;">
     <p>First paragraph</p>
     <p>Second paragraph</p>

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,18 +13,20 @@
 </head>
 
 <body>
-  <div id="button-container"><button id="content-data-toggle">Toggle data view</button></div>
-  <div id="content">
-    <div id="editor-container"></div>
-    <div id="content-data"></div>
+  <div id="content-container">
+    <div id="button-container"><button id="content-data-toggle">Toggle data view</button></div>
+    <div id="content">
+      <div id="editor-container"></div>
+      <div id="content-data"></div>
+    </div>
   </div>
+
 
   <div id="content-template" style="display: none;">
     <p>First paragraph</p>
     <p>Second paragraph</p>
   </div>
 
-  <hr />
   <script src="bundle.js"></script>
 
   <div class="modal">

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,12 +13,17 @@
 </head>
 
 <body>
-  <div id="button-container"></div>
-  <div id="editor-container"></div>
+  <div id="button-container"><button id="content-data-toggle">Toggle data view</button></div>
+  <div id="content">
+    <div id="editor-container"></div>
+    <div id="content-data"></div>
+  </div>
+
   <div id="content-template" style="display: none;">
     <p>First paragraph</p>
     <p>Second paragraph</p>
   </div>
+
   <hr />
   <script src="bundle.js"></script>
 

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -1,4 +1,5 @@
 import { FocusStyleManager } from "@guardian/src-foundations/utils";
+import omit from "lodash/omit";
 import type OrderedMap from "orderedmap";
 import { collab } from "prosemirror-collab";
 import { exampleSetup } from "prosemirror-example-setup";
@@ -42,14 +43,14 @@ import type { WindowType } from "./types";
 // Only show focus when the user is keyboard navigating, not when
 // they click a text field.
 FocusStyleManager.onlyShowFocusOnTabs();
-const embedElementName = "embedElement";
-const imageElementName = "imageElement";
+const embedElementName = "embed";
+const imageElementName = "image";
 const demoImageElementName = "demo-image-element";
-const codeElementName = "codeElement";
-const pullquoteElementName = "pullquoteElement";
-const richlinkElementName = "richlinkElement";
-const videoElementName = "videoElement";
-const interactiveElementName = "interactiveElement";
+const codeElementName = "code";
+const pullquoteElementName = "pullquote";
+const richlinkElementName = "rich-link";
+const videoElementName = "video";
+const interactiveElementName = "interactive";
 
 type Name =
   | typeof embedElementName
@@ -100,21 +101,21 @@ const {
   getElementDataFromNode,
 } = buildElementPlugin({
   "demo-image-element": createDemoImageElement(onSelectImage, onDemoCropImage),
-  imageElement,
-  embedElement: createEmbedElement({
+  image: imageElement,
+  embed: createEmbedElement({
     checkThirdPartyTracking: mockThirdPartyTracking,
     convertTwitter: (src) => console.log(`Add Twitter embed with src: ${src}`),
     convertYouTube: (src) => console.log(`Add youtube embed with src: ${src}`),
     createCaptionPlugins,
   }),
-  interactiveElement: createInteractiveElement({
+  interactive: createInteractiveElement({
     checkThirdPartyTracking: mockThirdPartyTracking,
     createCaptionPlugins,
   }),
-  codeElement,
-  pullquoteElement,
-  richlinkElement,
-  videoElement: createVideoElement({
+  code: codeElement,
+  pullquote: pullquoteElement,
+  "rich-link": richlinkElement,
+  video: createVideoElement({
     createCaptionPlugins,
     checkThirdPartyTracking: mockThirdPartyTracking,
   }),
@@ -129,7 +130,7 @@ const strike: MarkSpec = {
 
 const schema = new Schema({
   nodes: (basicSchema.spec.nodes as OrderedMap<NodeSpec>).append(nodeSpec),
-  marks: { ...marks, strike },
+  marks: { ...omit(marks, "code"), strike },
 });
 
 const { serializer, parser } = createParsers(schema);
@@ -201,7 +202,7 @@ const createEditor = (server: CollabServer) => {
       if (maybeElementData) {
         elementData.push(
           transformElementOut(
-            maybeElementData.elementName.replace("Element", "") as any,
+            maybeElementData.elementName as any,
             maybeElementData.values
           )
         );
@@ -376,7 +377,7 @@ const addEditorButton = document.createElement("button");
 addEditorButton.innerHTML = "Add another editor";
 addEditorButton.id = "add-editor";
 addEditorButton.addEventListener("click", () => createEditor(server));
-document.body.appendChild(addEditorButton);
+btnContainer.appendChild(addEditorButton);
 
 // Handy debugging tools. We assign a few things to window for our integration tests,
 // and to facilitate debugging.

--- a/demo/style.css
+++ b/demo/style.css
@@ -1,6 +1,9 @@
 html,
 body {
-  font-family: 'TE31 Text Egyptian'
+  font-family: 'TE31 Text Egyptian';
+  width: 100%;
+  height: 100%;
+  margin: 0;
 }
 
 html * {
@@ -97,17 +100,28 @@ h6 {
   background-color: #DCDCDC;
 }
 
+#content-container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
 #content {
   display: flex;
+  min-height: 0;
 }
 
 #editor-container, #content-data {
-  padding: 10px;
+  margin: 10px;
+  overflow-y: scroll;
 }
 
 #content-data {
   background: #eee;
   display: none;
+  padding: 10px;
   white-space: pre-wrap;
   font-family: monospace;
   flex-basis: 500px;

--- a/demo/style.css
+++ b/demo/style.css
@@ -97,11 +97,33 @@ h6 {
   background-color: #DCDCDC;
 }
 
+#content {
+  display: flex;
+}
+
+#editor-container, #content-data {
+  padding: 10px;
+}
+
+#content-data {
+  background: #eee;
+  display: none;
+  white-space: pre-wrap;
+  font-family: monospace;
+  flex-basis: 500px;
+  flex: 1 0 0;
+}
+
+#content-data.show-data {
+  display: block;
+}
+
 #editor-container {
   display: flex;
   width: 100%;
   /* Space for button container in fixed position */
   margin-top: 40px;
+  flex: 1 0 0;
 }
 
 #button-container {


### PR DESCRIPTION
## What does this change?

Adds a data pane, to make it easy to see what the data our elements  produce once they're run through our transformer.

![data-pane](https://user-images.githubusercontent.com/7767575/153226133-4a9800fd-3785-4e98-881a-d5bd191da4e8.gif)

When elements aren't recognised, they produce `null`.

Along the way, updates our layout with a few ergonomic bits and pieces: the top buttons are now sticky, and each pane for content and data now scrolls independently.

## How to test

Have a play. Does the pane perform as expected? Is it useful?
