### PR TITLE
fix: Do not escape html anymore – it has already escaped

### DIFF
--- a/src/elements/embed/Callout.tsx
+++ b/src/elements/embed/Callout.tsx
@@ -5,7 +5,6 @@ import React, { useEffect, useState } from "react";
 import { Error } from "../../editorial-source-components/Error";
 import { Label } from "../../editorial-source-components/Label";
 import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
-import { unescapeHtml } from "../helpers/html";
 import { EmbedTestId } from "./EmbedForm";
 
 type Props = {
@@ -122,7 +121,7 @@ const CalloutTable = ({
             <th>Description</th>
             <td
               dangerouslySetInnerHTML={{
-                __html: unescapeHtml(calloutData.fields.description),
+                __html: calloutData.fields.description,
               }}
             ></td>
           </tr>

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -7,7 +7,11 @@ import {
 } from "../../plugin/fieldViews/CustomFieldView";
 import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
-import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
+import {
+  htmlMaxLength,
+  maxLength,
+  required,
+} from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { parseHtml } from "../helpers/html";
 import type { TrackingStatus } from "../helpers/ThirdPartyStatusChecks";
@@ -54,7 +58,7 @@ export const createEmbedFields = ({ createCaptionPlugins }: MainEmbedProps) => {
       maxRows: 10,
       isResizeable: true,
       isMultiline: true,
-      validators: [htmlRequired(undefined, "WARN")],
+      validators: [required(undefined, "WARN")],
       placeholder: "Paste in the embed code…",
     }),
     caption: createFlatRichTextField({
@@ -66,7 +70,7 @@ export const createEmbedFields = ({ createCaptionPlugins }: MainEmbedProps) => {
     alt: createTextField({
       rows: 2,
       isResizeable: true,
-      validators: [htmlMaxLength(1000), htmlRequired()],
+      validators: [maxLength(1000), required()],
       placeholder: "Enter some alt text…",
     }),
     isMandatory: createCustomField(true, true),

--- a/src/elements/embed/embedComponents/__tests__/callout.spec.ts
+++ b/src/elements/embed/embedComponents/__tests__/callout.spec.ts
@@ -1,10 +1,10 @@
 import { getCalloutTag } from "../../EmbedSpec";
 
 const validCallout =
-  '&lt;div data-callout-tagname="ab-new-things-formatting"&gt;&lt;h2&gt;Callout&lt;h2&gt;&lt;p&gt;ab-new-things-formatting&lt;/p&gt;&lt;/div&gt;';
+  '<div data-callout-tagname="ab-new-things-formatting"><h2>Callout<h2><p>ab-new-things-formatting</p></div>';
 
 const invalidCallout =
-  '&lt;div data-callout-tagname="ab-new-things-formatting&gt;&lt;h2&gt;Callout&lt;h2&gt;&lt;p&gt;ab-new-things-formatting&lt;/p&gt;&lt;/div&gt;';
+  '<div data-callout-tagname="ab-new-things-formatting><h2>Callout<h2><p>ab-new-things-formatting</p></div>';
 
 describe("getCalloutTag", () => {
   it("should extract the tag from valid callout html", () => {

--- a/src/elements/helpers/Preview.tsx
+++ b/src/elements/helpers/Preview.tsx
@@ -4,7 +4,6 @@ import { Description } from "../../editorial-source-components/Description";
 import type { InputHeadingProps } from "../../editorial-source-components/InputHeading";
 import { InputHeading } from "../../editorial-source-components/InputHeading";
 import { hasOwnProperty } from "./hasOwnProperty";
-import { unescapeHtml } from "./html";
 
 type PreviewProps = Partial<InputHeadingProps> & {
   html?: string;
@@ -123,7 +122,7 @@ export const Preview = ({
   if (iframeUrl) {
     preview = (
       <iframe
-        src={unescapeHtml(iframeUrl)}
+        src={iframeUrl}
         css={crossDomainIframe}
         height={height}
         ref={ref}
@@ -133,7 +132,7 @@ export const Preview = ({
   } else if (html) {
     preview = (
       <iframe
-        srcDoc={unescapeHtml(html)}
+        srcDoc={html}
         css={iframe}
         height={height}
         ref={ref}

--- a/src/elements/helpers/__tests__/html.spec.ts
+++ b/src/elements/helpers/__tests__/html.spec.ts
@@ -15,8 +15,7 @@ describe("unescapeHtml", () => {
 
 describe("parseHtml", () => {
   it("should return an object", () => {
-    const escapedHtml =
-      "&lt;a href=&quot;https://www.example.com&quot;&gt;Example website&lt;/a&gt;";
+    const escapedHtml = `<a href="https://www.example.com">Example website</a>`;
     const identicalElement = document.createElement("a");
     identicalElement.setAttribute("href", "https://www.example.com");
     identicalElement.appendChild(document.createTextNode("Example website"));

--- a/src/elements/helpers/html.ts
+++ b/src/elements/helpers/html.ts
@@ -6,11 +6,7 @@ export const unescapeHtml = (html: string): string => {
 };
 
 export const parseHtml = (html: string) => {
-  const unescapedHtml = unescapeHtml(html);
-  const parsedHtml = new DOMParser().parseFromString(
-    unescapedHtml,
-    "text/html"
-  );
+  const parsedHtml = new DOMParser().parseFromString(html, "text/html");
   return parsedHtml.body.firstElementChild;
 };
 


### PR DESCRIPTION
## What does this change?

Following up #217, this PR updates our elements to avoid unescaping HTML as it's rendered, by removing the escape step from the `parseHtml` function.

This was necessary because we were mistakenly escaping non-rich-text – now, that's no longer necessary, so #217 breaks any functionality that previously escaped text content.

## How to test

- The automated tests should pass – we have tests for html parsing and detecting callouts that are affected by this change.
- Create an interactive. The preview should be visible.
- Create an embed. The preview should be visible. Adding an iFrame to a youtube video should work as expected (e.g. `<iframe width="560" height="315" src="https://www.youtube.com/embed/cCOL7MC4Pl0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`
- Create a callout. It should appear as normal.

## How can we measure success?

Things continue to work that would have otherwise been broken by #217 😁 

## Have we considered potential risks?

We've a bit of a blind spot where rendering elements is concerned – all of the manual steps taken above are currently untested. We may want to revisit our testing strategy if we feel that this sort of risk isn't acceptable.
