### PR TITLE
chore: Pin 3rd party actions to specific commit hash

### DIFF
--- a/.github/workflows/node-js.yml
+++ b/.github/workflows/node-js.yml
@@ -23,7 +23,7 @@ jobs:
       - run: yarn ci
       - run: yarn build
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@5982a02995853159735cb838992248c4f0f16166
         with:
           branches: |
             [

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -11,6 +11,6 @@ jobs:
     main:
         runs-on: ubuntu-latest
         steps:
-            - uses: amannn/action-semantic-pull-request@v3.4.0
+            - uses: amannn/action-semantic-pull-request@db6e259b93f286e3416eef27aaae88935d16cf2e
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this change?

Pins our semantic-release related GHAs, which are third party actions, to a particular commit hash, in line with the security advice for [third party actions.](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)

## How to test

- Does the release portion of the github action still run as expected?
- Does the PR linting still run as expected?
