### PR TITLE
feat: Add the Callout

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -35,6 +35,7 @@ import type { WindowType } from "./types";
 // they click a text field.
 FocusStyleManager.onlyShowFocusOnTabs();
 const embedElementName = "embedElement";
+const calloutElementName = "embedElement";
 const imageElementName = "imageElement";
 const demoImageElementName = "demo-image-element";
 const codeElementName = "codeElement";
@@ -45,6 +46,7 @@ const interactiveElementName = "interactiveElement";
 
 type Name =
   | typeof embedElementName
+  | typeof calloutElementName
   | typeof imageElementName
   | typeof demoImageElementName
   | typeof codeElementName
@@ -89,6 +91,12 @@ const { plugin: elementPlugin, insertElement, nodeSpec } = buildElementPlugin({
   "demo-image-element": createDemoImageElement(onSelectImage, onDemoCropImage),
   imageElement,
   embedElement: createEmbedElement({
+    checkThirdPartyTracking: mockThirdPartyTracking,
+    convertTwitter: (src) => console.log(`Add Twitter embed with src: ${src}`),
+    convertYouTube: (src) => console.log(`Add youtube embed with src: ${src}`),
+    createCaptionPlugins,
+  }),
+  calloutElement: createEmbedElement({
     checkThirdPartyTracking: mockThirdPartyTracking,
     convertTwitter: (src) => console.log(`Add Twitter embed with src: ${src}`),
     convertYouTube: (src) => console.log(`Add youtube embed with src: ${src}`),
@@ -219,6 +227,17 @@ const createEditor = (server: CollabServer) => {
     caption: "",
     altText: "",
     required: false,
+  });
+
+  createElementButton("Add callout element", calloutElementName, {
+    weighting: "",
+    sourceUrl: "",
+    embedCode: "",
+    caption: "",
+    altText: "",
+    required: false,
+    html:
+      '<div data-callout-tagname="callout-brexit"><h2>Callout<h2><p>callout-brexit</p></div>',
   });
 
   createElementButton("Add demo image element", demoImageElementName, {

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -35,7 +35,6 @@ import type { WindowType } from "./types";
 // they click a text field.
 FocusStyleManager.onlyShowFocusOnTabs();
 const embedElementName = "embedElement";
-const calloutElementName = "embedElement";
 const imageElementName = "imageElement";
 const demoImageElementName = "demo-image-element";
 const codeElementName = "codeElement";
@@ -46,7 +45,6 @@ const interactiveElementName = "interactiveElement";
 
 type Name =
   | typeof embedElementName
-  | typeof calloutElementName
   | typeof imageElementName
   | typeof demoImageElementName
   | typeof codeElementName
@@ -91,12 +89,6 @@ const { plugin: elementPlugin, insertElement, nodeSpec } = buildElementPlugin({
   "demo-image-element": createDemoImageElement(onSelectImage, onDemoCropImage),
   imageElement,
   embedElement: createEmbedElement({
-    checkThirdPartyTracking: mockThirdPartyTracking,
-    convertTwitter: (src) => console.log(`Add Twitter embed with src: ${src}`),
-    convertYouTube: (src) => console.log(`Add youtube embed with src: ${src}`),
-    createCaptionPlugins,
-  }),
-  calloutElement: createEmbedElement({
     checkThirdPartyTracking: mockThirdPartyTracking,
     convertTwitter: (src) => console.log(`Add Twitter embed with src: ${src}`),
     convertYouTube: (src) => console.log(`Add youtube embed with src: ${src}`),
@@ -229,13 +221,9 @@ const createEditor = (server: CollabServer) => {
     required: false,
   });
 
-  createElementButton("Add callout element", calloutElementName, {
-    weighting: "",
-    sourceUrl: "",
-    embedCode: "",
-    caption: "",
+  createElementButton("Add callout element", embedElementName, {
     altText: "",
-    required: false,
+    caption: "",
     html:
       '<div data-callout-tagname="callout-brexit"><h2>Callout<h2><p>callout-brexit</p></div>',
   });

--- a/src/elements/embed/Callout.tsx
+++ b/src/elements/embed/Callout.tsx
@@ -54,7 +54,7 @@ const calloutStyles = css`
     vertical-align: top;
   }
   th {
-    text-align: right;
+    text-align: left;
   }
   p,
   p:first-child {

--- a/src/elements/embed/Callout.tsx
+++ b/src/elements/embed/Callout.tsx
@@ -184,7 +184,8 @@ export const Callout: React.FunctionComponent<Props> = ({ tag }) => {
         }
       })
       .catch((e) => console.log(e));
-  }, []);
+    return () => setCallout(undefined);
+  }, [tag]);
 
   return (
     <FieldLayoutVertical data-cy={EmbedTestId}>

--- a/src/elements/embed/Callout.tsx
+++ b/src/elements/embed/Callout.tsx
@@ -7,6 +7,7 @@ import { Label } from "../../editorial-source-components/Label";
 import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
 import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
 import { unescapeHtml } from "../helpers/html";
+import { EmbedTestId } from "./EmbedForm";
 import type { createEmbedFields } from "./EmbedSpec";
 
 type Props = {
@@ -26,24 +27,6 @@ type TagFields = {
   formUrl: string;
 };
 
-export const EmbedElementTestId = "EmbedElement";
-
-const getCampaigns = (tag: string) => {
-  return fetch("https://targeting.gutools.co.uk/api/campaigns")
-    .then((response) => {
-      return response.json();
-    })
-    .then((data: Callout[]) => {
-      return data.find((callout) => callout.fields.tagName === tag);
-    });
-};
-
-export const extractTag = (html: string) => {
-  const pattern = 'data-callout-tagname="(.*?)"';
-  const tag = RegExp(pattern).exec(html);
-  return tag ? tag[1] : undefined;
-};
-
 const calloutStyles = css`
   ${textSans.small({ fontWeight: "regular", lineHeight: "loose" })}
   font-family: "Guardian Agate Sans";
@@ -57,7 +40,6 @@ const calloutStyles = css`
     padding: 1px 4px;
   }
   table {
-    /* table-layout: fixed; */
     width: 100%;
     border-collapse: collapse;
     border: 1px solid ${neutral[86]};
@@ -84,20 +66,34 @@ const calloutStyles = css`
   }
 `;
 
-const targetingAnchor = css`
-  display: inline-block;
-  margin-bottom: ${space[2]}px;
-`;
-
 const marginBottom = css`
   margin-bottom: ${space[2]}px !important;
 `;
+
+const getCampaigns = (tag: string) => {
+  return fetch("https://targeting.gutools.co.uk/api/campaigns")
+    .then((response) => {
+      return response.json();
+    })
+    .then((data: Callout[]) => {
+      return data.find((callout) => callout.fields.tagName === tag);
+    });
+};
+
+export const extractTag = (html: string) => {
+  const pattern = 'data-callout-tagname="(.*?)"';
+  const tag = RegExp(pattern).exec(html);
+  return tag ? tag[1] : undefined;
+};
 
 const CalloutTable = ({ calloutData }: { calloutData: Callout }) => {
   return (
     <div>
       <a
-        css={targetingAnchor}
+        css={css`
+          display: inline-block;
+          margin-bottom: ${space[2]}px;
+        `}
         href={`https://targeting.gutools.co.uk/campaigns/${calloutData.id}`}
       >
         View this callout on Targeting
@@ -184,9 +180,7 @@ const CalloutError = ({ tag }: { tag: string | undefined }) => {
   );
 };
 
-export const CalloutForm: React.FunctionComponent<Props> = ({
-  fieldValues,
-}) => {
+export const Callout: React.FunctionComponent<Props> = ({ fieldValues }) => {
   const [callout, setCallout] = useState<Callout | undefined>(undefined);
   const [campaigns, setCampaigns] = useState<Promise<Callout | undefined>>(
     new Promise((resolve) => resolve(undefined))
@@ -209,7 +203,7 @@ export const CalloutForm: React.FunctionComponent<Props> = ({
     .catch((e) => console.log(e));
 
   return (
-    <FieldLayoutVertical data-cy={EmbedElementTestId}>
+    <FieldLayoutVertical data-cy={EmbedTestId}>
       <div css={calloutStyles}>
         <Label>Callout</Label>
         {callout ? (

--- a/src/elements/embed/Callout.tsx
+++ b/src/elements/embed/Callout.tsx
@@ -9,7 +9,7 @@ import { unescapeHtml } from "../helpers/html";
 import { EmbedTestId } from "./EmbedForm";
 
 type Props = {
-  html: string;
+  tag: string;
 };
 
 type Callout = {
@@ -76,12 +76,6 @@ const getCampaigns = (tag: string) => {
     .then((data: Callout[]) => {
       return data.find((callout) => callout.fields.tagName === tag);
     });
-};
-
-export const extractTag = (html: string) => {
-  const pattern = 'data-callout-tagname="(.*?)"';
-  const tag = RegExp(pattern).exec(html);
-  return tag ? tag[1] : undefined;
 };
 
 const CalloutTable = ({ calloutData }: { calloutData: Callout }) => {
@@ -178,18 +172,14 @@ const CalloutError = ({ tag }: { tag: string | undefined }) => {
   );
 };
 
-export const Callout: React.FunctionComponent<Props> = ({ html }) => {
+export const Callout: React.FunctionComponent<Props> = ({ tag }) => {
   const [callout, setCallout] = useState<Callout | undefined>(undefined);
   const [campaigns, setCampaigns] = useState<Promise<Callout | undefined>>(
     new Promise((resolve) => resolve(undefined))
   );
 
-  const tag = extractTag(html);
-
   useEffect(() => {
-    if (tag) {
-      setCampaigns(getCampaigns(tag));
-    }
+    setCampaigns(getCampaigns(tag));
   }, []);
 
   campaigns

--- a/src/elements/embed/Callout.tsx
+++ b/src/elements/embed/Callout.tsx
@@ -124,6 +124,8 @@ const CalloutTable = ({ calloutData }: { calloutData: Callout }) => {
 };
 
 const CalloutError = ({ tag }: { tag: string | undefined }) => {
+  const edToolsEmail = "editorial.tools.dev@theguardian.com";
+  const centralProdEmail = "central.production@theguardian.com";
   return tag ? (
     <div>
       <Error css={marginBottom}>
@@ -137,14 +139,9 @@ const CalloutError = ({ tag }: { tag: string | undefined }) => {
         </li>
         <li>
           Contact Central Production (
-          <a href="mailto:central.production@guardian.co.uk">
-            central.production@guardian.co.uk
-          </a>
-          ) and the Editorial Tools team (
-          <a href="mailto:editorial.tools.dev@guardian.co.uk">
-            editorial.tools.dev@guardian.co.uk
-          </a>
-          ) for assistance.
+          <a href={`mailto:${centralProdEmail}`}>{centralProdEmail}</a>) and the
+          Editorial Tools team (
+          <a href={`mailto:${edToolsEmail}`}>{edToolsEmail}</a>) for assistance.
         </li>
       </ul>
     </div>
@@ -159,14 +156,9 @@ const CalloutError = ({ tag }: { tag: string | undefined }) => {
       </p>
       <p>
         If the problem persists, you may wish to contact Central Production (
-        <a href="mailto:central.production@guardian.co.uk">
-          central.production@guardian.co.uk
-        </a>
-        ) and the Editorial Tools team (
-        <a href="mailto:editorial.tools.dev@guardian.co.uk">
-          editorial.tools.dev@guardian.co.uk
-        </a>
-        ) for assistance.
+        <a href={`mailto:${centralProdEmail}`}>{centralProdEmail}</a>) and the
+        Editorial Tools team (
+        <a href={`mailto:${edToolsEmail}`}>{edToolsEmail}</a>) for assistance.
       </p>
     </div>
   );

--- a/src/elements/embed/Callout.tsx
+++ b/src/elements/embed/Callout.tsx
@@ -5,13 +5,11 @@ import React, { useEffect, useState } from "react";
 import { Error } from "../../editorial-source-components/Error";
 import { Label } from "../../editorial-source-components/Label";
 import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
-import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
 import { unescapeHtml } from "../helpers/html";
 import { EmbedTestId } from "./EmbedForm";
-import type { createEmbedFields } from "./EmbedSpec";
 
 type Props = {
-  fieldValues: FieldNameToValueMap<ReturnType<typeof createEmbedFields>>;
+  html: string;
 };
 
 type Callout = {
@@ -180,13 +178,13 @@ const CalloutError = ({ tag }: { tag: string | undefined }) => {
   );
 };
 
-export const Callout: React.FunctionComponent<Props> = ({ fieldValues }) => {
+export const Callout: React.FunctionComponent<Props> = ({ html }) => {
   const [callout, setCallout] = useState<Callout | undefined>(undefined);
   const [campaigns, setCampaigns] = useState<Promise<Callout | undefined>>(
     new Promise((resolve) => resolve(undefined))
   );
 
-  const tag = extractTag(fieldValues.html);
+  const tag = extractTag(html);
 
   useEffect(() => {
     if (tag) {

--- a/src/elements/embed/CalloutForm.tsx
+++ b/src/elements/embed/CalloutForm.tsx
@@ -34,7 +34,7 @@ const getCampaigns = (tag: string) => {
       return response.json();
     })
     .then((data: Callout[]) => {
-      return data.find((datum) => datum.fields.tagName === tag);
+      return data.find((callout) => callout.fields.tagName === tag);
     });
 };
 
@@ -102,7 +102,7 @@ const CalloutTable = ({ calloutData }: { calloutData: Callout }) => {
       >
         View this callout on Targeting
       </a>
-      <Label>Callout content:</Label>
+      <Label>Content:</Label>
       <table css={calloutStyles}>
         <tbody>
           <tr>

--- a/src/elements/embed/CalloutForm.tsx
+++ b/src/elements/embed/CalloutForm.tsx
@@ -145,7 +145,7 @@ const CalloutError = ({ tag }: { tag: string | undefined }) => {
   return tag ? (
     <div>
       <Error css={marginBottom}>
-        A callout was not found matching tag <code>{tag}</code>.
+        Error: A callout was not found matching tag <code>{tag}</code>.
       </Error>
       <p>Try refreshing the page. If the problem persists, you may wish to:</p>
       <ul>
@@ -169,10 +169,10 @@ const CalloutError = ({ tag }: { tag: string | undefined }) => {
   ) : (
     <div>
       <Error css={marginBottom}>
-        Error: Composer was unable to extract a tag from this Callout.
+        Error: Composer was unable to extract a tag from this callout.
       </Error>
       <p css={marginBottom}>
-        It is likely that the Callout element is malformed. Try deleting and
+        It is likely that the callout element is malformed. Try deleting and
         re-creating the the element.
       </p>
       <p>

--- a/src/elements/embed/CalloutForm.tsx
+++ b/src/elements/embed/CalloutForm.tsx
@@ -6,6 +6,7 @@ import { Error } from "../../editorial-source-components/Error";
 import { Label } from "../../editorial-source-components/Label";
 import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
 import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
+import { unescapeHtml } from "../helpers/html";
 import type { createEmbedFields } from "./EmbedSpec";
 
 type Props = {
@@ -27,24 +28,17 @@ type TagFields = {
 
 export const EmbedElementTestId = "EmbedElement";
 
-const decodeHtml = (html: string) => {
-  const txt = document.createElement("textarea");
-  txt.innerHTML = html;
-  return txt.value;
-};
-
 const getCampaigns = (tag: string) => {
   return fetch("https://targeting.gutools.co.uk/api/campaigns")
     .then((response) => {
       return response.json();
     })
     .then((data: Callout[]) => {
-      console.log(data);
       return data.find((datum) => datum.fields.tagName === tag);
     });
 };
 
-const extractTag = (html: string) => {
+export const extractTag = (html: string) => {
   const pattern = 'data-callout-tagname="(.*?)"';
   const tag = RegExp(pattern).exec(html);
   return tag ? tag[1] : undefined;
@@ -123,7 +117,7 @@ const CalloutTable = ({ calloutData }: { calloutData: Callout }) => {
             <th>Description</th>
             <td
               dangerouslySetInnerHTML={{
-                __html: decodeHtml(calloutData.fields.description),
+                __html: unescapeHtml(calloutData.fields.description),
               }}
             ></td>
           </tr>

--- a/src/elements/embed/CalloutForm.tsx
+++ b/src/elements/embed/CalloutForm.tsx
@@ -1,0 +1,185 @@
+import { css } from "@emotion/react";
+import { neutral, space, text } from "@guardian/src-foundations";
+import { textSans } from "@guardian/src-foundations/typography";
+import React, { useEffect, useState } from "react";
+import { Label } from "../../editorial-source-components/Label";
+import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
+import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
+import type { createEmbedFields } from "./EmbedSpec";
+
+type Props = {
+  fieldValues: FieldNameToValueMap<ReturnType<typeof createEmbedFields>>;
+};
+
+type Callout = {
+  id: string;
+  name: string;
+  fields: TagFields;
+};
+
+type TagFields = {
+  tagName: string;
+  callout: string;
+  description: string;
+  formUrl: string;
+};
+
+export const EmbedElementTestId = "EmbedElement";
+
+const decodeHtml = (html: string) => {
+  const txt = document.createElement("textarea");
+  txt.innerHTML = html;
+  return txt.value;
+};
+
+const getCampaigns = (tag: string) => {
+  return fetch("https://targeting.gutools.co.uk/api/campaigns")
+    .then((response) => {
+      return response.json();
+    })
+    .then((data: Callout[]) => {
+      console.log(data);
+      return data.find((datum) => datum.fields.tagName === tag);
+    });
+};
+
+const extractTag = (html: string) => {
+  const pattern = 'data-callout-tagname="(.*?)"';
+  const tag = RegExp(pattern).exec(html);
+  return tag ? tag[1] : undefined;
+};
+
+const calloutStyles = css`
+  ${textSans.small({ fontWeight: "regular", lineHeight: "loose" })}
+  font-family: "Guardian Agate Sans";
+  a {
+    color: ${text.anchorPrimary};
+  }
+  code {
+    font-family: monospace;
+    background-color: ${neutral[86]};
+    border-radius: ${space[1]}px;
+    padding: 1px 4px;
+  }
+  table {
+    /* table-layout: fixed; */
+    width: 100%;
+    border-collapse: collapse;
+    border: 1px solid ${neutral[86]};
+    font-size: 14px;
+  }
+  th,
+  tr,
+  td {
+    border: 1px solid ${neutral[86]};
+    padding: ${space[1]}px;
+    line-height: 14px;
+    vertical-align: top;
+  }
+  p,
+  p:first-child {
+    margin-top: 0px;
+    margin-bottom: 0px;
+  }
+`;
+
+const targetingAnchor = css`
+  display: inline-block;
+  margin-bottom: ${space[2]}px;
+`;
+
+export const CalloutForm: React.FunctionComponent<Props> = ({
+  fieldValues,
+}) => {
+  const [callout, setCallout] = useState<Callout | undefined>(undefined);
+  const [campaigns, setCampaigns] = useState<Promise<Callout | undefined>>(
+    new Promise((resolve) => resolve(undefined))
+  );
+
+  const tag = extractTag(fieldValues.html);
+
+  useEffect(() => {
+    if (tag) {
+      setCampaigns(getCampaigns(tag));
+    }
+  }, []);
+
+  campaigns
+    .then((callout) => {
+      if (callout) {
+        setCallout(callout);
+      }
+    })
+    .catch((e) => console.log(e));
+
+  return (
+    <FieldLayoutVertical data-cy={EmbedElementTestId}>
+      <div css={calloutStyles}>
+        <Label>Callout</Label>
+        {callout ? (
+          <div>
+            <a
+              css={targetingAnchor}
+              href={`https://targeting.gutools.co.uk/campaigns/${callout.id}`}
+            >
+              View this callout on Targeting
+            </a>
+
+            <table css={calloutStyles}>
+              <tbody>
+                <tr>
+                  <th>Tag Name</th>
+                  <td>{callout.fields.tagName}</td>
+                </tr>
+                <tr>
+                  <th>Title</th>
+                  <td>{callout.fields.callout}</td>
+                </tr>
+                <tr>
+                  <th>Description</th>
+                  <td
+                    dangerouslySetInnerHTML={{
+                      __html: decodeHtml(callout.fields.description),
+                    }}
+                  ></td>
+                </tr>
+                <tr>
+                  <th>Form URL</th>
+                  <td>
+                    <a href={callout.fields.formUrl}>
+                      {callout.fields.formUrl}
+                    </a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div>
+            <p>
+              A callout was not found matching tag{" "}
+              <code>{extractTag(fieldValues.html)}</code>.
+            </p>
+            <br />
+            <p>
+              Try refreshing the page. If the problem persists, you may wish to:
+            </p>
+            <ul>
+              <li>
+                Check that the callout exists in{" "}
+                <a href="https://targeting.gutools.co.uk/campaigns/">
+                  Targeting
+                </a>
+              </li>
+              <li>
+                Contact Central Production (central.production@guardian.co.uk)
+                and the Editorial Tools team (editorial.tools.dev@guardian.co.uk
+                ) for assistance.
+              </li>
+            </ul>
+          </div>
+        )}
+      </div>
+    </FieldLayoutVertical>
+  );
+};

--- a/src/elements/embed/CalloutForm.tsx
+++ b/src/elements/embed/CalloutForm.tsx
@@ -2,6 +2,7 @@ import { css } from "@emotion/react";
 import { neutral, space, text } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
 import React, { useEffect, useState } from "react";
+import { Error } from "../../editorial-source-components/Error";
 import { Label } from "../../editorial-source-components/Label";
 import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
 import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
@@ -76,9 +77,15 @@ const calloutStyles = css`
     line-height: 14px;
     vertical-align: top;
   }
+  th {
+    text-align: right;
+  }
   p,
   p:first-child {
     margin-top: 0px;
+    margin-bottom: 0px;
+  }
+  ul {
     margin-bottom: 0px;
   }
 `;
@@ -87,6 +94,101 @@ const targetingAnchor = css`
   display: inline-block;
   margin-bottom: ${space[2]}px;
 `;
+
+const marginBottom = css`
+  margin-bottom: ${space[2]}px !important;
+`;
+
+const CalloutTable = ({ calloutData }: { calloutData: Callout }) => {
+  return (
+    <div>
+      <a
+        css={targetingAnchor}
+        href={`https://targeting.gutools.co.uk/campaigns/${calloutData.id}`}
+      >
+        View this callout on Targeting
+      </a>
+      <Label>Callout content:</Label>
+      <table css={calloutStyles}>
+        <tbody>
+          <tr>
+            <th>Tag Name</th>
+            <td>{calloutData.fields.tagName}</td>
+          </tr>
+          <tr>
+            <th>Title</th>
+            <td>{calloutData.fields.callout}</td>
+          </tr>
+          <tr>
+            <th>Description</th>
+            <td
+              dangerouslySetInnerHTML={{
+                __html: decodeHtml(calloutData.fields.description),
+              }}
+            ></td>
+          </tr>
+          <tr>
+            <th>Form URL</th>
+            <td>
+              <a href={calloutData.fields.formUrl}>
+                {calloutData.fields.formUrl}
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+const CalloutError = ({ tag }: { tag: string | undefined }) => {
+  return tag ? (
+    <div>
+      <Error css={marginBottom}>
+        A callout was not found matching tag <code>{tag}</code>.
+      </Error>
+      <p>Try refreshing the page. If the problem persists, you may wish to:</p>
+      <ul>
+        <li>
+          Check that the callout exists in{" "}
+          <a href="https://targeting.gutools.co.uk/campaigns/">Targeting</a>
+        </li>
+        <li>
+          Contact Central Production (
+          <a href="mailto:central.production@guardian.co.uk">
+            central.production@guardian.co.uk
+          </a>
+          ) and the Editorial Tools team (
+          <a href="mailto:editorial.tools.dev@guardian.co.uk">
+            editorial.tools.dev@guardian.co.uk
+          </a>
+          ) for assistance.
+        </li>
+      </ul>
+    </div>
+  ) : (
+    <div>
+      <Error css={marginBottom}>
+        Error: Composer was unable to extract a tag from this Callout.
+      </Error>
+      <p css={marginBottom}>
+        It is likely that the Callout element is malformed. Try deleting and
+        re-creating the the element.
+      </p>
+      <p>
+        If the problem persists, you may wish to contact Central Production (
+        <a href="mailto:central.production@guardian.co.uk">
+          central.production@guardian.co.uk
+        </a>
+        ) and the Editorial Tools team (
+        <a href="mailto:editorial.tools.dev@guardian.co.uk">
+          editorial.tools.dev@guardian.co.uk
+        </a>
+        ) for assistance.
+      </p>
+    </div>
+  );
+};
 
 export const CalloutForm: React.FunctionComponent<Props> = ({
   fieldValues,
@@ -117,67 +219,9 @@ export const CalloutForm: React.FunctionComponent<Props> = ({
       <div css={calloutStyles}>
         <Label>Callout</Label>
         {callout ? (
-          <div>
-            <a
-              css={targetingAnchor}
-              href={`https://targeting.gutools.co.uk/campaigns/${callout.id}`}
-            >
-              View this callout on Targeting
-            </a>
-
-            <table css={calloutStyles}>
-              <tbody>
-                <tr>
-                  <th>Tag Name</th>
-                  <td>{callout.fields.tagName}</td>
-                </tr>
-                <tr>
-                  <th>Title</th>
-                  <td>{callout.fields.callout}</td>
-                </tr>
-                <tr>
-                  <th>Description</th>
-                  <td
-                    dangerouslySetInnerHTML={{
-                      __html: decodeHtml(callout.fields.description),
-                    }}
-                  ></td>
-                </tr>
-                <tr>
-                  <th>Form URL</th>
-                  <td>
-                    <a href={callout.fields.formUrl}>
-                      {callout.fields.formUrl}
-                    </a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+          <CalloutTable calloutData={callout} />
         ) : (
-          <div>
-            <p>
-              A callout was not found matching tag{" "}
-              <code>{extractTag(fieldValues.html)}</code>.
-            </p>
-            <br />
-            <p>
-              Try refreshing the page. If the problem persists, you may wish to:
-            </p>
-            <ul>
-              <li>
-                Check that the callout exists in{" "}
-                <a href="https://targeting.gutools.co.uk/campaigns/">
-                  Targeting
-                </a>
-              </li>
-              <li>
-                Contact Central Production (central.production@guardian.co.uk)
-                and the Editorial Tools team (editorial.tools.dev@guardian.co.uk
-                ) for assistance.
-              </li>
-            </ul>
-          </div>
+          <CalloutError tag={tag} />
         )}
       </div>
     </FieldLayoutVertical>

--- a/src/elements/embed/EmbedForm.tsx
+++ b/src/elements/embed/EmbedForm.tsx
@@ -22,9 +22,9 @@ type Props = {
   convertTwitter: (src: TwitterUrl) => void;
 };
 
-export const EmbedElementTestId = "EmbedElement";
+export const EmbedTestId = "EmbedElement";
 
-export const EmbedElementForm: React.FunctionComponent<Props> = ({
+export const EmbedForm: React.FunctionComponent<Props> = ({
   fieldValues,
   errors,
   fields,
@@ -32,7 +32,7 @@ export const EmbedElementForm: React.FunctionComponent<Props> = ({
   convertYouTube,
   convertTwitter,
 }) => (
-  <FieldLayoutVertical data-cy={EmbedElementTestId}>
+  <FieldLayoutVertical data-cy={EmbedTestId}>
     <EmbedRecommendation
       html={fieldValues.html}
       convertTwitter={convertTwitter}

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -66,19 +66,17 @@ export const createEmbedFields = ({ createCaptionPlugins }: MainEmbedProps) => {
 export const createEmbedElement = (props: MainEmbedProps) =>
   createReactElementSpec(
     createEmbedFields(props),
-    ({ fields, errors, fieldValues }) => {
-      if (isCallout(fieldValues.html)) {
-        return <Callout fieldValues={fieldValues} />;
-      } else
-        return (
-          <EmbedForm
-            fields={fields}
-            errors={errors}
-            fieldValues={fieldValues}
-            checkThirdPartyTracking={props.checkThirdPartyTracking}
-            convertYouTube={props.convertYouTube}
-            convertTwitter={props.convertTwitter}
-          />
-        );
-    }
+    ({ fields, errors, fieldValues }) =>
+      isCallout(fieldValues.html) ? (
+        <Callout fieldValues={fieldValues} />
+      ) : (
+        <EmbedForm
+          fields={fields}
+          errors={errors}
+          fieldValues={fieldValues}
+          checkThirdPartyTracking={props.checkThirdPartyTracking}
+          convertYouTube={props.convertYouTube}
+          convertTwitter={props.convertTwitter}
+        />
+      )
   );

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -11,7 +11,7 @@ import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import type { TrackingStatus } from "../helpers/ThirdPartyStatusChecks";
 import { undefinedDropdownValue } from "../helpers/transform";
-import { CalloutForm } from "./CalloutForm";
+import { Callout } from "./Callout";
 import type { TwitterUrl, YoutubeUrl } from "./embedComponents/embedUtils";
 import { EmbedForm } from "./EmbedForm";
 
@@ -68,7 +68,7 @@ export const createEmbedElement = (props: MainEmbedProps) =>
     createEmbedFields(props),
     ({ fields, errors, fieldValues }) => {
       if (isCallout(fieldValues.html)) {
-        return <CalloutForm fieldValues={fieldValues} />;
+        return <Callout fieldValues={fieldValues} />;
       } else
         return (
           <EmbedForm

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -68,7 +68,7 @@ export const createEmbedElement = (props: MainEmbedProps) =>
     createEmbedFields(props),
     ({ fields, errors, fieldValues }) =>
       isCallout(fieldValues.html) ? (
-        <Callout fieldValues={fieldValues} />
+        <Callout html={fieldValues.html} />
       ) : (
         <EmbedForm
           fields={fields}

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -9,6 +9,7 @@ import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldVi
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+import { parseHtml } from "../helpers/html";
 import type { TrackingStatus } from "../helpers/ThirdPartyStatusChecks";
 import { undefinedDropdownValue } from "../helpers/transform";
 import { Callout } from "./Callout";
@@ -22,8 +23,16 @@ export type MainEmbedProps = {
   createCaptionPlugins?: (schema: Schema) => Plugin[];
 };
 
-const isCallout = (html: string) => {
-  return html.includes("data-callout-tagname");
+export const getCalloutTag = (html: string) => {
+  const element = parseHtml(html);
+  if (element) {
+    const tagName = element.getAttribute("data-callout-tagname");
+
+    if (tagName) {
+      return tagName;
+    }
+  }
+  return undefined;
 };
 
 export const createEmbedFields = ({ createCaptionPlugins }: MainEmbedProps) => {
@@ -66,9 +75,10 @@ export const createEmbedFields = ({ createCaptionPlugins }: MainEmbedProps) => {
 export const createEmbedElement = (props: MainEmbedProps) =>
   createReactElementSpec(
     createEmbedFields(props),
-    ({ fields, errors, fieldValues }) =>
-      isCallout(fieldValues.html) ? (
-        <Callout html={fieldValues.html} />
+    ({ fields, errors, fieldValues }) => {
+      const calloutTag = getCalloutTag(fieldValues.html);
+      return calloutTag ? (
+        <Callout tag={calloutTag} />
       ) : (
         <EmbedForm
           fields={fields}
@@ -78,5 +88,6 @@ export const createEmbedElement = (props: MainEmbedProps) =>
           convertYouTube={props.convertYouTube}
           convertTwitter={props.convertTwitter}
         />
-      )
+      );
+    }
   );

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -11,14 +11,19 @@ import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import type { TrackingStatus } from "../helpers/ThirdPartyStatusChecks";
 import { undefinedDropdownValue } from "../helpers/transform";
+import { CalloutForm } from "./CalloutForm";
 import type { TwitterUrl, YoutubeUrl } from "./embedComponents/embedUtils";
-import { EmbedElementForm } from "./EmbedForm";
+import { EmbedForm } from "./EmbedForm";
 
 export type MainEmbedProps = {
   checkThirdPartyTracking: (html: string) => Promise<TrackingStatus>;
   convertYouTube: (src: YoutubeUrl) => void;
   convertTwitter: (src: TwitterUrl) => void;
   createCaptionPlugins?: (schema: Schema) => Plugin[];
+};
+
+const isCallout = (html: string) => {
+  return html.includes("data-callout-tagname");
 };
 
 export const createEmbedFields = ({ createCaptionPlugins }: MainEmbedProps) => {
@@ -62,15 +67,18 @@ export const createEmbedElement = (props: MainEmbedProps) =>
   createReactElementSpec(
     createEmbedFields(props),
     ({ fields, errors, fieldValues }) => {
-      return (
-        <EmbedElementForm
-          fields={fields}
-          errors={errors}
-          fieldValues={fieldValues}
-          checkThirdPartyTracking={props.checkThirdPartyTracking}
-          convertYouTube={props.convertYouTube}
-          convertTwitter={props.convertTwitter}
-        />
-      );
+      if (isCallout(fieldValues.html)) {
+        return <CalloutForm fieldValues={fieldValues} />;
+      } else
+        return (
+          <EmbedForm
+            fields={fields}
+            errors={errors}
+            fieldValues={fieldValues}
+            checkThirdPartyTracking={props.checkThirdPartyTracking}
+            convertYouTube={props.convertYouTube}
+            convertTwitter={props.convertTwitter}
+          />
+        );
     }
   );

--- a/src/elements/embed/embedComponents/__tests__/callout.spec.ts
+++ b/src/elements/embed/embedComponents/__tests__/callout.spec.ts
@@ -1,20 +1,20 @@
-import { extractTag } from "../../Callout";
+import { getCalloutTag } from "../../EmbedSpec";
 
 const validCallout =
-  '<div data-callout-tagname="ab-new-things-formatting"><h2>Callout<h2><p>ab-new-things-formatting</p></div>';
+  '&lt;div data-callout-tagname="ab-new-things-formatting"&gt;&lt;h2&gt;Callout&lt;h2&gt;&lt;p&gt;ab-new-things-formatting&lt;/p&gt;&lt;/div&gt;';
 
 const invalidCallout =
-  '<div data-callout-tagname="ab-new-things-formatting><h2>Callout<h2><p>ab-new-things-formatting</p></div>';
+  '&lt;div data-callout-tagname="ab-new-things-formatting&gt;&lt;h2&gt;Callout&lt;h2&gt;&lt;p&gt;ab-new-things-formatting&lt;/p&gt;&lt;/div&gt;';
 
-describe("extractTag", () => {
+describe("getCalloutTag", () => {
   it("should extract the tag from valid callout html", () => {
-    const tag = extractTag(validCallout);
+    const tag = getCalloutTag(validCallout);
 
     expect(tag).toEqual("ab-new-things-formatting");
   });
 
   it("should return undefined for invalid callout html", () => {
-    const tag = extractTag(invalidCallout);
+    const tag = getCalloutTag(invalidCallout);
 
     expect(tag).toEqual(undefined);
   });

--- a/src/elements/embed/embedComponents/__tests__/callout.spec.ts
+++ b/src/elements/embed/embedComponents/__tests__/callout.spec.ts
@@ -1,4 +1,4 @@
-import { extractTag } from "../../CalloutForm";
+import { extractTag } from "../../Callout";
 
 const validCallout =
   '<div data-callout-tagname="ab-new-things-formatting"><h2>Callout<h2><p>ab-new-things-formatting</p></div>';

--- a/src/elements/embed/embedComponents/__tests__/callout.spec.ts
+++ b/src/elements/embed/embedComponents/__tests__/callout.spec.ts
@@ -1,0 +1,21 @@
+import { extractTag } from "../../CalloutForm";
+
+const validCallout =
+  '<div data-callout-tagname="ab-new-things-formatting"><h2>Callout<h2><p>ab-new-things-formatting</p></div>';
+
+const invalidCallout =
+  '<div data-callout-tagname="ab-new-things-formatting><h2>Callout<h2><p>ab-new-things-formatting</p></div>';
+
+describe("extractTag", () => {
+  it("should extract the tag from valid callout html", () => {
+    const tag = extractTag(validCallout);
+
+    expect(tag).toEqual("ab-new-things-formatting");
+  });
+
+  it("should return undefined for invalid callout html", () => {
+    const tag = extractTag(invalidCallout);
+
+    expect(tag).toEqual(undefined);
+  });
+});


### PR DESCRIPTION
Co-authored with @SHession 

## What does this change?

This PR adds the Callout. This is rendered when the `html` field of an Embed element contains the string "data-callout-tagname".

I've taken the opportunity to make the Callout's UX more useful.

In Composer, the user doesn't get much feedback from the old Callout: 
![image](https://user-images.githubusercontent.com/34686302/154037838-22c39b86-876c-4524-9559-1aa2c6b2a6a6.png)
This makes it hard for a user to understand what the element actually represents, or whether it's working as intended.

The new Callout fetches information from [Targeting](https://targeting.gutools.co.uk/) - the same information that is used by platforms to render the Callout in articles.
![image](https://user-images.githubusercontent.com/34686302/154038308-b0eda46d-84e5-4090-8b54-41b3b9deeac5.png)

There are also two error states representing:
- a failure to find a callout matching the tag
- a failure to parse a tag

(Previously these would silently fail)
![image](https://user-images.githubusercontent.com/34686302/154038878-a85efcbc-afe1-4028-8fce-9e79b674eb65.png)


## Context: 

We recently turned on the Embed element's feature switch. Shortly after, @SHession noticed that Callouts were being displayed as Embed elements in [Composer](https://github.com/guardian/flexible-content).

'Under the hood' - Callouts **are** embed elements - specifically any Embed element that contains the string "data-callout-tagname". Instead of being rendered as a form (like other Embed elements) - the Callout is rendered as an uneditable DOM element. In Composer, they're normally added with the 'Create Callout' button, but an Embed will also be converted into a Callout if the `html` field contains the string "data-callout-tagname".

It's worth mentioning that the Callout element could previously add an optional 'title' field to its representation in flexible-api. This is not used downstream so we are not continuing to add it.

## How to test

Hit the 'add callout element' button.

Alternatively, paste callout html into the embed element's `Embed code` field.

Valid callout:
```
<div data-callout-tagname="callout-brexit"><h2>Callout<h2><p>callout-brexit</p></div>
```
Invalid callout:
```
<div data-callout-tagname="tag-name-here"><h2>Callout<h2><p>tag-name-here</p></div>
```
Tag read error:
```
data-callout-tagname
```


![2022-02-15 09 54 54](https://user-images.githubusercontent.com/34686302/154037911-7b211697-1290-4f6f-afe6-6238b5a6cdc4.gif)

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [X] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [X] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [X] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [X] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [X] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
