### PR TITLE
feat: adds warning styling to element border

### DIFF
--- a/src/editorial-source-components/Editor.ts
+++ b/src/editorial-source-components/Editor.ts
@@ -6,7 +6,7 @@ import { inputBorder } from "./inputBorder";
 
 export const Editor = styled.div<{ hasValidationErrors: boolean }>`
   ${body.small()}
-  .ProseMirror {
+  .ProseMirrorElements__RichTextField, .ProseMirrorElements__TextField {
     background-color: ${background.primary};
     ${inputBorder}
     ${({ hasValidationErrors }) =>


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Currently elements with warnings for presence/length checks render a red wanring message, however the red border around the input box is not present.
This PR aims to fix the CSS overriding issue in conjunction with the PR in `flexible-content`: https://github.com/guardian/flexible-content/pull/4006

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Running Composer Locally and creating a Pullquote element and ensuring that there is a red border around the input box along with the red warning text

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
### Before
<img width="717" alt="image" src="https://user-images.githubusercontent.com/49187886/154465399-b819b0e6-00f7-495b-9dea-bc47292a1984.png">

### After
<img width="722" alt="image" src="https://user-images.githubusercontent.com/49187886/154464921-d71c0e12-7718-4df1-8551-dfc571c589b1.png">

### Image Element - before
<img width="400" alt="image" src="https://user-images.githubusercontent.com/49187886/154481706-961bf42f-55dc-4d14-b3bd-25e9ae2d0579.png">

### Image Element - after
<img width="387" alt="image" src="https://user-images.githubusercontent.com/49187886/154481217-dee41129-01eb-4ee7-8d93-cc46768ecd84.png">

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [ ] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [ ] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
