### PR TITLE
chore: Add fixture based tests, and fixtures for rich-link element

### DIFF
--- a/src/elements/helpers/__tests__/fixtures/index.ts
+++ b/src/elements/helpers/__tests__/fixtures/index.ts
@@ -1,5 +1,9 @@
 import richLink from "./rich-link.json";
 
+/**
+ * A map of our element fixtures, where the key represents the element name that
+ * corresponds to the fixture, and the value is the fixture object.
+ */
 export const allElementFixtures = {
   "rich-link": richLink,
 };

--- a/src/elements/helpers/__tests__/fixtures/index.ts
+++ b/src/elements/helpers/__tests__/fixtures/index.ts
@@ -1,0 +1,5 @@
+import richLink from "./rich-link.json";
+
+export const allElementFixtures = {
+  "rich-link": richLink,
+};

--- a/src/elements/helpers/__tests__/fixtures/rich-link.json
+++ b/src/elements/helpers/__tests__/fixtures/rich-link.json
@@ -1,0 +1,302 @@
+[
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/education/2016/apr/07/how-to-stay-positive-and-manage-anxiety-during-exam-season\", \"role\": \"thumbnail\", \"linkText\": \"How to stay positive and manage anxiety during exam season\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/education/2016/apr/07/how-to-stay-positive-and-manage-anxiety-during-exam-season\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/education/2016/mar/21/eight-things-to-do-when-you-make-a-mistake\", \"role\": \"thumbnail\", \"linkText\": \"Eight things students should do when they make a mistake\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/education/2016/mar/21/eight-things-to-do-when-you-make-a-mistake\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/live/2016/may/05/tony-abbott-suggests-the-mining-industry-should-demonstrate-their-gratitude-to-ian-macfarlane-politics-live\", \"role\": \"thumbnail\", \"linkText\": \"Philip Lowe to replace Glenn Stevens as governor of the Reserve Bank – politics live\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/live/2016/may/05/tony-abbott-suggests-the-mining-industry-should-demonstrate-their-gratitude-to-ian-macfarlane-politics-live\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/2016/may/05/black-hole-attack-sucks-malcolm-turnbull-into-budget-twilight-zone\", \"role\": \"thumbnail\", \"linkText\": \"Black hole attack sucks Malcolm Turnbull into budget twilight zone | Lenore Taylor\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/2016/may/05/black-hole-attack-sucks-malcolm-turnbull-into-budget-twilight-zone\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/film/2016/apr/23/cillian-murphy-peaky-blinders-batman-scarecrow-tom-lamont\", \"role\": \"supporting\", \"linkText\": \"Cillian Murphy: ‘Is this it, for the rest of my days?’\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/film/2016/apr/23/cillian-murphy-peaky-blinders-batman-scarecrow-tom-lamont\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/sport/2016/may/04/chris-cusiter-retires-sale-scotland-glasgow-rugby-union\", \"role\": \"thumbnail\", \"linkText\": \"Scotland scrum-half Chris Cusiter announces retirement\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/sport/2016/may/04/chris-cusiter-retires-sale-scotland-glasgow-rugby-union\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/lifeandstyle/2015/dec/20/found-out-my-friend-used-ivf-she-should-tell-her-kids-mariella-frostrup\", \"role\": \"thumbnail\", \"linkText\": \"I found out my friend used IVF. I feel she should tell her kids | Mariella Frostrup\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/lifeandstyle/2015/dec/20/found-out-my-friend-used-ivf-she-should-tell-her-kids-mariella-frostrup\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/science/2016/may/04/scientists-break-record-for-keeping-lab-grown-human-embryos-alive\", \"role\": \"thumbnail\", \"linkText\": \"Researchers break record for keeping lab-grown human embryos alive\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/science/2016/may/04/scientists-break-record-for-keeping-lab-grown-human-embryos-alive\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/lifeandstyle/2016/apr/28/paying-for-baby-trouble-with-renting-womb-india\", \"role\": \"thumbnail\", \"linkText\": \"The trouble with renting a womb | Abby Rabinowitz\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/lifeandstyle/2016/apr/28/paying-for-baby-trouble-with-renting-womb-india\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/commentisfree/2016/apr/01/sex-babies-humans-parents-technology-science-fiction-pgd\", \"role\": \"thumbnail\", \"linkText\": \"Who needs sex to make babies? Pretty soon, humans won’t | Henry Greely\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/commentisfree/2016/apr/01/sex-babies-humans-parents-technology-science-fiction-pgd\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/2016/may/05/abbott-a-well-known-millionaire-offered-me-5000-when-i-was-a-new-mp\", \"role\": \"thumbnail\", \"linkText\": \"Abbott: a 'well-known millionaire' offered me $5,000 when I was a new MP\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/2016/may/05/abbott-a-well-known-millionaire-offered-me-5000-when-i-was-a-new-mp\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/2016/may/02/arthur-sinodinos-under-constant-stress-over-nsw-liberal-donations-revelations\", \"role\": \"thumbnail\", \"linkText\": \"Arthur Sinodinos 'under constant stress' over NSW Liberal donations revelations\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/2016/may/02/arthur-sinodinos-under-constant-stress-over-nsw-liberal-donations-revelations\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/2016/may/02/father-of-anzac-day-terror-plot-accused-pleads-for-son-to-be-released-on-bail\", \"role\": \"thumbnail\", \"linkText\": \"Father of Anzac Day terror plot accused pleads for son to be released on bail\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/2016/may/02/father-of-anzac-day-terror-plot-accused-pleads-for-son-to-be-released-on-bail\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/2016/apr/27/police-ran-online-sting-against-sydney-boy-charged-with-anzac-day-terrorism-plot\", \"role\": \"thumbnail\", \"linkText\": \"Police ran online sting against Sydney boy charged with Anzac Day terrorism plot\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/2016/apr/27/police-ran-online-sting-against-sydney-boy-charged-with-anzac-day-terrorism-plot\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/2016/may/03/corporate-tax-cuts-to-cost-budget-53bn-over-four-years\", \"role\": \"thumbnail\", \"linkText\": \"Corporate tax cuts to cost budget $5.3bn over four years\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/2016/may/03/corporate-tax-cuts-to-cost-budget-53bn-over-four-years\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/datablog/ng-interactive/2016/may/03/your-tax-dollars-how-is-the-government-spending-your-money\", \"role\": \"thumbnail\", \"linkText\": \"Your tax dollars: how is the government spending your money in the 2016 federal budget?\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/datablog/ng-interactive/2016/may/03/your-tax-dollars-how-is-the-government-spending-your-money\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/sustainable-business/2016/apr/04/workplace-wellness-how-offices-could-be-the-healthiest-place-for-you\", \"role\": \"thumbnail\", \"linkText\": \"Workplace wellness: how offices could be the healthiest place for you\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/sustainable-business/2016/apr/04/workplace-wellness-how-offices-could-be-the-healthiest-place-for-you\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/sustainable-business/2016/apr/20/building-with-nature-cities-that-steal-smart-ideas-from-plants-and-animals\", \"role\": \"thumbnail\", \"linkText\": \"Cities that steal smart ideas from plants and animals\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/sustainable-business/2016/apr/20/building-with-nature-cities-that-steal-smart-ideas-from-plants-and-animals\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/2016/may/04/youth-intern-scheme-will-exploit-workers-and-replace-real-jobs-say-unions\", \"role\": \"thumbnail\", \"linkText\": \"Youth intern scheme will exploit workers and replace 'real jobs', say unions\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/2016/may/04/youth-intern-scheme-will-exploit-workers-and-replace-real-jobs-say-unions\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/2016/may/05/budget-jobs-growth-investment-scott-morrison\", \"role\": \"thumbnail\", \"linkText\": \"Signs are not good for a budget based on 'jobs, growth and investment'\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/2016/may/05/budget-jobs-growth-investment-scott-morrison\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/world/2016/may/04/air-rage-inequality-happiness-plane-passengers\", \"role\": \"thumbnail\", \"linkText\": \"How the other half fly: what air rage tells us about inequality | Anne Perkins\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/world/2016/may/04/air-rage-inequality-happiness-plane-passengers\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/world/2016/may/02/armed-guards-at-indias-dams-as-drought-grips-country\", \"role\": \"thumbnail\", \"linkText\": \"Armed guards at India's dams as drought grips country\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/world/2016/may/02/armed-guards-at-indias-dams-as-drought-grips-country\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/lifeandstyle/2016/may/31/caramelised-recipes-tarte-tatin-canapes-dulce-de-leche-recipe-swap\", \"linkText\": \"Readers’ recipe swap: Caramelised | Dale Berning Sawa\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/lifeandstyle/2016/may/31/caramelised-recipes-tarte-tatin-canapes-dulce-de-leche-recipe-swap\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/environment/2016/may/14/fracking-ryedale-north-yorkshire-moors\", \"role\": \"thumbnail\", \"linkText\": \"In the timeless Yorkshire moors of my childhood, the frackers are poised to start drilling\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/environment/2016/may/14/fracking-ryedale-north-yorkshire-moors\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/world/gallery/2016/apr/18/ecuador-earthquake-rescue-operation-in-pictures\", \"role\": \"thumbnail\", \"linkText\": \"Ecuador earthquake rescue operation – in pictures\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/world/gallery/2016/apr/18/ecuador-earthquake-rescue-operation-in-pictures\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/uk-news/2016/mar/16/budget-2016-at-a-glance-key-points\", \"role\": \"thumbnail\", \"linkText\": \"Budget 2016 at a glance: the key points\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/uk-news/2016/mar/16/budget-2016-at-a-glance-key-points\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/books/2016/jul/04/the-statue-of-liberty-immigrants-independence-day\", \"role\": \"thumbnail\", \"linkText\": \"The Statue of Liberty was built to welcome immigrants – that welcome must not end | Dave Eggers\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/books/2016/jul/04/the-statue-of-liberty-immigrants-independence-day\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/us-news/2015/oct/29/new-york-city-statue-of-liberty-1886\", \"role\": \"thumbnail\", \"linkText\": \"New York City unveils Statue of Liberty: archive, 29 October 1886\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/us-news/2015/oct/29/new-york-city-statue-of-liberty-1886\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/commentisfree/2016/oct/10/debate-snub-ferguson-black-lives-matter\", \"role\": \"thumbnail\", \"linkText\": \"The greatest snub of the debate? It was against Black Lives Matter | Steven W Thrasher\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/commentisfree/2016/oct/10/debate-snub-ferguson-black-lives-matter\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/us-news/2016/oct/19/half-of-young-americans-prefer-meteor-apocalypse-to-donald-trump-presidency\", \"role\": \"thumbnail\", \"linkText\": \"Half of young Americans prefer meteor apocalypse to Donald Trump presidency\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/us-news/2016/oct/19/half-of-young-americans-prefer-meteor-apocalypse-to-donald-trump-presidency\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/datablog/ng-interactive/2016/feb/01/australian-political-donations-2014-15-search-the-data\", \"role\": \"thumbnail\", \"linkText\": \"Australian political donations 2014-15: search the data\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/datablog/ng-interactive/2016/feb/01/australian-political-donations-2014-15-search-the-data\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/2016/feb/01/liberal-party-accepted-25000-from-linc-energy-months-after-gas-leaks\", \"role\": \"thumbnail\", \"linkText\": \"Liberals accepted $25,000 from Linc Energy months after charges over gas leaks\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/2016/feb/01/liberal-party-accepted-25000-from-linc-energy-months-after-gas-leaks\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/football/blog/2016/may/04/manchester-city-vincent-kompany\", \"role\": \"thumbnail\", \"linkText\": \"Vincent Kompany injury again highlights Manchester City’s damning weakness | Jamie Jackson\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/football/blog/2016/may/04/manchester-city-vincent-kompany\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/football/blog/2016/may/04/real-madrid-atletico-derby-day-champions-league-final-manchester-city\", \"role\": \"supporting\", \"linkText\": \"Madrid given another derby day as Real match Atlético in Champions League | Sid Lowe\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/football/blog/2016/may/04/real-madrid-atletico-derby-day-champions-league-final-manchester-city\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/football/2016/may/01/swansea-city-liverpool-premier-league-match-report\", \"role\": \"thumbnail\", \"linkText\": \"Swansea’s André Ayew and Jack Cork teach Liverpool kids harsh lesson\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/football/2016/may/01/swansea-city-liverpool-premier-league-match-report\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/environment/2015/dec/07/storm-desmond-how-has-it-affected-you\", \"role\": \"thumbnail\", \"linkText\": \"Storm Desmond: how has it affected you?\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/environment/2015/dec/07/storm-desmond-how-has-it-affected-you\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/media/greenslade/2016/apr/26/10-journalists-resign-over-covert-funding-of-hungarian-news-website\", \"role\": \"thumbnail\", \"linkText\": \"10 journalists resign over covert funding of Hungarian news website\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/media/greenslade/2016/apr/26/10-journalists-resign-over-covert-funding-of-hungarian-news-website\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/commentisfree/2016/oct/05/birmingham-witnessing-tory-reformation-conservative-conference-brexit\", \"role\": \"thumbnail\", \"linkText\": \"We are witnessing nothing less than a Tory reformation  | Rafael Behr\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/commentisfree/2016/oct/05/birmingham-witnessing-tory-reformation-conservative-conference-brexit\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/books/2016/oct/04/disappearances-by-kj-orr-read-the-2016-winner-of-the-bbc-national-short-story-award\", \"role\": \"thumbnail\", \"linkText\": \"Disappearances by KJ Orr – read the 2016 winner of the BBC national short story award\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/books/2016/oct/04/disappearances-by-kj-orr-read-the-2016-winner-of-the-bbc-national-short-story-award\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/tv-and-radio/tvandradioblog/2015/oct/21/asian-provocateur-romesh-ranganathan-travel-tv-sri-lanka\", \"role\": \"thumbnail\", \"linkText\": \"Asian Provocateur: Romesh Ranganathan avoids travel TV cliches in his Sri Lankan journey\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/tv-and-radio/tvandradioblog/2015/oct/21/asian-provocateur-romesh-ranganathan-travel-tv-sri-lanka\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/tv-and-radio/2015/sep/30/asian-provocateur-romesh-ranganathan-in-sri-lanka\", \"role\": \"thumbnail\", \"linkText\": \"Romesh Ranganathan: ‘I was a bumbling Englishman in a Sri Lankan disguise’\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/tv-and-radio/2015/sep/30/asian-provocateur-romesh-ranganathan-in-sri-lanka\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/tv-and-radio/gallery/2017/jun/10/adam-west-a-life-in-pictures\", \"role\": \"thumbnail\", \"linkText\": \"Adam West – a life in pictures\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/tv-and-radio/gallery/2017/jun/10/adam-west-a-life-in-pictures\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/film/2016/jun/02/race-review-reverential-middle-of-the-pack-drama\", \"role\": \"thumbnail\", \"linkText\": \"Race review – reverential middle-of-the-pack drama\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/film/2016/jun/02/race-review-reverential-middle-of-the-pack-drama\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/football/2016/jan/30/volcano-iceland-national-football-team\", \"role\": \"thumbnail\", \"linkText\": \"Volcano! The incredible rise of Iceland's national football team\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/football/2016/jan/30/volcano-iceland-national-football-team\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/world/2016/may/28/iceland-great-time-to-be-tourist-football-glory-euro-2016\", \"role\": \"thumbnail\", \"linkText\": \"‘It’s a great time to be a tourist here’: Iceland prepares for sporting glory\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/world/2016/may/28/iceland-great-time-to-be-tourist-football-glory-euro-2016\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/technology/2015/apr/04/periscope-live-streaming-iphone-app\", \"role\": \"thumbnail\", \"linkText\": \"Periscope phone app gives millions a way to live-stream their lives\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/technology/2015/apr/04/periscope-live-streaming-iphone-app\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/media/2015/sep/13/periscope-app-syrian-refugees-bild\", \"role\": \"thumbnail\", \"linkText\": \"How live video on Periscope helped 'get inside' the Syrian refugees story\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/media/2015/sep/13/periscope-app-syrian-refugees-bild\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/world/2015/jul/23/what-is-wilson-doctrine-story-behind-mps-protection-snooping\", \"role\": \"thumbnail\", \"linkText\": \"What is the Wilson doctrine? The story behind MPs' protection from snooping\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/world/2015/jul/23/what-is-wilson-doctrine-story-behind-mps-protection-snooping\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/see-newcastle-gateshead/2016/may/03/win-a-weekend-trip-to-newcastlegateshead\", \"linkText\": \"Win a weekend trip to NewcastleGateshead\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/see-newcastle-gateshead/2016/may/03/win-a-weekend-trip-to-newcastlegateshead\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/football/2016/may/31/republic-of-ireland-euro-2016-squad\", \"role\": \"thumbnail\", \"linkText\": \"Ireland include Robbie Keane and James McCarthy in Euro 2016 squad\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/football/2016/may/31/republic-of-ireland-euro-2016-squad\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/fashion/2016/jun/11/long-lasting-nail-polish-chip-test-beauty-sali-hughes\", \"linkText\": \"Beauty: nail polish that stays put\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/fashion/2016/jun/11/long-lasting-nail-polish-chip-test-beauty-sali-hughes\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/books/2016/apr/17/the-sleep-revolution-by-arianna-huffington-digested-read\", \"role\": \"thumbnail\", \"linkText\": \"The Sleep Revolution by Arianna Huffington – digested read\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/books/2016/apr/17/the-sleep-revolution-by-arianna-huffington-digested-read\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/commentisfree/2016/may/23/spending-blights-nhs-cash-results-care\", \"role\": \"thumbnail\", \"linkText\": \"Spending blights the NHS – but not in the way you think | Anne Perkins\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/commentisfree/2016/may/23/spending-blights-nhs-cash-results-care\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/healthcare-network/2016/may/31/nhs-moving-backwards-race-equality\", \"role\": \"thumbnail\", \"linkText\": \"The NHS is moving backwards on race equality\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/healthcare-network/2016/may/31/nhs-moving-backwards-race-equality\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/music/2015/oct/12/jimi-hendrix-estate-sues-for-return-of-guitar-worth-up-to-1m\", \"role\": \"thumbnail\", \"linkText\": \"Jimi Hendrix estate sues for return of guitar worth up to $1m\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/music/2015/oct/12/jimi-hendrix-estate-sues-for-return-of-guitar-worth-up-to-1m\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/music/2012/oct/06/bb-king-music-blues-guitar\", \"role\": \"thumbnail\", \"linkText\": \"BB King at 87: the last of the great bluesmen\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/music/2012/oct/06/bb-king-music-blues-guitar\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/culture/2016/jun/07/kim-cattrall-battle-chronic-insomnia-sex-and-the-city\", \"role\": \"thumbnail\", \"linkText\": \"Kim Cattrall on her battle with insomnia: 'I was in a void'\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/culture/2016/jun/07/kim-cattrall-battle-chronic-insomnia-sex-and-the-city\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/world/2016/jun/06/eu-sudan-eritrea-migration\", \"role\": \"thumbnail\", \"linkText\": \"EU considering working with Sudan and Eritrea to stem migration\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/world/2016/jun/06/eu-sudan-eritrea-migration\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/world/2015/jul/22/eritrea-migrants-child-soldier-fled-what-is-going\", \"role\": \"thumbnail\", \"linkText\": \"It's not at war, but up to 3% of its people have fled. What is going on in Eritrea?\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/world/2015/jul/22/eritrea-migrants-child-soldier-fled-what-is-going\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/world/2016/may/24/desmond-tutus-daughter-leaves-clergy-after-marrying-female-partner\", \"role\": \"thumbnail\", \"linkText\": \"Desmond Tutu's daughter leaves clergy after marrying female partner\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/world/2016/may/24/desmond-tutus-daughter-leaves-clergy-after-marrying-female-partner\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/lifeandstyle/2015/oct/11/the-day-i-walked-in-the-bushveld-with-desmond-tutu\", \"role\": \"thumbnail\", \"linkText\": \"The day I walked in the bushveld with Desmond Tutu\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/lifeandstyle/2015/oct/11/the-day-i-walked-in-the-bushveld-with-desmond-tutu\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/world/2016/jan/08/how-issue-of-gay-rights-has-racked-anglican-churches-for-decades\", \"role\": \"thumbnail\", \"linkText\": \"How issue of gay rights has racked Anglican churches for decades\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/world/2016/jan/08/how-issue-of-gay-rights-has-racked-anglican-churches-for-decades\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/commentisfree/2014/jul/12/desmond-tutu-in-favour-of-assisted-dying\", \"role\": \"thumbnail\", \"linkText\": \"Desmond Tutu: a dignified death is our right – I am in favour of assisted dying | Desmond Tutu\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/commentisfree/2014/jul/12/desmond-tutu-in-favour-of-assisted-dying\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/media/2016/mar/12/radio-5-live-time-for-online-only\", \"role\": \"thumbnail\", \"linkText\": \"BBC Radio 5Live keeps the nation company. It would be wrong to take it off-air\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/media/2016/mar/12/radio-5-live-time-for-online-only\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/media/2016/mar/11/fake-giant-rat-picture-internet\", \"role\": \"thumbnail\", \"linkText\": \"How to fake a giant rat (and why you shouldn't trust pictures on the internet)\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/media/2016/mar/11/fake-giant-rat-picture-internet\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/media/2016/apr/17/fake-news-stories-clicks-fact-checking\", \"role\": \"thumbnail\", \"linkText\": \"How newsroom pressure is letting fake stories on to the web\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/media/2016/apr/17/fake-news-stories-clicks-fact-checking\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/cities/2016/jan/08/costs-berlin-rent-housing-subway-map\", \"role\": \"thumbnail\", \"linkText\": \"How much it costs to rent in Berlin – mapped by its metro stations\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/cities/2016/jan/08/costs-berlin-rent-housing-subway-map\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/cities/2015/sep/23/housing-trap-how-berlin-avoid-following-london-pricey-footsteps\", \"role\": \"thumbnail\", \"linkText\": \"The housing trap: how can Berlin avoid following in London's pricey footsteps?\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/cities/2015/sep/23/housing-trap-how-berlin-avoid-following-london-pricey-footsteps\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/commentisfree/2016/oct/14/black-actors-overlooked-worse-ethnic-minorities-asian-racial-stereotypes\", \"role\": \"thumbnail\", \"linkText\": \"Black actors are too often overlooked. It’s even worse for other ethnic minorities | Andrew Rajan\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/commentisfree/2016/oct/14/black-actors-overlooked-worse-ethnic-minorities-asian-racial-stereotypes\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/money/commentisfree/2016/mar/21/fear-cashless-world-contactless\", \"role\": \"thumbnail\", \"linkText\": \"Why we should fear a cashless world | Dominic Frisby\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/money/commentisfree/2016/mar/21/fear-cashless-world-contactless\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/small-business-network/2016/apr/09/are-fintechs-helping-banks-evolve-or-planning-a-revolution\", \"role\": \"thumbnail\", \"linkText\": \"Are fintechs helping banks evolve – or planning a revolution?\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/small-business-network/2016/apr/09/are-fintechs-helping-banks-evolve-or-planning-a-revolution\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/music/2016/may/07/never-mind-bus-pass-punks-look-back-wildest-days\", \"role\": \"thumbnail\", \"linkText\": \"Never mind the bus pass: punks look back at their wildest days\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/music/2016/may/07/never-mind-bus-pass-punks-look-back-wildest-days\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/australia-news/2017/aug/23/the-answers-in-the-post-australian-marriage-equality-vote-explainer\", \"role\": \"thumbnail\", \"linkText\": \"The answer's in the post – Australian marriage equality vote explainer\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/australia-news/2017/aug/23/the-answers-in-the-post-australian-marriage-equality-vote-explainer\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/australia-news/2017/aug/09/abbotts-obstruction-of-gay-marriage-is-a-defence-of-privilege-and-the-power-of-shame-david-marr\", \"role\": \"thumbnail\", \"linkText\": \"Abbott's obstruction of gay marriage is a defence of privilege and the power of shame | David Marr\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/australia-news/2017/aug/09/abbotts-obstruction-of-gay-marriage-is-a-defence-of-privilege-and-the-power-of-shame-david-marr\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/world/2016/may/05/ahmet-davutoglus-future-turkish-prime-minister-balance\", \"role\": \"thumbnail\", \"linkText\": \"Turkish PM Davutoğlu resigns as President Erdoğan tightens grip\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/world/2016/may/05/ahmet-davutoglus-future-turkish-prime-minister-balance\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/world/2016/may/03/merkel-served-me-up-for-tea-to-erdogan-german-comedian-jan-bohmermann-\", \"role\": \"thumbnail\", \"linkText\": \"Merkel 'served me up for tea' to Erdoğan, says German comedian\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/world/2016/may/03/merkel-served-me-up-for-tea-to-erdogan-german-comedian-jan-bohmermann-\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/books/2010/feb/14/crime-fiction-merritt-sj-parris\", \"role\": \"thumbnail\", \"linkText\": \"Forget 'serious' novels, I've turned to a life of crime\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/books/2010/feb/14/crime-fiction-merritt-sj-parris\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/music/2016/mar/13/punk-1976-1978-british-library-40th-anniversary-sex-pistols-buzzcocks\", \"role\": \"thumbnail\", \"linkText\": \"Happy Birthday Punk: the British Library celebrates 40 years of anarchy and innovation\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/music/2016/mar/13/punk-1976-1978-british-library-40th-anniversary-sex-pistols-buzzcocks\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/film/2016/apr/29/proms-kevin-costner-a-smiley-face-the-onion-we-review-anything\", \"role\": \"thumbnail\", \"linkText\": \"Proms, Kevin Costner's \\\"English\\\" accent, a smiley face, the onion – we review anything\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/film/2016/apr/29/proms-kevin-costner-a-smiley-face-the-onion-we-review-anything\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/culture/2016/apr/15/games-based-on-pop-stars-yesterday-afternoon-a-bin-root-canals-we-review-anything\", \"role\": \"thumbnail\", \"linkText\": \"Games based on pop stars, yesterday afternoon, a bin, root canals – we review anything\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/culture/2016/apr/15/games-based-on-pop-stars-yesterday-afternoon-a-bin-root-canals-we-review-anything\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/culture/2016/apr/08/iggy-pops-cockatoo-hamster-toys-a-sign-a-guide-writers-career-choices-we-review-anything\", \"role\": \"thumbnail\", \"linkText\": \"Iggy Pop's cockatoo, hamster toys, a sign, a Guide writer's career choices: we review anything\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/culture/2016/apr/08/iggy-pops-cockatoo-hamster-toys-a-sign-a-guide-writers-career-choices-we-review-anything\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/football/2016/apr/26/hillsborough-disaster-deadly-mistakes-and-lies-that-lasted-decades\", \"role\": \"thumbnail\", \"linkText\": \"Hillsborough disaster: deadly mistakes and lies that lasted decades\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/football/2016/apr/26/hillsborough-disaster-deadly-mistakes-and-lies-that-lasted-decades\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/football/2016/may/03/hillsborough-families-criticise-south-yorkshire-pcc-over-inquest-tactics\", \"role\": \"thumbnail\", \"linkText\": \"Hillsborough families criticise South Yorkshire PCC over inquest tactics\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/football/2016/may/03/hillsborough-families-criticise-south-yorkshire-pcc-over-inquest-tactics\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/us-news/live/2016/may/05/donald-trump-nomination-republican-party-us-election-news-sanders-clinton-live\", \"role\": \"thumbnail\", \"linkText\": \"Trump's presumptive nomination divides Republicans – campaign live\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/us-news/live/2016/may/05/donald-trump-nomination-republican-party-us-election-news-sanders-clinton-live\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/commentisfree/2017/jun/16/theresa-may-scared-grenfell-survivors-finished-austerity-cameron-osborne\", \"role\": \"thumbnail\", \"linkText\": \"Theresa May was too scared to meet the Grenfell survivors. She’s finished | Polly Toynbee\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/commentisfree/2017/jun/16/theresa-may-scared-grenfell-survivors-finished-austerity-cameron-osborne\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/lifeandstyle/australia-food-blog/2014/nov/26/forget-the-thermomix-your-kitchen-appliances-have-secret-powers\", \"role\": \"thumbnail\", \"linkText\": \"Forget the Thermomix - your kitchen appliances have secret powers\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/lifeandstyle/australia-food-blog/2014/nov/26/forget-the-thermomix-your-kitchen-appliances-have-secret-powers\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/us-news/2017/mar/27/solar-power-florida-new-york-renewable-energy-policies\", \"role\": \"thumbnail\", \"linkText\": \"Sunshine state shuns solar as overcast New York basks in clean energy boom\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/us-news/2017/mar/27/solar-power-florida-new-york-renewable-energy-policies\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/environment/2017/jun/01/donald-trump-paris-climate-deal-pullout-us-impact\", \"role\": \"thumbnail\", \"linkText\": \"The Paris deal pullout is more damaging to the US than the climate\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/environment/2017/jun/01/donald-trump-paris-climate-deal-pullout-us-impact\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/politics/2017/jun/14/liberal-democrats-leadership-race-the-early-runners-and-riders\", \"role\": \"thumbnail\", \"linkText\": \"Liberal Democrats leadership race: the early runners and riders\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/politics/2017/jun/14/liberal-democrats-leadership-race-the-early-runners-and-riders\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/politics/2017/jun/14/tim-farron-quits-as-lib-dem-leader\", \"role\": \"thumbnail\", \"linkText\": \"Tim Farron quits as Lib Dem leader\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/politics/2017/jun/14/tim-farron-quits-as-lib-dem-leader\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/politics/2017/jun/14/lib-dem-peer-brian-paddick-resigns-over-farrons-views-on-gay-sex\", \"role\": \"thumbnail\", \"linkText\": \"Lib Dem peer resigns over Farron's views on homosexuality\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/politics/2017/jun/14/lib-dem-peer-brian-paddick-resigns-over-farrons-views-on-gay-sex\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/football/blog/2017/jun/15/russia-confederations-cup-2018-world-cup-concerns\", \"linkText\": \"Russia hopes Confederations Cup will banish 2018 World Cup concerns | Shaun Walker\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/football/blog/2017/jun/15/russia-confederations-cup-2018-world-cup-concerns\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/politics/2016/may/04/miners-strike-ipcc-considers-unredacted-orgreave-report\", \"role\": \"thumbnail\", \"linkText\": \"Miners' strike: IPCC considers unredacted Orgreave report\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/politics/2016/may/04/miners-strike-ipcc-considers-unredacted-orgreave-report\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/us-news/2016/may/04/barack-obama-flint-michigan-water-crisis\", \"role\": \"thumbnail\", \"linkText\": \"Obama in Flint: water crisis is a 'tragedy that never should have happened'\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/us-news/2016/may/04/barack-obama-flint-michigan-water-crisis\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/environment/2016/jan/22/water-lead-content-tests-us-authorities-distorting-flint-crisis\", \"role\": \"thumbnail\", \"linkText\": \"US authorities distorting tests to downplay lead content of water\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/environment/2016/jan/22/water-lead-content-tests-us-authorities-distorting-flint-crisis\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/music/2016/apr/29/prince-final-days-death-percocet\", \"role\": \"thumbnail\", \"linkText\": \"Prince's final days: few clues pointed to secret behind star's untimely death\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/music/2016/apr/29/prince-final-days-death-percocet\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/lifeandstyle/2016/oct/01/me-and-my-garden-we-planted-a-rose-garden-with-our-daughters-ashes\", \"role\": \"thumbnail\", \"linkText\": \"Me and my garden: ‘We planted a rose garden with our daughter’s ashes’\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/lifeandstyle/2016/oct/01/me-and-my-garden-we-planted-a-rose-garden-with-our-daughters-ashes\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/world/2017/jun/12/isis-islamic-state-iraq-baaj-abu-bakr-al-baghdadi\", \"role\": \"thumbnail\", \"linkText\": \"Booby-traps … but no Baghdadi: the men cleaning up after Isis in northern Iraq\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/world/2017/jun/12/isis-islamic-state-iraq-baaj-abu-bakr-al-baghdadi\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/world/2016/feb/09/this-is-hell-british-man-held-in-myanmar-for-14-months-without-charge-pleads-for-help\", \"role\": \"thumbnail\", \"linkText\": \"'This is hell': British man held in Myanmar for 14 months without charge pleads for help\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/world/2016/feb/09/this-is-hell-british-man-held-in-myanmar-for-14-months-without-charge-pleads-for-help\"}, \"elementType\": \"rich-link\"}"
+  },
+  {
+    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/football/blog/2017/jun/16/the-sids-2017-complete-review-2016-17-la-liga-season\", \"role\": \"thumbnail\", \"linkText\": \"It’s the Sids 2017! The complete review of the 2016-17 La Liga season\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/football/blog/2017/jun/16/the-sids-2017-complete-review-2016-17-la-liga-season\"}, \"elementType\": \"rich-link\"}"
+  }
+]

--- a/src/elements/helpers/__tests__/fixtures/rich-link.json
+++ b/src/elements/helpers/__tests__/fixtures/rich-link.json
@@ -1,302 +1,1322 @@
 [
   {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/education/2016/apr/07/how-to-stay-positive-and-manage-anxiety-during-exam-season\", \"role\": \"thumbnail\", \"linkText\": \"How to stay positive and manage anxiety during exam season\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/education/2016/apr/07/how-to-stay-positive-and-manage-anxiety-during-exam-season\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/education/2016/mar/21/eight-things-to-do-when-you-make-a-mistake\", \"role\": \"thumbnail\", \"linkText\": \"Eight things students should do when they make a mistake\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/education/2016/mar/21/eight-things-to-do-when-you-make-a-mistake\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/live/2016/may/05/tony-abbott-suggests-the-mining-industry-should-demonstrate-their-gratitude-to-ian-macfarlane-politics-live\", \"role\": \"thumbnail\", \"linkText\": \"Philip Lowe to replace Glenn Stevens as governor of the Reserve Bank – politics live\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/live/2016/may/05/tony-abbott-suggests-the-mining-industry-should-demonstrate-their-gratitude-to-ian-macfarlane-politics-live\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/2016/may/05/black-hole-attack-sucks-malcolm-turnbull-into-budget-twilight-zone\", \"role\": \"thumbnail\", \"linkText\": \"Black hole attack sucks Malcolm Turnbull into budget twilight zone | Lenore Taylor\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/2016/may/05/black-hole-attack-sucks-malcolm-turnbull-into-budget-twilight-zone\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/film/2016/apr/23/cillian-murphy-peaky-blinders-batman-scarecrow-tom-lamont\", \"role\": \"supporting\", \"linkText\": \"Cillian Murphy: ‘Is this it, for the rest of my days?’\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/film/2016/apr/23/cillian-murphy-peaky-blinders-batman-scarecrow-tom-lamont\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/sport/2016/may/04/chris-cusiter-retires-sale-scotland-glasgow-rugby-union\", \"role\": \"thumbnail\", \"linkText\": \"Scotland scrum-half Chris Cusiter announces retirement\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/sport/2016/may/04/chris-cusiter-retires-sale-scotland-glasgow-rugby-union\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/lifeandstyle/2015/dec/20/found-out-my-friend-used-ivf-she-should-tell-her-kids-mariella-frostrup\", \"role\": \"thumbnail\", \"linkText\": \"I found out my friend used IVF. I feel she should tell her kids | Mariella Frostrup\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/lifeandstyle/2015/dec/20/found-out-my-friend-used-ivf-she-should-tell-her-kids-mariella-frostrup\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/science/2016/may/04/scientists-break-record-for-keeping-lab-grown-human-embryos-alive\", \"role\": \"thumbnail\", \"linkText\": \"Researchers break record for keeping lab-grown human embryos alive\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/science/2016/may/04/scientists-break-record-for-keeping-lab-grown-human-embryos-alive\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/lifeandstyle/2016/apr/28/paying-for-baby-trouble-with-renting-womb-india\", \"role\": \"thumbnail\", \"linkText\": \"The trouble with renting a womb | Abby Rabinowitz\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/lifeandstyle/2016/apr/28/paying-for-baby-trouble-with-renting-womb-india\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/commentisfree/2016/apr/01/sex-babies-humans-parents-technology-science-fiction-pgd\", \"role\": \"thumbnail\", \"linkText\": \"Who needs sex to make babies? Pretty soon, humans won’t | Henry Greely\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/commentisfree/2016/apr/01/sex-babies-humans-parents-technology-science-fiction-pgd\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/2016/may/05/abbott-a-well-known-millionaire-offered-me-5000-when-i-was-a-new-mp\", \"role\": \"thumbnail\", \"linkText\": \"Abbott: a 'well-known millionaire' offered me $5,000 when I was a new MP\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/2016/may/05/abbott-a-well-known-millionaire-offered-me-5000-when-i-was-a-new-mp\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/2016/may/02/arthur-sinodinos-under-constant-stress-over-nsw-liberal-donations-revelations\", \"role\": \"thumbnail\", \"linkText\": \"Arthur Sinodinos 'under constant stress' over NSW Liberal donations revelations\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/2016/may/02/arthur-sinodinos-under-constant-stress-over-nsw-liberal-donations-revelations\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/2016/may/02/father-of-anzac-day-terror-plot-accused-pleads-for-son-to-be-released-on-bail\", \"role\": \"thumbnail\", \"linkText\": \"Father of Anzac Day terror plot accused pleads for son to be released on bail\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/2016/may/02/father-of-anzac-day-terror-plot-accused-pleads-for-son-to-be-released-on-bail\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/2016/apr/27/police-ran-online-sting-against-sydney-boy-charged-with-anzac-day-terrorism-plot\", \"role\": \"thumbnail\", \"linkText\": \"Police ran online sting against Sydney boy charged with Anzac Day terrorism plot\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/2016/apr/27/police-ran-online-sting-against-sydney-boy-charged-with-anzac-day-terrorism-plot\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/2016/may/03/corporate-tax-cuts-to-cost-budget-53bn-over-four-years\", \"role\": \"thumbnail\", \"linkText\": \"Corporate tax cuts to cost budget $5.3bn over four years\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/2016/may/03/corporate-tax-cuts-to-cost-budget-53bn-over-four-years\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/datablog/ng-interactive/2016/may/03/your-tax-dollars-how-is-the-government-spending-your-money\", \"role\": \"thumbnail\", \"linkText\": \"Your tax dollars: how is the government spending your money in the 2016 federal budget?\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/datablog/ng-interactive/2016/may/03/your-tax-dollars-how-is-the-government-spending-your-money\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/sustainable-business/2016/apr/04/workplace-wellness-how-offices-could-be-the-healthiest-place-for-you\", \"role\": \"thumbnail\", \"linkText\": \"Workplace wellness: how offices could be the healthiest place for you\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/sustainable-business/2016/apr/04/workplace-wellness-how-offices-could-be-the-healthiest-place-for-you\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/sustainable-business/2016/apr/20/building-with-nature-cities-that-steal-smart-ideas-from-plants-and-animals\", \"role\": \"thumbnail\", \"linkText\": \"Cities that steal smart ideas from plants and animals\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/sustainable-business/2016/apr/20/building-with-nature-cities-that-steal-smart-ideas-from-plants-and-animals\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/2016/may/04/youth-intern-scheme-will-exploit-workers-and-replace-real-jobs-say-unions\", \"role\": \"thumbnail\", \"linkText\": \"Youth intern scheme will exploit workers and replace 'real jobs', say unions\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/2016/may/04/youth-intern-scheme-will-exploit-workers-and-replace-real-jobs-say-unions\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/2016/may/05/budget-jobs-growth-investment-scott-morrison\", \"role\": \"thumbnail\", \"linkText\": \"Signs are not good for a budget based on 'jobs, growth and investment'\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/2016/may/05/budget-jobs-growth-investment-scott-morrison\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/world/2016/may/04/air-rage-inequality-happiness-plane-passengers\", \"role\": \"thumbnail\", \"linkText\": \"How the other half fly: what air rage tells us about inequality | Anne Perkins\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/world/2016/may/04/air-rage-inequality-happiness-plane-passengers\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/world/2016/may/02/armed-guards-at-indias-dams-as-drought-grips-country\", \"role\": \"thumbnail\", \"linkText\": \"Armed guards at India's dams as drought grips country\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/world/2016/may/02/armed-guards-at-indias-dams-as-drought-grips-country\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/lifeandstyle/2016/may/31/caramelised-recipes-tarte-tatin-canapes-dulce-de-leche-recipe-swap\", \"linkText\": \"Readers’ recipe swap: Caramelised | Dale Berning Sawa\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/lifeandstyle/2016/may/31/caramelised-recipes-tarte-tatin-canapes-dulce-de-leche-recipe-swap\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/environment/2016/may/14/fracking-ryedale-north-yorkshire-moors\", \"role\": \"thumbnail\", \"linkText\": \"In the timeless Yorkshire moors of my childhood, the frackers are poised to start drilling\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/environment/2016/may/14/fracking-ryedale-north-yorkshire-moors\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/world/gallery/2016/apr/18/ecuador-earthquake-rescue-operation-in-pictures\", \"role\": \"thumbnail\", \"linkText\": \"Ecuador earthquake rescue operation – in pictures\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/world/gallery/2016/apr/18/ecuador-earthquake-rescue-operation-in-pictures\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/uk-news/2016/mar/16/budget-2016-at-a-glance-key-points\", \"role\": \"thumbnail\", \"linkText\": \"Budget 2016 at a glance: the key points\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/uk-news/2016/mar/16/budget-2016-at-a-glance-key-points\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/books/2016/jul/04/the-statue-of-liberty-immigrants-independence-day\", \"role\": \"thumbnail\", \"linkText\": \"The Statue of Liberty was built to welcome immigrants – that welcome must not end | Dave Eggers\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/books/2016/jul/04/the-statue-of-liberty-immigrants-independence-day\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/us-news/2015/oct/29/new-york-city-statue-of-liberty-1886\", \"role\": \"thumbnail\", \"linkText\": \"New York City unveils Statue of Liberty: archive, 29 October 1886\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/us-news/2015/oct/29/new-york-city-statue-of-liberty-1886\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/commentisfree/2016/oct/10/debate-snub-ferguson-black-lives-matter\", \"role\": \"thumbnail\", \"linkText\": \"The greatest snub of the debate? It was against Black Lives Matter | Steven W Thrasher\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/commentisfree/2016/oct/10/debate-snub-ferguson-black-lives-matter\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/us-news/2016/oct/19/half-of-young-americans-prefer-meteor-apocalypse-to-donald-trump-presidency\", \"role\": \"thumbnail\", \"linkText\": \"Half of young Americans prefer meteor apocalypse to Donald Trump presidency\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/us-news/2016/oct/19/half-of-young-americans-prefer-meteor-apocalypse-to-donald-trump-presidency\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/datablog/ng-interactive/2016/feb/01/australian-political-donations-2014-15-search-the-data\", \"role\": \"thumbnail\", \"linkText\": \"Australian political donations 2014-15: search the data\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/datablog/ng-interactive/2016/feb/01/australian-political-donations-2014-15-search-the-data\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/australia-news/2016/feb/01/liberal-party-accepted-25000-from-linc-energy-months-after-gas-leaks\", \"role\": \"thumbnail\", \"linkText\": \"Liberals accepted $25,000 from Linc Energy months after charges over gas leaks\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/australia-news/2016/feb/01/liberal-party-accepted-25000-from-linc-energy-months-after-gas-leaks\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/football/blog/2016/may/04/manchester-city-vincent-kompany\", \"role\": \"thumbnail\", \"linkText\": \"Vincent Kompany injury again highlights Manchester City’s damning weakness | Jamie Jackson\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/football/blog/2016/may/04/manchester-city-vincent-kompany\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/football/blog/2016/may/04/real-madrid-atletico-derby-day-champions-league-final-manchester-city\", \"role\": \"supporting\", \"linkText\": \"Madrid given another derby day as Real match Atlético in Champions League | Sid Lowe\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/football/blog/2016/may/04/real-madrid-atletico-derby-day-champions-league-final-manchester-city\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/football/2016/may/01/swansea-city-liverpool-premier-league-match-report\", \"role\": \"thumbnail\", \"linkText\": \"Swansea’s André Ayew and Jack Cork teach Liverpool kids harsh lesson\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/football/2016/may/01/swansea-city-liverpool-premier-league-match-report\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/environment/2015/dec/07/storm-desmond-how-has-it-affected-you\", \"role\": \"thumbnail\", \"linkText\": \"Storm Desmond: how has it affected you?\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/environment/2015/dec/07/storm-desmond-how-has-it-affected-you\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/media/greenslade/2016/apr/26/10-journalists-resign-over-covert-funding-of-hungarian-news-website\", \"role\": \"thumbnail\", \"linkText\": \"10 journalists resign over covert funding of Hungarian news website\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/media/greenslade/2016/apr/26/10-journalists-resign-over-covert-funding-of-hungarian-news-website\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/commentisfree/2016/oct/05/birmingham-witnessing-tory-reformation-conservative-conference-brexit\", \"role\": \"thumbnail\", \"linkText\": \"We are witnessing nothing less than a Tory reformation  | Rafael Behr\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/commentisfree/2016/oct/05/birmingham-witnessing-tory-reformation-conservative-conference-brexit\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/books/2016/oct/04/disappearances-by-kj-orr-read-the-2016-winner-of-the-bbc-national-short-story-award\", \"role\": \"thumbnail\", \"linkText\": \"Disappearances by KJ Orr – read the 2016 winner of the BBC national short story award\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/books/2016/oct/04/disappearances-by-kj-orr-read-the-2016-winner-of-the-bbc-national-short-story-award\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/tv-and-radio/tvandradioblog/2015/oct/21/asian-provocateur-romesh-ranganathan-travel-tv-sri-lanka\", \"role\": \"thumbnail\", \"linkText\": \"Asian Provocateur: Romesh Ranganathan avoids travel TV cliches in his Sri Lankan journey\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/tv-and-radio/tvandradioblog/2015/oct/21/asian-provocateur-romesh-ranganathan-travel-tv-sri-lanka\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/tv-and-radio/2015/sep/30/asian-provocateur-romesh-ranganathan-in-sri-lanka\", \"role\": \"thumbnail\", \"linkText\": \"Romesh Ranganathan: ‘I was a bumbling Englishman in a Sri Lankan disguise’\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/tv-and-radio/2015/sep/30/asian-provocateur-romesh-ranganathan-in-sri-lanka\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/tv-and-radio/gallery/2017/jun/10/adam-west-a-life-in-pictures\", \"role\": \"thumbnail\", \"linkText\": \"Adam West – a life in pictures\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/tv-and-radio/gallery/2017/jun/10/adam-west-a-life-in-pictures\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/film/2016/jun/02/race-review-reverential-middle-of-the-pack-drama\", \"role\": \"thumbnail\", \"linkText\": \"Race review – reverential middle-of-the-pack drama\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/film/2016/jun/02/race-review-reverential-middle-of-the-pack-drama\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/football/2016/jan/30/volcano-iceland-national-football-team\", \"role\": \"thumbnail\", \"linkText\": \"Volcano! The incredible rise of Iceland's national football team\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/football/2016/jan/30/volcano-iceland-national-football-team\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/world/2016/may/28/iceland-great-time-to-be-tourist-football-glory-euro-2016\", \"role\": \"thumbnail\", \"linkText\": \"‘It’s a great time to be a tourist here’: Iceland prepares for sporting glory\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/world/2016/may/28/iceland-great-time-to-be-tourist-football-glory-euro-2016\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/technology/2015/apr/04/periscope-live-streaming-iphone-app\", \"role\": \"thumbnail\", \"linkText\": \"Periscope phone app gives millions a way to live-stream their lives\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/technology/2015/apr/04/periscope-live-streaming-iphone-app\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/media/2015/sep/13/periscope-app-syrian-refugees-bild\", \"role\": \"thumbnail\", \"linkText\": \"How live video on Periscope helped 'get inside' the Syrian refugees story\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/media/2015/sep/13/periscope-app-syrian-refugees-bild\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/world/2015/jul/23/what-is-wilson-doctrine-story-behind-mps-protection-snooping\", \"role\": \"thumbnail\", \"linkText\": \"What is the Wilson doctrine? The story behind MPs' protection from snooping\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/world/2015/jul/23/what-is-wilson-doctrine-story-behind-mps-protection-snooping\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/see-newcastle-gateshead/2016/may/03/win-a-weekend-trip-to-newcastlegateshead\", \"linkText\": \"Win a weekend trip to NewcastleGateshead\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/see-newcastle-gateshead/2016/may/03/win-a-weekend-trip-to-newcastlegateshead\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/football/2016/may/31/republic-of-ireland-euro-2016-squad\", \"role\": \"thumbnail\", \"linkText\": \"Ireland include Robbie Keane and James McCarthy in Euro 2016 squad\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/football/2016/may/31/republic-of-ireland-euro-2016-squad\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/fashion/2016/jun/11/long-lasting-nail-polish-chip-test-beauty-sali-hughes\", \"linkText\": \"Beauty: nail polish that stays put\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/fashion/2016/jun/11/long-lasting-nail-polish-chip-test-beauty-sali-hughes\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/books/2016/apr/17/the-sleep-revolution-by-arianna-huffington-digested-read\", \"role\": \"thumbnail\", \"linkText\": \"The Sleep Revolution by Arianna Huffington – digested read\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/books/2016/apr/17/the-sleep-revolution-by-arianna-huffington-digested-read\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/commentisfree/2016/may/23/spending-blights-nhs-cash-results-care\", \"role\": \"thumbnail\", \"linkText\": \"Spending blights the NHS – but not in the way you think | Anne Perkins\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/commentisfree/2016/may/23/spending-blights-nhs-cash-results-care\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/healthcare-network/2016/may/31/nhs-moving-backwards-race-equality\", \"role\": \"thumbnail\", \"linkText\": \"The NHS is moving backwards on race equality\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/healthcare-network/2016/may/31/nhs-moving-backwards-race-equality\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/music/2015/oct/12/jimi-hendrix-estate-sues-for-return-of-guitar-worth-up-to-1m\", \"role\": \"thumbnail\", \"linkText\": \"Jimi Hendrix estate sues for return of guitar worth up to $1m\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/music/2015/oct/12/jimi-hendrix-estate-sues-for-return-of-guitar-worth-up-to-1m\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/music/2012/oct/06/bb-king-music-blues-guitar\", \"role\": \"thumbnail\", \"linkText\": \"BB King at 87: the last of the great bluesmen\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/music/2012/oct/06/bb-king-music-blues-guitar\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/culture/2016/jun/07/kim-cattrall-battle-chronic-insomnia-sex-and-the-city\", \"role\": \"thumbnail\", \"linkText\": \"Kim Cattrall on her battle with insomnia: 'I was in a void'\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/culture/2016/jun/07/kim-cattrall-battle-chronic-insomnia-sex-and-the-city\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/world/2016/jun/06/eu-sudan-eritrea-migration\", \"role\": \"thumbnail\", \"linkText\": \"EU considering working with Sudan and Eritrea to stem migration\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/world/2016/jun/06/eu-sudan-eritrea-migration\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/world/2015/jul/22/eritrea-migrants-child-soldier-fled-what-is-going\", \"role\": \"thumbnail\", \"linkText\": \"It's not at war, but up to 3% of its people have fled. What is going on in Eritrea?\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/world/2015/jul/22/eritrea-migrants-child-soldier-fled-what-is-going\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/world/2016/may/24/desmond-tutus-daughter-leaves-clergy-after-marrying-female-partner\", \"role\": \"thumbnail\", \"linkText\": \"Desmond Tutu's daughter leaves clergy after marrying female partner\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/world/2016/may/24/desmond-tutus-daughter-leaves-clergy-after-marrying-female-partner\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/lifeandstyle/2015/oct/11/the-day-i-walked-in-the-bushveld-with-desmond-tutu\", \"role\": \"thumbnail\", \"linkText\": \"The day I walked in the bushveld with Desmond Tutu\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/lifeandstyle/2015/oct/11/the-day-i-walked-in-the-bushveld-with-desmond-tutu\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/world/2016/jan/08/how-issue-of-gay-rights-has-racked-anglican-churches-for-decades\", \"role\": \"thumbnail\", \"linkText\": \"How issue of gay rights has racked Anglican churches for decades\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/world/2016/jan/08/how-issue-of-gay-rights-has-racked-anglican-churches-for-decades\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/commentisfree/2014/jul/12/desmond-tutu-in-favour-of-assisted-dying\", \"role\": \"thumbnail\", \"linkText\": \"Desmond Tutu: a dignified death is our right – I am in favour of assisted dying | Desmond Tutu\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/commentisfree/2014/jul/12/desmond-tutu-in-favour-of-assisted-dying\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/media/2016/mar/12/radio-5-live-time-for-online-only\", \"role\": \"thumbnail\", \"linkText\": \"BBC Radio 5Live keeps the nation company. It would be wrong to take it off-air\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/media/2016/mar/12/radio-5-live-time-for-online-only\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/media/2016/mar/11/fake-giant-rat-picture-internet\", \"role\": \"thumbnail\", \"linkText\": \"How to fake a giant rat (and why you shouldn't trust pictures on the internet)\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/media/2016/mar/11/fake-giant-rat-picture-internet\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/media/2016/apr/17/fake-news-stories-clicks-fact-checking\", \"role\": \"thumbnail\", \"linkText\": \"How newsroom pressure is letting fake stories on to the web\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/media/2016/apr/17/fake-news-stories-clicks-fact-checking\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/cities/2016/jan/08/costs-berlin-rent-housing-subway-map\", \"role\": \"thumbnail\", \"linkText\": \"How much it costs to rent in Berlin – mapped by its metro stations\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/cities/2016/jan/08/costs-berlin-rent-housing-subway-map\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/cities/2015/sep/23/housing-trap-how-berlin-avoid-following-london-pricey-footsteps\", \"role\": \"thumbnail\", \"linkText\": \"The housing trap: how can Berlin avoid following in London's pricey footsteps?\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"https://www.theguardian.com/cities/2015/sep/23/housing-trap-how-berlin-avoid-following-london-pricey-footsteps\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/commentisfree/2016/oct/14/black-actors-overlooked-worse-ethnic-minorities-asian-racial-stereotypes\", \"role\": \"thumbnail\", \"linkText\": \"Black actors are too often overlooked. It’s even worse for other ethnic minorities | Andrew Rajan\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/commentisfree/2016/oct/14/black-actors-overlooked-worse-ethnic-minorities-asian-racial-stereotypes\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/money/commentisfree/2016/mar/21/fear-cashless-world-contactless\", \"role\": \"thumbnail\", \"linkText\": \"Why we should fear a cashless world | Dominic Frisby\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/money/commentisfree/2016/mar/21/fear-cashless-world-contactless\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/small-business-network/2016/apr/09/are-fintechs-helping-banks-evolve-or-planning-a-revolution\", \"role\": \"thumbnail\", \"linkText\": \"Are fintechs helping banks evolve – or planning a revolution?\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/small-business-network/2016/apr/09/are-fintechs-helping-banks-evolve-or-planning-a-revolution\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/music/2016/may/07/never-mind-bus-pass-punks-look-back-wildest-days\", \"role\": \"thumbnail\", \"linkText\": \"Never mind the bus pass: punks look back at their wildest days\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/music/2016/may/07/never-mind-bus-pass-punks-look-back-wildest-days\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/australia-news/2017/aug/23/the-answers-in-the-post-australian-marriage-equality-vote-explainer\", \"role\": \"thumbnail\", \"linkText\": \"The answer's in the post – Australian marriage equality vote explainer\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/australia-news/2017/aug/23/the-answers-in-the-post-australian-marriage-equality-vote-explainer\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/australia-news/2017/aug/09/abbotts-obstruction-of-gay-marriage-is-a-defence-of-privilege-and-the-power-of-shame-david-marr\", \"role\": \"thumbnail\", \"linkText\": \"Abbott's obstruction of gay marriage is a defence of privilege and the power of shame | David Marr\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/australia-news/2017/aug/09/abbotts-obstruction-of-gay-marriage-is-a-defence-of-privilege-and-the-power-of-shame-david-marr\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/world/2016/may/05/ahmet-davutoglus-future-turkish-prime-minister-balance\", \"role\": \"thumbnail\", \"linkText\": \"Turkish PM Davutoğlu resigns as President Erdoğan tightens grip\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/world/2016/may/05/ahmet-davutoglus-future-turkish-prime-minister-balance\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/world/2016/may/03/merkel-served-me-up-for-tea-to-erdogan-german-comedian-jan-bohmermann-\", \"role\": \"thumbnail\", \"linkText\": \"Merkel 'served me up for tea' to Erdoğan, says German comedian\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/world/2016/may/03/merkel-served-me-up-for-tea-to-erdogan-german-comedian-jan-bohmermann-\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/books/2010/feb/14/crime-fiction-merritt-sj-parris\", \"role\": \"thumbnail\", \"linkText\": \"Forget 'serious' novels, I've turned to a life of crime\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/books/2010/feb/14/crime-fiction-merritt-sj-parris\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/music/2016/mar/13/punk-1976-1978-british-library-40th-anniversary-sex-pistols-buzzcocks\", \"role\": \"thumbnail\", \"linkText\": \"Happy Birthday Punk: the British Library celebrates 40 years of anarchy and innovation\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/music/2016/mar/13/punk-1976-1978-british-library-40th-anniversary-sex-pistols-buzzcocks\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/film/2016/apr/29/proms-kevin-costner-a-smiley-face-the-onion-we-review-anything\", \"role\": \"thumbnail\", \"linkText\": \"Proms, Kevin Costner's \\\"English\\\" accent, a smiley face, the onion – we review anything\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/film/2016/apr/29/proms-kevin-costner-a-smiley-face-the-onion-we-review-anything\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/culture/2016/apr/15/games-based-on-pop-stars-yesterday-afternoon-a-bin-root-canals-we-review-anything\", \"role\": \"thumbnail\", \"linkText\": \"Games based on pop stars, yesterday afternoon, a bin, root canals – we review anything\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/culture/2016/apr/15/games-based-on-pop-stars-yesterday-afternoon-a-bin-root-canals-we-review-anything\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/culture/2016/apr/08/iggy-pops-cockatoo-hamster-toys-a-sign-a-guide-writers-career-choices-we-review-anything\", \"role\": \"thumbnail\", \"linkText\": \"Iggy Pop's cockatoo, hamster toys, a sign, a Guide writer's career choices: we review anything\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/culture/2016/apr/08/iggy-pops-cockatoo-hamster-toys-a-sign-a-guide-writers-career-choices-we-review-anything\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/football/2016/apr/26/hillsborough-disaster-deadly-mistakes-and-lies-that-lasted-decades\", \"role\": \"thumbnail\", \"linkText\": \"Hillsborough disaster: deadly mistakes and lies that lasted decades\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/football/2016/apr/26/hillsborough-disaster-deadly-mistakes-and-lies-that-lasted-decades\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/football/2016/may/03/hillsborough-families-criticise-south-yorkshire-pcc-over-inquest-tactics\", \"role\": \"thumbnail\", \"linkText\": \"Hillsborough families criticise South Yorkshire PCC over inquest tactics\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/football/2016/may/03/hillsborough-families-criticise-south-yorkshire-pcc-over-inquest-tactics\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/us-news/live/2016/may/05/donald-trump-nomination-republican-party-us-election-news-sanders-clinton-live\", \"role\": \"thumbnail\", \"linkText\": \"Trump's presumptive nomination divides Republicans – campaign live\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/us-news/live/2016/may/05/donald-trump-nomination-republican-party-us-election-news-sanders-clinton-live\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/commentisfree/2017/jun/16/theresa-may-scared-grenfell-survivors-finished-austerity-cameron-osborne\", \"role\": \"thumbnail\", \"linkText\": \"Theresa May was too scared to meet the Grenfell survivors. She’s finished | Polly Toynbee\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/commentisfree/2017/jun/16/theresa-may-scared-grenfell-survivors-finished-austerity-cameron-osborne\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/lifeandstyle/australia-food-blog/2014/nov/26/forget-the-thermomix-your-kitchen-appliances-have-secret-powers\", \"role\": \"thumbnail\", \"linkText\": \"Forget the Thermomix - your kitchen appliances have secret powers\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/lifeandstyle/australia-food-blog/2014/nov/26/forget-the-thermomix-your-kitchen-appliances-have-secret-powers\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/us-news/2017/mar/27/solar-power-florida-new-york-renewable-energy-policies\", \"role\": \"thumbnail\", \"linkText\": \"Sunshine state shuns solar as overcast New York basks in clean energy boom\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/us-news/2017/mar/27/solar-power-florida-new-york-renewable-energy-policies\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/environment/2017/jun/01/donald-trump-paris-climate-deal-pullout-us-impact\", \"role\": \"thumbnail\", \"linkText\": \"The Paris deal pullout is more damaging to the US than the climate\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/environment/2017/jun/01/donald-trump-paris-climate-deal-pullout-us-impact\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/politics/2017/jun/14/liberal-democrats-leadership-race-the-early-runners-and-riders\", \"role\": \"thumbnail\", \"linkText\": \"Liberal Democrats leadership race: the early runners and riders\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/politics/2017/jun/14/liberal-democrats-leadership-race-the-early-runners-and-riders\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/politics/2017/jun/14/tim-farron-quits-as-lib-dem-leader\", \"role\": \"thumbnail\", \"linkText\": \"Tim Farron quits as Lib Dem leader\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/politics/2017/jun/14/tim-farron-quits-as-lib-dem-leader\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/politics/2017/jun/14/lib-dem-peer-brian-paddick-resigns-over-farrons-views-on-gay-sex\", \"role\": \"thumbnail\", \"linkText\": \"Lib Dem peer resigns over Farron's views on homosexuality\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/politics/2017/jun/14/lib-dem-peer-brian-paddick-resigns-over-farrons-views-on-gay-sex\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/football/blog/2017/jun/15/russia-confederations-cup-2018-world-cup-concerns\", \"linkText\": \"Russia hopes Confederations Cup will banish 2018 World Cup concerns | Shaun Walker\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/football/blog/2017/jun/15/russia-confederations-cup-2018-world-cup-concerns\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/politics/2016/may/04/miners-strike-ipcc-considers-unredacted-orgreave-report\", \"role\": \"thumbnail\", \"linkText\": \"Miners' strike: IPCC considers unredacted Orgreave report\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/politics/2016/may/04/miners-strike-ipcc-considers-unredacted-orgreave-report\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/us-news/2016/may/04/barack-obama-flint-michigan-water-crisis\", \"role\": \"thumbnail\", \"linkText\": \"Obama in Flint: water crisis is a 'tragedy that never should have happened'\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/us-news/2016/may/04/barack-obama-flint-michigan-water-crisis\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/environment/2016/jan/22/water-lead-content-tests-us-authorities-distorting-flint-crisis\", \"role\": \"thumbnail\", \"linkText\": \"US authorities distorting tests to downplay lead content of water\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/environment/2016/jan/22/water-lead-content-tests-us-authorities-distorting-flint-crisis\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"http://www.theguardian.com/music/2016/apr/29/prince-final-days-death-percocet\", \"role\": \"thumbnail\", \"linkText\": \"Prince's final days: few clues pointed to secret behind star's untimely death\", \"linkPrefix\": \"Related: \", \"originalUrl\": \"http://www.theguardian.com/music/2016/apr/29/prince-final-days-death-percocet\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/lifeandstyle/2016/oct/01/me-and-my-garden-we-planted-a-rose-garden-with-our-daughters-ashes\", \"role\": \"thumbnail\", \"linkText\": \"Me and my garden: ‘We planted a rose garden with our daughter’s ashes’\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/lifeandstyle/2016/oct/01/me-and-my-garden-we-planted-a-rose-garden-with-our-daughters-ashes\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/world/2017/jun/12/isis-islamic-state-iraq-baaj-abu-bakr-al-baghdadi\", \"role\": \"thumbnail\", \"linkText\": \"Booby-traps … but no Baghdadi: the men cleaning up after Isis in northern Iraq\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/world/2017/jun/12/isis-islamic-state-iraq-baaj-abu-bakr-al-baghdadi\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/world/2016/feb/09/this-is-hell-british-man-held-in-myanmar-for-14-months-without-charge-pleads-for-help\", \"role\": \"thumbnail\", \"linkText\": \"'This is hell': British man held in Myanmar for 14 months without charge pleads for help\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/world/2016/feb/09/this-is-hell-british-man-held-in-myanmar-for-14-months-without-charge-pleads-for-help\"}, \"elementType\": \"rich-link\"}"
-  },
-  {
-    "elements": "{\"assets\": [], \"fields\": {\"url\": \"https://www.theguardian.com/football/blog/2017/jun/16/the-sids-2017-complete-review-2016-17-la-liga-season\", \"role\": \"thumbnail\", \"linkText\": \"It’s the Sids 2017! The complete review of the 2016-17 La Liga season\", \"linkPrefix\": \"Related: \", \"isMandatory\": \"true\", \"originalUrl\": \"https://www.theguardian.com/football/blog/2017/jun/16/the-sids-2017-complete-review-2016-17-la-liga-season\"}, \"elementType\": \"rich-link\"}"
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/education/2016/apr/07/how-to-stay-positive-and-manage-anxiety-during-exam-season",
+        "role": "thumbnail",
+        "linkText": "How to stay positive and manage anxiety during exam season",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/education/2016/apr/07/how-to-stay-positive-and-manage-anxiety-during-exam-season"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/education/2016/mar/21/eight-things-to-do-when-you-make-a-mistake",
+        "role": "thumbnail",
+        "linkText": "Eight things students should do when they make a mistake",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/education/2016/mar/21/eight-things-to-do-when-you-make-a-mistake"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/australia-news/live/2016/may/05/tony-abbott-suggests-the-mining-industry-should-demonstrate-their-gratitude-to-ian-macfarlane-politics-live",
+        "role": "thumbnail",
+        "linkText": "Philip Lowe to replace Glenn Stevens as governor of the Reserve Bank – politics live",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/australia-news/live/2016/may/05/tony-abbott-suggests-the-mining-industry-should-demonstrate-their-gratitude-to-ian-macfarlane-politics-live"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/australia-news/2016/may/05/black-hole-attack-sucks-malcolm-turnbull-into-budget-twilight-zone",
+        "role": "thumbnail",
+        "linkText": "Black hole attack sucks Malcolm Turnbull into budget twilight zone | Lenore Taylor",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/australia-news/2016/may/05/black-hole-attack-sucks-malcolm-turnbull-into-budget-twilight-zone"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/film/2016/apr/23/cillian-murphy-peaky-blinders-batman-scarecrow-tom-lamont",
+        "role": "supporting",
+        "linkText": "Cillian Murphy: ‘Is this it, for the rest of my days?’",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/film/2016/apr/23/cillian-murphy-peaky-blinders-batman-scarecrow-tom-lamont"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/sport/2016/may/04/chris-cusiter-retires-sale-scotland-glasgow-rugby-union",
+        "role": "thumbnail",
+        "linkText": "Scotland scrum-half Chris Cusiter announces retirement",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/sport/2016/may/04/chris-cusiter-retires-sale-scotland-glasgow-rugby-union"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/lifeandstyle/2015/dec/20/found-out-my-friend-used-ivf-she-should-tell-her-kids-mariella-frostrup",
+        "role": "thumbnail",
+        "linkText": "I found out my friend used IVF. I feel she should tell her kids | Mariella Frostrup",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/lifeandstyle/2015/dec/20/found-out-my-friend-used-ivf-she-should-tell-her-kids-mariella-frostrup"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/science/2016/may/04/scientists-break-record-for-keeping-lab-grown-human-embryos-alive",
+        "role": "thumbnail",
+        "linkText": "Researchers break record for keeping lab-grown human embryos alive",
+        "linkPrefix": "Related: ",
+        "originalUrl": "https://www.theguardian.com/science/2016/may/04/scientists-break-record-for-keeping-lab-grown-human-embryos-alive"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/lifeandstyle/2016/apr/28/paying-for-baby-trouble-with-renting-womb-india",
+        "role": "thumbnail",
+        "linkText": "The trouble with renting a womb | Abby Rabinowitz",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/lifeandstyle/2016/apr/28/paying-for-baby-trouble-with-renting-womb-india"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/commentisfree/2016/apr/01/sex-babies-humans-parents-technology-science-fiction-pgd",
+        "role": "thumbnail",
+        "linkText": "Who needs sex to make babies? Pretty soon, humans won’t | Henry Greely",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/commentisfree/2016/apr/01/sex-babies-humans-parents-technology-science-fiction-pgd"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/australia-news/2016/may/05/abbott-a-well-known-millionaire-offered-me-5000-when-i-was-a-new-mp",
+        "role": "thumbnail",
+        "linkText": "Abbott: a 'well-known millionaire' offered me $5,000 when I was a new MP",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/australia-news/2016/may/05/abbott-a-well-known-millionaire-offered-me-5000-when-i-was-a-new-mp"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/australia-news/2016/may/02/arthur-sinodinos-under-constant-stress-over-nsw-liberal-donations-revelations",
+        "role": "thumbnail",
+        "linkText": "Arthur Sinodinos 'under constant stress' over NSW Liberal donations revelations",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/australia-news/2016/may/02/arthur-sinodinos-under-constant-stress-over-nsw-liberal-donations-revelations"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/australia-news/2016/may/02/father-of-anzac-day-terror-plot-accused-pleads-for-son-to-be-released-on-bail",
+        "role": "thumbnail",
+        "linkText": "Father of Anzac Day terror plot accused pleads for son to be released on bail",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/australia-news/2016/may/02/father-of-anzac-day-terror-plot-accused-pleads-for-son-to-be-released-on-bail"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/australia-news/2016/apr/27/police-ran-online-sting-against-sydney-boy-charged-with-anzac-day-terrorism-plot",
+        "role": "thumbnail",
+        "linkText": "Police ran online sting against Sydney boy charged with Anzac Day terrorism plot",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/australia-news/2016/apr/27/police-ran-online-sting-against-sydney-boy-charged-with-anzac-day-terrorism-plot"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/australia-news/2016/may/03/corporate-tax-cuts-to-cost-budget-53bn-over-four-years",
+        "role": "thumbnail",
+        "linkText": "Corporate tax cuts to cost budget $5.3bn over four years",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/australia-news/2016/may/03/corporate-tax-cuts-to-cost-budget-53bn-over-four-years"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/australia-news/datablog/ng-interactive/2016/may/03/your-tax-dollars-how-is-the-government-spending-your-money",
+        "role": "thumbnail",
+        "linkText": "Your tax dollars: how is the government spending your money in the 2016 federal budget?",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/australia-news/datablog/ng-interactive/2016/may/03/your-tax-dollars-how-is-the-government-spending-your-money"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/sustainable-business/2016/apr/04/workplace-wellness-how-offices-could-be-the-healthiest-place-for-you",
+        "role": "thumbnail",
+        "linkText": "Workplace wellness: how offices could be the healthiest place for you",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/sustainable-business/2016/apr/04/workplace-wellness-how-offices-could-be-the-healthiest-place-for-you"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/sustainable-business/2016/apr/20/building-with-nature-cities-that-steal-smart-ideas-from-plants-and-animals",
+        "role": "thumbnail",
+        "linkText": "Cities that steal smart ideas from plants and animals",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/sustainable-business/2016/apr/20/building-with-nature-cities-that-steal-smart-ideas-from-plants-and-animals"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/australia-news/2016/may/04/youth-intern-scheme-will-exploit-workers-and-replace-real-jobs-say-unions",
+        "role": "thumbnail",
+        "linkText": "Youth intern scheme will exploit workers and replace 'real jobs', say unions",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/australia-news/2016/may/04/youth-intern-scheme-will-exploit-workers-and-replace-real-jobs-say-unions"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/australia-news/2016/may/05/budget-jobs-growth-investment-scott-morrison",
+        "role": "thumbnail",
+        "linkText": "Signs are not good for a budget based on 'jobs, growth and investment'",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/australia-news/2016/may/05/budget-jobs-growth-investment-scott-morrison"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/world/2016/may/04/air-rage-inequality-happiness-plane-passengers",
+        "role": "thumbnail",
+        "linkText": "How the other half fly: what air rage tells us about inequality | Anne Perkins",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/world/2016/may/04/air-rage-inequality-happiness-plane-passengers"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/world/2016/may/02/armed-guards-at-indias-dams-as-drought-grips-country",
+        "role": "thumbnail",
+        "linkText": "Armed guards at India's dams as drought grips country",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/world/2016/may/02/armed-guards-at-indias-dams-as-drought-grips-country"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/lifeandstyle/2016/may/31/caramelised-recipes-tarte-tatin-canapes-dulce-de-leche-recipe-swap",
+        "linkText": "Readers’ recipe swap: Caramelised | Dale Berning Sawa",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/lifeandstyle/2016/may/31/caramelised-recipes-tarte-tatin-canapes-dulce-de-leche-recipe-swap"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/environment/2016/may/14/fracking-ryedale-north-yorkshire-moors",
+        "role": "thumbnail",
+        "linkText": "In the timeless Yorkshire moors of my childhood, the frackers are poised to start drilling",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/environment/2016/may/14/fracking-ryedale-north-yorkshire-moors"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/world/gallery/2016/apr/18/ecuador-earthquake-rescue-operation-in-pictures",
+        "role": "thumbnail",
+        "linkText": "Ecuador earthquake rescue operation – in pictures",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/world/gallery/2016/apr/18/ecuador-earthquake-rescue-operation-in-pictures"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/uk-news/2016/mar/16/budget-2016-at-a-glance-key-points",
+        "role": "thumbnail",
+        "linkText": "Budget 2016 at a glance: the key points",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/uk-news/2016/mar/16/budget-2016-at-a-glance-key-points"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/books/2016/jul/04/the-statue-of-liberty-immigrants-independence-day",
+        "role": "thumbnail",
+        "linkText": "The Statue of Liberty was built to welcome immigrants – that welcome must not end | Dave Eggers",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/books/2016/jul/04/the-statue-of-liberty-immigrants-independence-day"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/us-news/2015/oct/29/new-york-city-statue-of-liberty-1886",
+        "role": "thumbnail",
+        "linkText": "New York City unveils Statue of Liberty: archive, 29 October 1886",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/us-news/2015/oct/29/new-york-city-statue-of-liberty-1886"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/commentisfree/2016/oct/10/debate-snub-ferguson-black-lives-matter",
+        "role": "thumbnail",
+        "linkText": "The greatest snub of the debate? It was against Black Lives Matter | Steven W Thrasher",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/commentisfree/2016/oct/10/debate-snub-ferguson-black-lives-matter"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/us-news/2016/oct/19/half-of-young-americans-prefer-meteor-apocalypse-to-donald-trump-presidency",
+        "role": "thumbnail",
+        "linkText": "Half of young Americans prefer meteor apocalypse to Donald Trump presidency",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/us-news/2016/oct/19/half-of-young-americans-prefer-meteor-apocalypse-to-donald-trump-presidency"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/australia-news/datablog/ng-interactive/2016/feb/01/australian-political-donations-2014-15-search-the-data",
+        "role": "thumbnail",
+        "linkText": "Australian political donations 2014-15: search the data",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/australia-news/datablog/ng-interactive/2016/feb/01/australian-political-donations-2014-15-search-the-data"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/australia-news/2016/feb/01/liberal-party-accepted-25000-from-linc-energy-months-after-gas-leaks",
+        "role": "thumbnail",
+        "linkText": "Liberals accepted $25,000 from Linc Energy months after charges over gas leaks",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/australia-news/2016/feb/01/liberal-party-accepted-25000-from-linc-energy-months-after-gas-leaks"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/football/blog/2016/may/04/manchester-city-vincent-kompany",
+        "role": "thumbnail",
+        "linkText": "Vincent Kompany injury again highlights Manchester City’s damning weakness | Jamie Jackson",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/football/blog/2016/may/04/manchester-city-vincent-kompany"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/football/blog/2016/may/04/real-madrid-atletico-derby-day-champions-league-final-manchester-city",
+        "role": "supporting",
+        "linkText": "Madrid given another derby day as Real match Atlético in Champions League | Sid Lowe",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/football/blog/2016/may/04/real-madrid-atletico-derby-day-champions-league-final-manchester-city"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/football/2016/may/01/swansea-city-liverpool-premier-league-match-report",
+        "role": "thumbnail",
+        "linkText": "Swansea’s André Ayew and Jack Cork teach Liverpool kids harsh lesson",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/football/2016/may/01/swansea-city-liverpool-premier-league-match-report"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/environment/2015/dec/07/storm-desmond-how-has-it-affected-you",
+        "role": "thumbnail",
+        "linkText": "Storm Desmond: how has it affected you?",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/environment/2015/dec/07/storm-desmond-how-has-it-affected-you"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/media/greenslade/2016/apr/26/10-journalists-resign-over-covert-funding-of-hungarian-news-website",
+        "role": "thumbnail",
+        "linkText": "10 journalists resign over covert funding of Hungarian news website",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/media/greenslade/2016/apr/26/10-journalists-resign-over-covert-funding-of-hungarian-news-website"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/commentisfree/2016/oct/05/birmingham-witnessing-tory-reformation-conservative-conference-brexit",
+        "role": "thumbnail",
+        "linkText": "We are witnessing nothing less than a Tory reformation  | Rafael Behr",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/commentisfree/2016/oct/05/birmingham-witnessing-tory-reformation-conservative-conference-brexit"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/books/2016/oct/04/disappearances-by-kj-orr-read-the-2016-winner-of-the-bbc-national-short-story-award",
+        "role": "thumbnail",
+        "linkText": "Disappearances by KJ Orr – read the 2016 winner of the BBC national short story award",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/books/2016/oct/04/disappearances-by-kj-orr-read-the-2016-winner-of-the-bbc-national-short-story-award"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/tv-and-radio/tvandradioblog/2015/oct/21/asian-provocateur-romesh-ranganathan-travel-tv-sri-lanka",
+        "role": "thumbnail",
+        "linkText": "Asian Provocateur: Romesh Ranganathan avoids travel TV cliches in his Sri Lankan journey",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/tv-and-radio/tvandradioblog/2015/oct/21/asian-provocateur-romesh-ranganathan-travel-tv-sri-lanka"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/tv-and-radio/2015/sep/30/asian-provocateur-romesh-ranganathan-in-sri-lanka",
+        "role": "thumbnail",
+        "linkText": "Romesh Ranganathan: ‘I was a bumbling Englishman in a Sri Lankan disguise’",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/tv-and-radio/2015/sep/30/asian-provocateur-romesh-ranganathan-in-sri-lanka"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/tv-and-radio/gallery/2017/jun/10/adam-west-a-life-in-pictures",
+        "role": "thumbnail",
+        "linkText": "Adam West – a life in pictures",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/tv-and-radio/gallery/2017/jun/10/adam-west-a-life-in-pictures"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/film/2016/jun/02/race-review-reverential-middle-of-the-pack-drama",
+        "role": "thumbnail",
+        "linkText": "Race review – reverential middle-of-the-pack drama",
+        "linkPrefix": "Related: ",
+        "originalUrl": "https://www.theguardian.com/film/2016/jun/02/race-review-reverential-middle-of-the-pack-drama"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/football/2016/jan/30/volcano-iceland-national-football-team",
+        "role": "thumbnail",
+        "linkText": "Volcano! The incredible rise of Iceland's national football team",
+        "linkPrefix": "Related: ",
+        "originalUrl": "https://www.theguardian.com/football/2016/jan/30/volcano-iceland-national-football-team"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/world/2016/may/28/iceland-great-time-to-be-tourist-football-glory-euro-2016",
+        "role": "thumbnail",
+        "linkText": "‘It’s a great time to be a tourist here’: Iceland prepares for sporting glory",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/world/2016/may/28/iceland-great-time-to-be-tourist-football-glory-euro-2016"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/technology/2015/apr/04/periscope-live-streaming-iphone-app",
+        "role": "thumbnail",
+        "linkText": "Periscope phone app gives millions a way to live-stream their lives",
+        "linkPrefix": "Related: ",
+        "originalUrl": "https://www.theguardian.com/technology/2015/apr/04/periscope-live-streaming-iphone-app"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/media/2015/sep/13/periscope-app-syrian-refugees-bild",
+        "role": "thumbnail",
+        "linkText": "How live video on Periscope helped 'get inside' the Syrian refugees story",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/media/2015/sep/13/periscope-app-syrian-refugees-bild"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/world/2015/jul/23/what-is-wilson-doctrine-story-behind-mps-protection-snooping",
+        "role": "thumbnail",
+        "linkText": "What is the Wilson doctrine? The story behind MPs' protection from snooping",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/world/2015/jul/23/what-is-wilson-doctrine-story-behind-mps-protection-snooping"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/see-newcastle-gateshead/2016/may/03/win-a-weekend-trip-to-newcastlegateshead",
+        "linkText": "Win a weekend trip to NewcastleGateshead",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/see-newcastle-gateshead/2016/may/03/win-a-weekend-trip-to-newcastlegateshead"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/football/2016/may/31/republic-of-ireland-euro-2016-squad",
+        "role": "thumbnail",
+        "linkText": "Ireland include Robbie Keane and James McCarthy in Euro 2016 squad",
+        "linkPrefix": "Related: ",
+        "originalUrl": "https://www.theguardian.com/football/2016/may/31/republic-of-ireland-euro-2016-squad"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/fashion/2016/jun/11/long-lasting-nail-polish-chip-test-beauty-sali-hughes",
+        "linkText": "Beauty: nail polish that stays put",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/fashion/2016/jun/11/long-lasting-nail-polish-chip-test-beauty-sali-hughes"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/books/2016/apr/17/the-sleep-revolution-by-arianna-huffington-digested-read",
+        "role": "thumbnail",
+        "linkText": "The Sleep Revolution by Arianna Huffington – digested read",
+        "linkPrefix": "Related: ",
+        "originalUrl": "https://www.theguardian.com/books/2016/apr/17/the-sleep-revolution-by-arianna-huffington-digested-read"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/commentisfree/2016/may/23/spending-blights-nhs-cash-results-care",
+        "role": "thumbnail",
+        "linkText": "Spending blights the NHS – but not in the way you think | Anne Perkins",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/commentisfree/2016/may/23/spending-blights-nhs-cash-results-care"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/healthcare-network/2016/may/31/nhs-moving-backwards-race-equality",
+        "role": "thumbnail",
+        "linkText": "The NHS is moving backwards on race equality",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/healthcare-network/2016/may/31/nhs-moving-backwards-race-equality"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/music/2015/oct/12/jimi-hendrix-estate-sues-for-return-of-guitar-worth-up-to-1m",
+        "role": "thumbnail",
+        "linkText": "Jimi Hendrix estate sues for return of guitar worth up to $1m",
+        "linkPrefix": "Related: ",
+        "originalUrl": "https://www.theguardian.com/music/2015/oct/12/jimi-hendrix-estate-sues-for-return-of-guitar-worth-up-to-1m"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/music/2012/oct/06/bb-king-music-blues-guitar",
+        "role": "thumbnail",
+        "linkText": "BB King at 87: the last of the great bluesmen",
+        "linkPrefix": "Related: ",
+        "originalUrl": "https://www.theguardian.com/music/2012/oct/06/bb-king-music-blues-guitar"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/culture/2016/jun/07/kim-cattrall-battle-chronic-insomnia-sex-and-the-city",
+        "role": "thumbnail",
+        "linkText": "Kim Cattrall on her battle with insomnia: 'I was in a void'",
+        "linkPrefix": "Related: ",
+        "originalUrl": "https://www.theguardian.com/culture/2016/jun/07/kim-cattrall-battle-chronic-insomnia-sex-and-the-city"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/world/2016/jun/06/eu-sudan-eritrea-migration",
+        "role": "thumbnail",
+        "linkText": "EU considering working with Sudan and Eritrea to stem migration",
+        "linkPrefix": "Related: ",
+        "originalUrl": "https://www.theguardian.com/world/2016/jun/06/eu-sudan-eritrea-migration"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/world/2015/jul/22/eritrea-migrants-child-soldier-fled-what-is-going",
+        "role": "thumbnail",
+        "linkText": "It's not at war, but up to 3% of its people have fled. What is going on in Eritrea?",
+        "linkPrefix": "Related: ",
+        "originalUrl": "https://www.theguardian.com/world/2015/jul/22/eritrea-migrants-child-soldier-fled-what-is-going"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/world/2016/may/24/desmond-tutus-daughter-leaves-clergy-after-marrying-female-partner",
+        "role": "thumbnail",
+        "linkText": "Desmond Tutu's daughter leaves clergy after marrying female partner",
+        "linkPrefix": "Related: ",
+        "originalUrl": "https://www.theguardian.com/world/2016/may/24/desmond-tutus-daughter-leaves-clergy-after-marrying-female-partner"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/lifeandstyle/2015/oct/11/the-day-i-walked-in-the-bushveld-with-desmond-tutu",
+        "role": "thumbnail",
+        "linkText": "The day I walked in the bushveld with Desmond Tutu",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/lifeandstyle/2015/oct/11/the-day-i-walked-in-the-bushveld-with-desmond-tutu"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/world/2016/jan/08/how-issue-of-gay-rights-has-racked-anglican-churches-for-decades",
+        "role": "thumbnail",
+        "linkText": "How issue of gay rights has racked Anglican churches for decades",
+        "linkPrefix": "Related: ",
+        "originalUrl": "https://www.theguardian.com/world/2016/jan/08/how-issue-of-gay-rights-has-racked-anglican-churches-for-decades"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/commentisfree/2014/jul/12/desmond-tutu-in-favour-of-assisted-dying",
+        "role": "thumbnail",
+        "linkText": "Desmond Tutu: a dignified death is our right – I am in favour of assisted dying | Desmond Tutu",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/commentisfree/2014/jul/12/desmond-tutu-in-favour-of-assisted-dying"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/media/2016/mar/12/radio-5-live-time-for-online-only",
+        "role": "thumbnail",
+        "linkText": "BBC Radio 5Live keeps the nation company. It would be wrong to take it off-air",
+        "linkPrefix": "Related: ",
+        "originalUrl": "https://www.theguardian.com/media/2016/mar/12/radio-5-live-time-for-online-only"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/media/2016/mar/11/fake-giant-rat-picture-internet",
+        "role": "thumbnail",
+        "linkText": "How to fake a giant rat (and why you shouldn't trust pictures on the internet)",
+        "linkPrefix": "Related: ",
+        "originalUrl": "https://www.theguardian.com/media/2016/mar/11/fake-giant-rat-picture-internet"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/media/2016/apr/17/fake-news-stories-clicks-fact-checking",
+        "role": "thumbnail",
+        "linkText": "How newsroom pressure is letting fake stories on to the web",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/media/2016/apr/17/fake-news-stories-clicks-fact-checking"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/cities/2016/jan/08/costs-berlin-rent-housing-subway-map",
+        "role": "thumbnail",
+        "linkText": "How much it costs to rent in Berlin – mapped by its metro stations",
+        "linkPrefix": "Related: ",
+        "originalUrl": "https://www.theguardian.com/cities/2016/jan/08/costs-berlin-rent-housing-subway-map"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/cities/2015/sep/23/housing-trap-how-berlin-avoid-following-london-pricey-footsteps",
+        "role": "thumbnail",
+        "linkText": "The housing trap: how can Berlin avoid following in London's pricey footsteps?",
+        "linkPrefix": "Related: ",
+        "originalUrl": "https://www.theguardian.com/cities/2015/sep/23/housing-trap-how-berlin-avoid-following-london-pricey-footsteps"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/commentisfree/2016/oct/14/black-actors-overlooked-worse-ethnic-minorities-asian-racial-stereotypes",
+        "role": "thumbnail",
+        "linkText": "Black actors are too often overlooked. It’s even worse for other ethnic minorities | Andrew Rajan",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/commentisfree/2016/oct/14/black-actors-overlooked-worse-ethnic-minorities-asian-racial-stereotypes"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/money/commentisfree/2016/mar/21/fear-cashless-world-contactless",
+        "role": "thumbnail",
+        "linkText": "Why we should fear a cashless world | Dominic Frisby",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/money/commentisfree/2016/mar/21/fear-cashless-world-contactless"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/small-business-network/2016/apr/09/are-fintechs-helping-banks-evolve-or-planning-a-revolution",
+        "role": "thumbnail",
+        "linkText": "Are fintechs helping banks evolve – or planning a revolution?",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/small-business-network/2016/apr/09/are-fintechs-helping-banks-evolve-or-planning-a-revolution"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/music/2016/may/07/never-mind-bus-pass-punks-look-back-wildest-days",
+        "role": "thumbnail",
+        "linkText": "Never mind the bus pass: punks look back at their wildest days",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/music/2016/may/07/never-mind-bus-pass-punks-look-back-wildest-days"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/australia-news/2017/aug/23/the-answers-in-the-post-australian-marriage-equality-vote-explainer",
+        "role": "thumbnail",
+        "linkText": "The answer's in the post – Australian marriage equality vote explainer",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/australia-news/2017/aug/23/the-answers-in-the-post-australian-marriage-equality-vote-explainer"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/australia-news/2017/aug/09/abbotts-obstruction-of-gay-marriage-is-a-defence-of-privilege-and-the-power-of-shame-david-marr",
+        "role": "thumbnail",
+        "linkText": "Abbott's obstruction of gay marriage is a defence of privilege and the power of shame | David Marr",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/australia-news/2017/aug/09/abbotts-obstruction-of-gay-marriage-is-a-defence-of-privilege-and-the-power-of-shame-david-marr"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/world/2016/may/05/ahmet-davutoglus-future-turkish-prime-minister-balance",
+        "role": "thumbnail",
+        "linkText": "Turkish PM Davutoğlu resigns as President Erdoğan tightens grip",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/world/2016/may/05/ahmet-davutoglus-future-turkish-prime-minister-balance"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/world/2016/may/03/merkel-served-me-up-for-tea-to-erdogan-german-comedian-jan-bohmermann-",
+        "role": "thumbnail",
+        "linkText": "Merkel 'served me up for tea' to Erdoğan, says German comedian",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/world/2016/may/03/merkel-served-me-up-for-tea-to-erdogan-german-comedian-jan-bohmermann-"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/books/2010/feb/14/crime-fiction-merritt-sj-parris",
+        "role": "thumbnail",
+        "linkText": "Forget 'serious' novels, I've turned to a life of crime",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/books/2010/feb/14/crime-fiction-merritt-sj-parris"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/music/2016/mar/13/punk-1976-1978-british-library-40th-anniversary-sex-pistols-buzzcocks",
+        "role": "thumbnail",
+        "linkText": "Happy Birthday Punk: the British Library celebrates 40 years of anarchy and innovation",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/music/2016/mar/13/punk-1976-1978-british-library-40th-anniversary-sex-pistols-buzzcocks"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/film/2016/apr/29/proms-kevin-costner-a-smiley-face-the-onion-we-review-anything",
+        "role": "thumbnail",
+        "linkText": "Proms, Kevin Costner's \"English\" accent, a smiley face, the onion – we review anything",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/film/2016/apr/29/proms-kevin-costner-a-smiley-face-the-onion-we-review-anything"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/culture/2016/apr/15/games-based-on-pop-stars-yesterday-afternoon-a-bin-root-canals-we-review-anything",
+        "role": "thumbnail",
+        "linkText": "Games based on pop stars, yesterday afternoon, a bin, root canals – we review anything",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/culture/2016/apr/15/games-based-on-pop-stars-yesterday-afternoon-a-bin-root-canals-we-review-anything"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/culture/2016/apr/08/iggy-pops-cockatoo-hamster-toys-a-sign-a-guide-writers-career-choices-we-review-anything",
+        "role": "thumbnail",
+        "linkText": "Iggy Pop's cockatoo, hamster toys, a sign, a Guide writer's career choices: we review anything",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/culture/2016/apr/08/iggy-pops-cockatoo-hamster-toys-a-sign-a-guide-writers-career-choices-we-review-anything"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/football/2016/apr/26/hillsborough-disaster-deadly-mistakes-and-lies-that-lasted-decades",
+        "role": "thumbnail",
+        "linkText": "Hillsborough disaster: deadly mistakes and lies that lasted decades",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/football/2016/apr/26/hillsborough-disaster-deadly-mistakes-and-lies-that-lasted-decades"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/football/2016/may/03/hillsborough-families-criticise-south-yorkshire-pcc-over-inquest-tactics",
+        "role": "thumbnail",
+        "linkText": "Hillsborough families criticise South Yorkshire PCC over inquest tactics",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/football/2016/may/03/hillsborough-families-criticise-south-yorkshire-pcc-over-inquest-tactics"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/us-news/live/2016/may/05/donald-trump-nomination-republican-party-us-election-news-sanders-clinton-live",
+        "role": "thumbnail",
+        "linkText": "Trump's presumptive nomination divides Republicans – campaign live",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/us-news/live/2016/may/05/donald-trump-nomination-republican-party-us-election-news-sanders-clinton-live"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/commentisfree/2017/jun/16/theresa-may-scared-grenfell-survivors-finished-austerity-cameron-osborne",
+        "role": "thumbnail",
+        "linkText": "Theresa May was too scared to meet the Grenfell survivors. She’s finished | Polly Toynbee",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/commentisfree/2017/jun/16/theresa-may-scared-grenfell-survivors-finished-austerity-cameron-osborne"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/lifeandstyle/australia-food-blog/2014/nov/26/forget-the-thermomix-your-kitchen-appliances-have-secret-powers",
+        "role": "thumbnail",
+        "linkText": "Forget the Thermomix - your kitchen appliances have secret powers",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/lifeandstyle/australia-food-blog/2014/nov/26/forget-the-thermomix-your-kitchen-appliances-have-secret-powers"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/us-news/2017/mar/27/solar-power-florida-new-york-renewable-energy-policies",
+        "role": "thumbnail",
+        "linkText": "Sunshine state shuns solar as overcast New York basks in clean energy boom",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/us-news/2017/mar/27/solar-power-florida-new-york-renewable-energy-policies"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/environment/2017/jun/01/donald-trump-paris-climate-deal-pullout-us-impact",
+        "role": "thumbnail",
+        "linkText": "The Paris deal pullout is more damaging to the US than the climate",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/environment/2017/jun/01/donald-trump-paris-climate-deal-pullout-us-impact"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/politics/2017/jun/14/liberal-democrats-leadership-race-the-early-runners-and-riders",
+        "role": "thumbnail",
+        "linkText": "Liberal Democrats leadership race: the early runners and riders",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/politics/2017/jun/14/liberal-democrats-leadership-race-the-early-runners-and-riders"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/politics/2017/jun/14/tim-farron-quits-as-lib-dem-leader",
+        "role": "thumbnail",
+        "linkText": "Tim Farron quits as Lib Dem leader",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/politics/2017/jun/14/tim-farron-quits-as-lib-dem-leader"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/politics/2017/jun/14/lib-dem-peer-brian-paddick-resigns-over-farrons-views-on-gay-sex",
+        "role": "thumbnail",
+        "linkText": "Lib Dem peer resigns over Farron's views on homosexuality",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/politics/2017/jun/14/lib-dem-peer-brian-paddick-resigns-over-farrons-views-on-gay-sex"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/football/blog/2017/jun/15/russia-confederations-cup-2018-world-cup-concerns",
+        "linkText": "Russia hopes Confederations Cup will banish 2018 World Cup concerns | Shaun Walker",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/football/blog/2017/jun/15/russia-confederations-cup-2018-world-cup-concerns"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/politics/2016/may/04/miners-strike-ipcc-considers-unredacted-orgreave-report",
+        "role": "thumbnail",
+        "linkText": "Miners' strike: IPCC considers unredacted Orgreave report",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/politics/2016/may/04/miners-strike-ipcc-considers-unredacted-orgreave-report"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/us-news/2016/may/04/barack-obama-flint-michigan-water-crisis",
+        "role": "thumbnail",
+        "linkText": "Obama in Flint: water crisis is a 'tragedy that never should have happened'",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/us-news/2016/may/04/barack-obama-flint-michigan-water-crisis"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/environment/2016/jan/22/water-lead-content-tests-us-authorities-distorting-flint-crisis",
+        "role": "thumbnail",
+        "linkText": "US authorities distorting tests to downplay lead content of water",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/environment/2016/jan/22/water-lead-content-tests-us-authorities-distorting-flint-crisis"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "http://www.theguardian.com/music/2016/apr/29/prince-final-days-death-percocet",
+        "role": "thumbnail",
+        "linkText": "Prince's final days: few clues pointed to secret behind star's untimely death",
+        "linkPrefix": "Related: ",
+        "originalUrl": "http://www.theguardian.com/music/2016/apr/29/prince-final-days-death-percocet"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/lifeandstyle/2016/oct/01/me-and-my-garden-we-planted-a-rose-garden-with-our-daughters-ashes",
+        "role": "thumbnail",
+        "linkText": "Me and my garden: ‘We planted a rose garden with our daughter’s ashes’",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/lifeandstyle/2016/oct/01/me-and-my-garden-we-planted-a-rose-garden-with-our-daughters-ashes"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/world/2017/jun/12/isis-islamic-state-iraq-baaj-abu-bakr-al-baghdadi",
+        "role": "thumbnail",
+        "linkText": "Booby-traps … but no Baghdadi: the men cleaning up after Isis in northern Iraq",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/world/2017/jun/12/isis-islamic-state-iraq-baaj-abu-bakr-al-baghdadi"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/world/2016/feb/09/this-is-hell-british-man-held-in-myanmar-for-14-months-without-charge-pleads-for-help",
+        "role": "thumbnail",
+        "linkText": "'This is hell': British man held in Myanmar for 14 months without charge pleads for help",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/world/2016/feb/09/this-is-hell-british-man-held-in-myanmar-for-14-months-without-charge-pleads-for-help"
+      },
+      "elementType": "rich-link"
+    }
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "url": "https://www.theguardian.com/football/blog/2017/jun/16/the-sids-2017-complete-review-2016-17-la-liga-season",
+        "role": "thumbnail",
+        "linkText": "It’s the Sids 2017! The complete review of the 2016-17 La Liga season",
+        "linkPrefix": "Related: ",
+        "isMandatory": "true",
+        "originalUrl": "https://www.theguardian.com/football/blog/2017/jun/16/the-sids-2017-complete-review-2016-17-la-liga-season"
+      },
+      "elementType": "rich-link"
+    }
   }
 ]

--- a/src/elements/helpers/__tests__/transformFixtures.spec.ts
+++ b/src/elements/helpers/__tests__/transformFixtures.spec.ts
@@ -5,6 +5,16 @@ import { transformElementIn, transformElementOut } from "../transform";
 import { allElementFixtures } from "./fixtures";
 
 describe("Element fixtures", () => {
+  /**
+   * This spec runs every fixture declared in `./fixtures/index.ts` through
+   * prosemirror-elements' node representation, and out again. It's useful for
+   * spotting any discrepencies that we might inadvertently introduce as we use
+   * prosemirror-elements for more elements in our CMS.
+   *
+   * To add a new fixture, add the fixture JSON to `./fixtures/index.ts`, and
+   * add the relevant element to the `elements` object below, to ensure the
+   * prosemirror-elements plugin recognises the new element type.
+   */
   const elements = {
     "rich-link": richlinkElement,
   } as const;
@@ -43,10 +53,8 @@ describe("Element fixtures", () => {
           const roundTripElementData = createRoundTripElementData(
             elementName as keyof typeof elements
           );
-          elementFixtures.forEach(({ elements: elementJson }) => {
-            /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- we're asserting this data at runtime in the test */
-            const elementData = JSON.parse(elementJson);
-            const roundTrippedElementData = roundTripElementData(elementData);
+          elementFixtures.forEach(({ element }) => {
+            const roundTrippedElementData = roundTripElementData(element);
 
             /**
              * We expect certain differences in our elements, as both role and isMandatory
@@ -55,14 +63,14 @@ describe("Element fixtures", () => {
              * element data.
              */
             const ignoredFieldValues = [];
-            if (!elementData.fields.isMandatory) {
+            if (!element.fields.isMandatory) {
               ignoredFieldValues.push("fields.isMandatory");
             }
-            if (!elementData.fields.role) {
+            if (!element.fields.role) {
               ignoredFieldValues.push("fields.role");
             }
             const elementToCompare = omit(
-              elementData,
+              element,
               "elementType",
               ...ignoredFieldValues
             );
@@ -72,7 +80,6 @@ describe("Element fixtures", () => {
             );
 
             expect(roundTrippedElementToCompare).toEqual(elementToCompare);
-            /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
           });
         });
       });

--- a/src/elements/helpers/__tests__/transformFixtures.spec.ts
+++ b/src/elements/helpers/__tests__/transformFixtures.spec.ts
@@ -1,0 +1,81 @@
+import { flow, omit } from "lodash";
+import { buildElementPlugin, richlinkElement } from "../../..";
+import { createTestSchema } from "../test";
+import { transformElementIn, transformElementOut } from "../transform";
+import { allElementFixtures } from "./fixtures";
+
+describe("Element fixtures", () => {
+  const elements = {
+    "rich-link": richlinkElement,
+  } as const;
+
+  const {
+    getElementDataFromNode,
+    getNodeFromElementData,
+    nodeSpec,
+  } = buildElementPlugin(elements);
+
+  const { schema, serializer } = createTestSchema(nodeSpec);
+
+  /**
+   * Creates a function that passes element data through our data
+   * transformers, into a Prosemirror node, and then back out through the
+   * transformers again.
+   *
+   * This reflects what happens when an element is parsed into a document in
+   * Composer, and then parsed back out to be saved.
+   */
+  const createRoundTripElementData = (elementName: keyof typeof elements) =>
+    flow(
+      (flexElement) => transformElementIn(elementName, flexElement),
+      (values) => getNodeFromElementData({ elementName, values }, schema),
+      (node) => node && getElementDataFromNode(node, serializer),
+      (maybePMEElement) =>
+        maybePMEElement &&
+        transformElementOut(maybePMEElement.elementName, maybePMEElement.values)
+    );
+
+  // Run fixtures for each element specified in `./fixtures/index.ts` through our round-trip tests.
+  Object.entries(allElementFixtures).forEach(
+    ([elementName, elementFixtures]) => {
+      describe(`round-tripping data for the ${elementName} element fixtures in and out of prosemirror-elements' node representation`, () => {
+        it("should not change element data, unless we are knowingly supplying new defaults", () => {
+          const roundTripElementData = createRoundTripElementData(
+            elementName as keyof typeof elements
+          );
+          elementFixtures.forEach(({ elements: elementJson }) => {
+            /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- we're asserting this data at runtime in the test */
+            const elementData = JSON.parse(elementJson);
+            const roundTrippedElementData = roundTripElementData(elementData);
+
+            /**
+             * We expect certain differences in our elements, as both role and isMandatory
+             * properties may historically be absent but will now be added as default.
+             * If our element data does not have these properties, we ignore them in the new
+             * element data.
+             */
+            const ignoredFieldValues = [];
+            if (!elementData.fields.isMandatory) {
+              ignoredFieldValues.push("fields.isMandatory");
+            }
+            if (!elementData.fields.role) {
+              ignoredFieldValues.push("fields.role");
+            }
+            const elementToCompare = omit(
+              elementData,
+              "elementType",
+              ...ignoredFieldValues
+            );
+            const roundTrippedElementToCompare = omit(
+              roundTrippedElementData,
+              ...ignoredFieldValues
+            );
+
+            expect(roundTrippedElementToCompare).toEqual(elementToCompare);
+            /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
+          });
+        });
+      });
+    }
+  );
+});

--- a/src/elements/helpers/test.ts
+++ b/src/elements/helpers/test.ts
@@ -1,0 +1,32 @@
+import { omit } from "lodash";
+import type OrderedMap from "orderedmap";
+import type { MarkSpec, NodeSpec } from "prosemirror-model";
+import { Schema } from "prosemirror-model";
+import { schema as basicSchema, marks } from "prosemirror-schema-basic";
+import { createParsers } from "../../plugin/helpers/prosemirror";
+
+/**
+ * Creates a basic schema, and associated parsers/serializers, with enough
+ * scaffolding to satisfy basic test cases. Pass a nodeSpec to add the spec to
+ * the schema.
+ */
+export const createTestSchema = (nodeSpec: NodeSpec) => {
+  const strike: MarkSpec = {
+    parseDOM: [{ tag: "s" }, { tag: "del" }, { tag: "strike" }],
+    toDOM() {
+      return ["s"];
+    },
+  };
+
+  const schema = new Schema({
+    nodes: (basicSchema.spec.nodes as OrderedMap<NodeSpec>).append(nodeSpec),
+    marks: { ...omit(marks, "code"), strike },
+  });
+  const { serializer, parser } = createParsers(schema);
+
+  return {
+    schema,
+    serializer,
+    parser,
+  };
+};

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -14,7 +14,8 @@
     "esModuleInterop": true,
     "rootDir": "./src",
     "outDir": "dist/esm",
-    "declarationDir": "dist/declaration"
+    "declarationDir": "dist/declaration",
+    "resolveJsonModule": true
   },
   "include": ["src/**/*"],
 }


### PR DESCRIPTION
## What does this change?

Adds fixture-based tests for element data, with an example dataset for the rich-link element.

These tests allow us to pull data from Composer and roundtrip it through prosemirror-elements. Here's a sample SQL query:

```sql
SELECT element
FROM livecontent, jsonb_array_elements(content -> 'blocks') as blocks,
     jsonb_array_elements(blocks -> 'elements') as element
WHERE elements->> 'elementType' = 'embed'
LIMIT 100
```

We've been caught by small differences in our data before, and these tests should help make these differences visible before we ship new elements.

We have to compromise in a few places because it's sometimes reasonable for our data to be modified by this library:

- some rich links are missing a `role` field, which we supply by default
- some rich links are missing an `isMandatory` field, which we supply by default

As a result, in our test, where these properties don't exist on incoming elements, we ignore them.

## How to test

- Do the automated tests pass?
- Is it roughly clear what they're doing, and why the compromises mentioned about have been made?