### PR TITLE
feat: ds/rich-link warning unpublished article

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -228,9 +228,10 @@ const createEditor = (server: CollabServer) => {
   });
 
   createElementButton("Add rich-link element", richlinkElementName, {
-    linkText: "example",
+    linkText: "example2",
     url: "https://example.com",
     weighting: "",
+    draftReference: "ds",
   });
 
   createElementButton("Add video element", videoElementName, {

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -231,7 +231,7 @@ const createEditor = (server: CollabServer) => {
     linkText: "example2",
     url: "https://example.com",
     weighting: "",
-    draftReference: "ds",
+    draftReference: "",
   });
 
   createElementButton("Add video element", videoElementName, {

--- a/src/elements/rich-link/RichlinkForm.tsx
+++ b/src/elements/rich-link/RichlinkForm.tsx
@@ -63,7 +63,7 @@ export const RichlinkElementForm: React.FunctionComponent<Props> = ({
         <span css={warningStyle}>
           <SvgAlertTriangle />
           This rich link references unpublished content. It will not appear
-          until the tarket has been published.
+          until the target has been published.
         </span>
       ) : null}
     </div>

--- a/src/elements/rich-link/RichlinkForm.tsx
+++ b/src/elements/rich-link/RichlinkForm.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/react";
 import React from "react";
 import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
 import type { FieldValidationErrors } from "../../plugin/elementSpec";
@@ -11,6 +12,10 @@ type Props = {
   errors: FieldValidationErrors;
   fields: FieldNameToField<typeof richlinkFields>;
 };
+
+const warningStyle = css`
+  background-color: purple;
+`;
 
 export const RichlinkElementForm: React.FunctionComponent<Props> = ({
   errors,
@@ -30,5 +35,12 @@ export const RichlinkElementForm: React.FunctionComponent<Props> = ({
       errors={errors.weighting}
       display="inline"
     />
+    <div css={warningStyle}>
+      {fieldValues.draftReference ? (
+        <div>TRUE DONE: {fieldValues.draftReference}</div>
+      ) : (
+        <div>TRY NOTER</div>
+      )}
+    </div>{" "}
   </FieldLayoutVertical>
 );

--- a/src/elements/rich-link/RichlinkForm.tsx
+++ b/src/elements/rich-link/RichlinkForm.tsx
@@ -58,14 +58,14 @@ export const RichlinkElementForm: React.FunctionComponent<Props> = ({
       errors={errors.weighting}
       display="inline"
     />
-    <div css={warningContainer}>
-      {fieldValues.draftReference ? (
+    {fieldValues.draftReference ? (
+      <div css={warningContainer}>
         <span css={warningStyle}>
           <SvgAlertTriangle />
           This rich link references unpublished content. It will not appear
           until the target has been published.
         </span>
-      ) : null}
-    </div>
+      </div>
+    ) : null}
   </FieldLayoutVertical>
 );

--- a/src/elements/rich-link/RichlinkForm.tsx
+++ b/src/elements/rich-link/RichlinkForm.tsx
@@ -1,4 +1,5 @@
 import { css } from "@emotion/react";
+import { SvgAlertTriangle } from "@guardian/src-icons";
 import React from "react";
 import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
 import type { FieldValidationErrors } from "../../plugin/elementSpec";
@@ -14,7 +15,29 @@ type Props = {
 };
 
 const warningStyle = css`
-  background-color: purple;
+  font-family: "Guardian Agate Sans";
+  font-size: 0.9375em;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1em;
+  letter-spacing: 0em;
+  text-align: left;
+  color: #c7291c;
+  svg {
+    fill: #c7291c;
+    height: 1.2em;
+    top: 0.25em;
+    position: relative;
+    left: 0.045em;
+  }
+`;
+
+const warningContainer = css`
+  height: 1.25em;
+  width: 41.43em;
+  left: 1.25em;
+  top: 0em;
+  border-radius: nullpx;
 `;
 
 export const RichlinkElementForm: React.FunctionComponent<Props> = ({
@@ -35,12 +58,14 @@ export const RichlinkElementForm: React.FunctionComponent<Props> = ({
       errors={errors.weighting}
       display="inline"
     />
-    <div css={warningStyle}>
+    <div css={warningContainer}>
       {fieldValues.draftReference ? (
-        <div>TRUE DONE: {fieldValues.draftReference}</div>
-      ) : (
-        <div>TRY NOTER</div>
-      )}
-    </div>{" "}
+        <span css={warningStyle}>
+          <SvgAlertTriangle />
+          This rich link references unpublished content. It will not appear
+          until the tarket has been published.
+        </span>
+      ) : null}
+    </div>
   </FieldLayoutVertical>
 );

--- a/src/elements/rich-link/RichlinkSpec.tsx
+++ b/src/elements/rich-link/RichlinkSpec.tsx
@@ -13,6 +13,7 @@ export const richlinkFields = {
   url: createTextField(),
   originalUrl: createTextField(),
   linkPrefix: createTextField(),
+  draftReference: createTextField(),
 };
 
 export const richlinkElement = createReactElementSpec(


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Currently the behaviour for the rich link identifies whether the article which is being linked has been published or is in draft/preview mode.

However the new rich link element does not, this PR aims to amend this by adding:
- `draftReference` as in the rich link spec to communicate the status to Composer
- Styling to the element which renders a warning message to the user
- New style for warning designed by Ana Pradas - https://www.figma.com/file/Ji1XENAJJjzcxwwwfWZnJc/Embeds?node-id=606%3A5771

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
1 - Create an article in Composer up to a publishable state - but do not publish
2 - Create/open another Composer article
3 - Add the (non published) URL as a rich link in the new article and at this point the warning message will render
4 - Add a URL of an existing published article to see that no warning message shows

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
### Before
<img width="656" alt="image" src="https://user-images.githubusercontent.com/49187886/154921159-d208c355-c347-4bb4-b63a-468cc3bbbd62.png">

### Original element
<img width="652" alt="image" src="https://user-images.githubusercontent.com/49187886/154921267-f115929a-49ac-42bb-b024-70f9a7888fa4.png">

### New Element
<img width="733" alt="image" src="https://user-images.githubusercontent.com/49187886/154957557-11eb039f-efaa-4f6d-a955-124ae74ae005.png">


## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [ ] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [ ] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
