### PR TITLE
feat: Callout - use targeting url matching environment

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -225,7 +225,7 @@ const createEditor = (server: CollabServer) => {
     altText: "",
     caption: "",
     html:
-      '<div data-callout-tagname="callout-brexit"><h2>Callout<h2><p>callout-brexit</p></div>',
+      '<div data-callout-tagname="test-form-six"><h2>Callout<h2><p>test-form-six</p></div>',
   });
 
   createElementButton("Add demo image element", demoImageElementName, {

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -93,6 +93,10 @@ const { plugin: elementPlugin, insertElement, nodeSpec } = buildElementPlugin({
     convertTwitter: (src) => console.log(`Add Twitter embed with src: ${src}`),
     convertYouTube: (src) => console.log(`Add youtube embed with src: ${src}`),
     createCaptionPlugins,
+    targetingUrls: {
+      prod: "https://targeting.gutools.co.uk",
+      code: "https://targeting.code.dev-gutools.co.uk",
+    },
   }),
   interactiveElement: createInteractiveElement({
     checkThirdPartyTracking: mockThirdPartyTracking,

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -93,10 +93,7 @@ const { plugin: elementPlugin, insertElement, nodeSpec } = buildElementPlugin({
     convertTwitter: (src) => console.log(`Add Twitter embed with src: ${src}`),
     convertYouTube: (src) => console.log(`Add youtube embed with src: ${src}`),
     createCaptionPlugins,
-    targetingUrls: {
-      prod: "https://targeting.gutools.co.uk",
-      code: "https://targeting.code.dev-gutools.co.uk",
-    },
+    targetingUrl: "https://targeting.code.dev-gutools.co.uk",
   }),
   interactiveElement: createInteractiveElement({
     checkThirdPartyTracking: mockThirdPartyTracking,

--- a/src/elements/embed/Callout.tsx
+++ b/src/elements/embed/Callout.tsx
@@ -68,13 +68,24 @@ const marginBottom = css`
   margin-bottom: ${space[2]}px !important;
 `;
 
+const env =
+  document.location.hostname.includes("local") ||
+  document.location.hostname.includes("code")
+    ? "CODE"
+    : "PROD";
+
+const targetingDomain =
+  env === "CODE"
+    ? "https://targeting.code.dev-gutools.co.uk"
+    : "https://targeting.gutools.co.uk";
+
 const getCampaigns = () => {
   let campaigns: Promise<Callout[]> | undefined = undefined;
   return () => {
     if (campaigns === undefined) {
-      campaigns = fetch(
-        "https://targeting.gutools.co.uk/api/campaigns"
-      ).then((response) => response.json());
+      campaigns = fetch(`${targetingDomain}/api/campaigns`).then((response) =>
+        response.json()
+      );
     }
     return campaigns;
   };
@@ -95,7 +106,7 @@ const CalloutTable = ({ calloutData }: { calloutData: Callout }) => {
           display: inline-block;
           margin-bottom: ${space[2]}px;
         `}
-        href={`https://targeting.gutools.co.uk/campaigns/${calloutData.id}`}
+        href={`${targetingDomain}/campaigns/${calloutData.id}`}
       >
         View this callout on Targeting
       </a>
@@ -144,7 +155,7 @@ const CalloutError = ({ tag }: { tag: string | undefined }) => {
       <ul>
         <li>
           Check that the callout exists in{" "}
-          <a href="https://targeting.gutools.co.uk/campaigns/">Targeting</a>
+          <a href={targetingDomain}>Targeting</a>
         </li>
         <li>
           Contact Central Production (

--- a/src/elements/embed/Callout.tsx
+++ b/src/elements/embed/Callout.tsx
@@ -7,11 +7,10 @@ import { Label } from "../../editorial-source-components/Label";
 import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
 import { unescapeHtml } from "../helpers/html";
 import { EmbedTestId } from "./EmbedForm";
-import type { TargetingUrls } from "./EmbedSpec";
 
 type Props = {
   tag: string;
-  targetingUrls: TargetingUrls;
+  targetingUrl: string;
 };
 
 type Callout = {
@@ -70,12 +69,6 @@ const marginBottom = css`
   margin-bottom: ${space[2]}px !important;
 `;
 
-const env =
-  document.location.hostname.includes("local") ||
-  document.location.hostname.includes("code")
-    ? "CODE"
-    : "PROD";
-
 const getCampaigns = (targetingDomain: string) => {
   let campaigns: Promise<Callout[]> | undefined = undefined;
   return () => {
@@ -98,10 +91,10 @@ const getCalloutByTag = (tag: string, targetingDomain: string) =>
 
 const CalloutTable = ({
   calloutData,
-  targetingDomain,
+  targetingUrl,
 }: {
   calloutData: Callout;
-  targetingDomain: string;
+  targetingUrl: string;
 }) => {
   return (
     <div>
@@ -110,7 +103,7 @@ const CalloutTable = ({
           display: inline-block;
           margin-bottom: ${space[2]}px;
         `}
-        href={`${targetingDomain}/campaigns/${calloutData.id}`}
+        href={`${targetingUrl}/campaigns/${calloutData.id}`}
       >
         View this callout on Targeting
       </a>
@@ -149,10 +142,10 @@ const CalloutTable = ({
 
 const CalloutError = ({
   tag,
-  targetingDomain,
+  targetingUrl,
 }: {
   tag: string | undefined;
-  targetingDomain: string;
+  targetingUrl: string;
 }) => {
   const edToolsEmail = "editorial.tools.dev@theguardian.com";
   const centralProdEmail = "central.production@theguardian.com";
@@ -164,8 +157,7 @@ const CalloutError = ({
       <p>Try refreshing the page. If the problem persists, you may wish to:</p>
       <ul>
         <li>
-          Check that the callout exists in{" "}
-          <a href={targetingDomain}>Targeting</a>
+          Check that the callout exists in <a href={targetingUrl}>Targeting</a>
         </li>
         <li>
           Contact Central Production (
@@ -196,15 +188,12 @@ const CalloutError = ({
 
 export const Callout: React.FunctionComponent<Props> = ({
   tag,
-  targetingUrls,
+  targetingUrl,
 }) => {
   const [callout, setCallout] = useState<Callout | undefined>(undefined);
 
-  const targetingDomain =
-    env === "CODE" ? targetingUrls.code : targetingUrls.prod;
-
   useEffect(() => {
-    getCalloutByTag(tag, targetingDomain)
+    getCalloutByTag(tag, targetingUrl)
       .then((callout) => {
         if (callout) {
           setCallout(callout);
@@ -219,12 +208,9 @@ export const Callout: React.FunctionComponent<Props> = ({
       <div css={calloutStyles}>
         <Label>Callout</Label>
         {callout ? (
-          <CalloutTable
-            calloutData={callout}
-            targetingDomain={targetingDomain}
-          />
+          <CalloutTable calloutData={callout} targetingUrl={targetingUrl} />
         ) : (
-          <CalloutError tag={tag} targetingDomain={targetingDomain} />
+          <CalloutError tag={tag} targetingUrl={targetingUrl} />
         )}
       </div>
     </FieldLayoutVertical>

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -16,17 +16,12 @@ import { Callout } from "./Callout";
 import type { TwitterUrl, YoutubeUrl } from "./embedComponents/embedUtils";
 import { EmbedForm } from "./EmbedForm";
 
-export type TargetingUrls = {
-  prod: string;
-  code: string;
-};
-
 export type MainEmbedProps = {
   checkThirdPartyTracking: (html: string) => Promise<TrackingStatus>;
   convertYouTube: (src: YoutubeUrl) => void;
   convertTwitter: (src: TwitterUrl) => void;
   createCaptionPlugins?: (schema: Schema) => Plugin[];
-  targetingUrls: TargetingUrls;
+  targetingUrl: string;
 };
 
 export const getCalloutTag = (html: string) => {
@@ -84,7 +79,7 @@ export const createEmbedElement = (props: MainEmbedProps) =>
     ({ fields, errors, fieldValues }) => {
       const calloutTag = getCalloutTag(fieldValues.html);
       return calloutTag ? (
-        <Callout tag={calloutTag} targetingUrls={props.targetingUrls} />
+        <Callout tag={calloutTag} targetingUrl={props.targetingUrl} />
       ) : (
         <EmbedForm
           fields={fields}

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -16,11 +16,17 @@ import { Callout } from "./Callout";
 import type { TwitterUrl, YoutubeUrl } from "./embedComponents/embedUtils";
 import { EmbedForm } from "./EmbedForm";
 
+export type TargetingUrls = {
+  prod: string;
+  code: string;
+};
+
 export type MainEmbedProps = {
   checkThirdPartyTracking: (html: string) => Promise<TrackingStatus>;
   convertYouTube: (src: YoutubeUrl) => void;
   convertTwitter: (src: TwitterUrl) => void;
   createCaptionPlugins?: (schema: Schema) => Plugin[];
+  targetingUrls: TargetingUrls;
 };
 
 export const getCalloutTag = (html: string) => {
@@ -78,7 +84,7 @@ export const createEmbedElement = (props: MainEmbedProps) =>
     ({ fields, errors, fieldValues }) => {
       const calloutTag = getCalloutTag(fieldValues.html);
       return calloutTag ? (
-        <Callout tag={calloutTag} />
+        <Callout tag={calloutTag} targetingUrls={props.targetingUrls} />
       ) : (
         <EmbedForm
           fields={fields}


### PR DESCRIPTION
## What does this change?
This PR changes the Targeting URL used by the Callout if the environment is local or CODE.

The following will use [Targeting CODE](https://targeting.code.dev-gutools.co.uk/):
- https://composer.local.dev-gutools.co.uk/
- https://composer.code.dev-gutools.co.uk/
- https://prosemirror-elements.local.dev-gutools.co.uk/

The following will use [Targeting PROD](https://targeting.gutools.co.uk/):
- https://composer.gutools.co.uk/

This will match the tags provided by Composer's environments (e.g. CODE/local Composer use tags from Targeting CODE).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Run locally following the instructions in the readme and add a callout element.

Does the callout correctly find callouts from [Targeting CODE](https://targeting.code.dev-gutools.co.uk/)?