### PR TITLE
fix: Consolidate two methods of moving from node -> field data

### DIFF
--- a/src/plugin/__tests__/plugin.spec.tsx
+++ b/src/plugin/__tests__/plugin.spec.tsx
@@ -4,10 +4,7 @@ import type { EditorView } from "prosemirror-view";
 import { Decoration, DecorationSet } from "prosemirror-view";
 import { createElementSpec } from "../elementSpec";
 import { ProseMirrorFieldView } from "../fieldViews/ProseMirrorFieldView";
-import {
-  createDefaultRichTextField,
-  createRichTextField,
-} from "../fieldViews/RichTextFieldView";
+import { createDefaultRichTextField } from "../fieldViews/RichTextFieldView";
 import { createTextField } from "../fieldViews/TextFieldView";
 import type { FieldNameToValueMapWithEmptyValues } from "../helpers/fieldView";
 import { createEditorWithElements } from "../helpers/test";

--- a/src/plugin/fieldViews/AttributeFieldView.ts
+++ b/src/plugin/fieldViews/AttributeFieldView.ts
@@ -28,14 +28,6 @@ export abstract class AttributeFieldView<Value extends unknown>
     this.nodeType = node.type;
   }
 
-  public getNodeValue(node: Node): Value {
-    return node.attrs.fields as Value;
-  }
-
-  public getNodeFromValue(fields: Value): Node {
-    return this.nodeType.create({ fields });
-  }
-
   // Classes extending AttributeFieldView should call e.g. this.createInnerView(node.attrs.fields || defaultFields)
   // in their constructor
   protected abstract createInnerView(fields: Value): void;

--- a/src/plugin/fieldViews/CustomFieldView.ts
+++ b/src/plugin/fieldViews/CustomFieldView.ts
@@ -63,14 +63,6 @@ export class CustomFieldView<Value = unknown> implements FieldView<Value> {
     protected offset: number
   ) {}
 
-  public getNodeValue(node: Node): Value {
-    return node.attrs.fields as Value;
-  }
-
-  public getNodeFromValue(fields: Value): Node {
-    return this.node.type.create({ fields });
-  }
-
   /**
    * @returns A function that can be called to update the node fields.
    */

--- a/src/plugin/fieldViews/FieldView.ts
+++ b/src/plugin/fieldViews/FieldView.ts
@@ -46,14 +46,4 @@ export abstract class FieldView<NodeValue> {
    * Destroy this fieldView, cleaning up any resources it has instantiated.
    */
   public abstract destroy(): void;
-
-  /**
-   * Get the value from a given node that's represented by this fieldView.
-   */
-  public abstract getNodeValue(node: Node): NodeValue;
-
-  /**
-   * Create a node for this fieldView with the given value.
-   */
-  public abstract getNodeFromValue(data: NodeValue): Node;
 }

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -84,20 +84,6 @@ export abstract class ProseMirrorFieldView implements FieldView<string> {
     }
   }
 
-  public getNodeValue(node: Node) {
-    const dom = this.serialiser.serializeFragment(node.content);
-    const e = document.createElement("div");
-    e.appendChild(dom);
-    return e.innerHTML;
-  }
-
-  public getNodeFromValue(htmlContent: string) {
-    const element = document.createElement("div");
-    element.innerHTML = htmlContent;
-    const content = this.parser.parse(element);
-    return this.node.type.create({ type: this.fieldName }, content);
-  }
-
   public onUpdate(
     node: Node,
     elementOffset: number,
@@ -348,5 +334,12 @@ export abstract class ProseMirrorFieldView implements FieldView<string> {
     this.innerEditorView.destroy();
     this.innerEditorView = undefined;
     this.fieldViewElement.textContent = "";
+  }
+
+  private getNodeFromValue(htmlContent: string) {
+    const element = document.createElement("div");
+    element.innerHTML = htmlContent;
+    const content = this.parser.parse(element);
+    return this.node.type.create({ type: this.fieldName }, content);
   }
 }

--- a/src/plugin/fieldViews/TextFieldView.ts
+++ b/src/plugin/fieldViews/TextFieldView.ts
@@ -175,8 +175,4 @@ export class TextFieldView extends ProseMirrorFieldView {
 
     this.fieldViewElement.classList.add("ProseMirrorElements__TextField");
   }
-
-  public getNodeValue(node: Node) {
-    return node.textContent;
-  }
 }

--- a/src/plugin/fieldViews/TextFieldView.ts
+++ b/src/plugin/fieldViews/TextFieldView.ts
@@ -175,4 +175,8 @@ export class TextFieldView extends ProseMirrorFieldView {
 
     this.fieldViewElement.classList.add("ProseMirrorElements__TextField");
   }
+
+  public getNodeValue(node: Node) {
+    return node.textContent;
+  }
 }

--- a/src/plugin/helpers/element.ts
+++ b/src/plugin/helpers/element.ts
@@ -104,7 +104,7 @@ export const createGetElementDataFromNode = <
       node
     ) as keyof FieldNameToField<FDesc>;
     const fieldDescription = element.fieldDescriptions[fieldName];
-    const value = getValuesFromNode(node, fieldDescription, serializer);
+    const value = getFieldValueFromNode(node, fieldDescription, serializer);
 
     if (
       (fieldDescription.type === "richText" ||
@@ -124,7 +124,7 @@ export const createGetElementDataFromNode = <
   } as ExtractDataTypeFromElementSpec<ESpecMap, ElementNames>;
 };
 
-const getValuesFromNode = (
+export const getFieldValueFromNode = (
   node: Node,
   fieldDescription: FieldDescription,
   serializer: DOMSerializer

--- a/src/plugin/helpers/fieldView.ts
+++ b/src/plugin/helpers/fieldView.ts
@@ -1,4 +1,4 @@
-import type { Node } from "prosemirror-model";
+import type { DOMSerializer, Node } from "prosemirror-model";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import { CheckboxFieldView } from "../fieldViews/CheckboxFieldView";
 import type { CheckboxValue } from "../fieldViews/CheckboxFieldView";
@@ -13,6 +13,7 @@ import type {
   FieldDescriptions,
   FieldNameToField,
 } from "../types/Element";
+import { getFieldValueFromNode } from "./element";
 import type { KeysWithValsOfType, Optional } from "./types";
 
 export const fieldTypeToViewMap = {
@@ -126,7 +127,8 @@ export const getElementFieldViewFromType = (
 
 export const getFieldValuesFromNode = <FDesc extends FieldDescriptions<string>>(
   fields: FieldNameToField<FDesc>,
-  node: Node
+  node: Node,
+  serializer: DOMSerializer
 ) => {
   // We gather the values from each child as we iterate over the
   // node, to update the renderer. It's difficult to be typesafe here,
@@ -138,7 +140,12 @@ export const getFieldValuesFromNode = <FDesc extends FieldDescriptions<string>>(
       node
     ) as keyof FieldNameToField<FDesc>;
     const field = fields[fieldName];
-    fieldValues[fieldName] = field.view.getNodeValue(node);
+
+    fieldValues[fieldName] = getFieldValueFromNode(
+      node,
+      field.description,
+      serializer
+    );
   });
 
   return fieldValues as FieldNameToValueMap<FDesc>;

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -1,3 +1,4 @@
+import { DOMSerializer } from "prosemirror-model";
 import type { Node, Schema } from "prosemirror-model";
 import type { EditorState } from "prosemirror-state";
 import { NodeSelection, Plugin, PluginKey } from "prosemirror-state";
@@ -188,7 +189,8 @@ const createNodeView = <
     } as unknown) as FieldNameToField<FDesc>[typeof fieldName];
   });
 
-  const initValues = getFieldValuesFromNode(fields, initNode);
+  const serializer = DOMSerializer.fromSchema(initNode.type.schema);
+  const initValues = getFieldValuesFromNode(fields, initNode, serializer);
   const initCommands = commands(getPos, view);
 
   // Because nodes and decorations are immutable in ProseMirror, we can compare
@@ -246,7 +248,7 @@ const createNodeView = <
 
         // Only recalculate our field values if our node content has changed.
         const newFieldValues = fieldValuesChanged
-          ? getFieldValuesFromNode(fields, newNode)
+          ? getFieldValuesFromNode(fields, newNode, serializer)
           : currentValues;
 
         // Only update our FieldViews if their content or decorations have changed.


### PR DESCRIPTION
## What does this change?

At the moment, we have two ways of serializing nodes representing fields into the values they represent:

- A method, `getElementDataFromNode`, which does what it says on the tin
- Instance methods on each `FieldView` instance, `getNodeValue`, which given a field node pass back data.

Although they're called in different contexts and with different sorts of data, they both at root do the same thing – translate node representing field data into the data itself.

We should only have one way of doing this. I've consolidated both ways into a single method, `getFieldValueFromNode`, and removed the relevant method(s) from our `FieldView` interface.

This fixes a problem where we treat text nodes as rich text on serialisation within the renderer, which means we're incorrectly escaping HTML chars in our serialised output. For an example, insert the interactive element in the demo, and click on 'original URL'. You should find that there's an `&amp;` string in the URL that breaks the resulting link.

## How to test

- The automated tests should pass.
- Insert an interactive element in the demo, and click 'original URL'. You should find that the URL now works.