### PR TITLE
feat: Minor amends to rich text element

### DIFF
--- a/src/elements/rich-link/RichlinkForm.tsx
+++ b/src/elements/rich-link/RichlinkForm.tsx
@@ -32,14 +32,6 @@ const warningStyle = css`
   }
 `;
 
-const warningContainer = css`
-  height: 1.25em;
-  width: 41.43em;
-  left: 1.25em;
-  top: 0em;
-  border-radius: nullpx;
-`;
-
 export const RichlinkElementForm: React.FunctionComponent<Props> = ({
   errors,
   fields,
@@ -59,12 +51,10 @@ export const RichlinkElementForm: React.FunctionComponent<Props> = ({
       display="inline"
     />
     {fieldValues.draftReference ? (
-      <div css={warningContainer}>
-        <span css={warningStyle}>
-          <SvgAlertTriangle />
-          This rich link references unpublished content. It will not appear
-          until the target has been published.
-        </span>
+      <div css={warningStyle}>
+        <SvgAlertTriangle />
+        This rich link references unpublished content. It will not appear until
+        the target has been published.
       </div>
     ) : null}
   </FieldLayoutVertical>

--- a/src/elements/rich-link/RichlinkSpec.tsx
+++ b/src/elements/rich-link/RichlinkSpec.tsx
@@ -13,7 +13,7 @@ export const richlinkFields = {
   url: createTextField(),
   originalUrl: createTextField(),
   linkPrefix: createTextField(),
-  draftReference: createTextField(),
+  draftReference: createTextField({ absentOnEmpty: true }),
 };
 
 export const richlinkElement = createReactElementSpec(


### PR DESCRIPTION
## What does this change?

 - Removes the warning container to ensure warning text wraps
 - Ensures that draftReference is absent in output data when it is an empty string, for consistency with PROD

## How to test

- Add a draftReference to the rich link creation function in `demo/index.ts`, and check that the text wraps
- It's actually quite difficult to test the draftReference w/o using it in consuming code! You'll need to use `yalc` to confirm. Alternatively, merge with #196 locally and observe the output data.

## How can we measure success?

Consistency w/ our current setup.