### PR TITLE
feat!: Adds basic telemetry sending functionality

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -135,13 +135,14 @@ const {
     membership: membershipElement,
   },
   {
-    sendTelemetryEvent: (type: string) =>
+    sendTelemetryEvent: (type: string, tags) =>
       telemetryEventService.addEvent({
         app: "ProseMirrorElements",
         stage: "TEST",
         eventTime: new Date().toISOString(),
         type,
         value: true,
+        tags,
       }),
   }
 );

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -1,4 +1,5 @@
 import { FocusStyleManager } from "@guardian/src-foundations/utils";
+import { UserTelemetryEventSender } from "@guardian/user-telemetry-client";
 import omit from "lodash/omit";
 import type OrderedMap from "orderedmap";
 import { collab } from "prosemirror-collab";
@@ -97,34 +98,53 @@ const {
   additionalRoleOptions,
 });
 
+const telemetryEventService = new UserTelemetryEventSender("example.com");
+
 const {
   plugin: elementPlugin,
   insertElement,
   nodeSpec,
   getElementDataFromNode,
-} = buildElementPlugin({
-  "demo-image-element": createDemoImageElement(onSelectImage, onDemoCropImage),
-  image: imageElement,
-  embed: createEmbedElement({
-    checkThirdPartyTracking: mockThirdPartyTracking,
-    convertTwitter: (src) => console.log(`Add Twitter embed with src: ${src}`),
-    convertYouTube: (src) => console.log(`Add youtube embed with src: ${src}`),
-    createCaptionPlugins,
-    targetingUrl: "https://targeting.code.dev-gutools.co.uk",
-  }),
-  interactive: createInteractiveElement({
-    checkThirdPartyTracking: mockThirdPartyTracking,
-    createCaptionPlugins,
-  }),
-  code: codeElement,
-  pullquote: pullquoteElement,
-  "rich-link": richlinkElement,
-  video: createVideoElement({
-    createCaptionPlugins,
-    checkThirdPartyTracking: mockThirdPartyTracking,
-  }),
-  membership: membershipElement,
-});
+} = buildElementPlugin(
+  {
+    "demo-image-element": createDemoImageElement(
+      onSelectImage,
+      onDemoCropImage
+    ),
+    image: imageElement,
+    embed: createEmbedElement({
+      checkThirdPartyTracking: mockThirdPartyTracking,
+      convertTwitter: (src) =>
+        console.log(`Add Twitter embed with src: ${src}`),
+      convertYouTube: (src) =>
+        console.log(`Add youtube embed with src: ${src}`),
+      createCaptionPlugins,
+      targetingUrl: "https://targeting.code.dev-gutools.co.uk",
+    }),
+    interactive: createInteractiveElement({
+      checkThirdPartyTracking: mockThirdPartyTracking,
+      createCaptionPlugins,
+    }),
+    code: codeElement,
+    pullquote: pullquoteElement,
+    "rich-link": richlinkElement,
+    video: createVideoElement({
+      createCaptionPlugins,
+      checkThirdPartyTracking: mockThirdPartyTracking,
+    }),
+    membership: membershipElement,
+  },
+  {
+    sendTelemetryEvent: (type: string) =>
+      telemetryEventService.addEvent({
+        app: "ProseMirrorElements",
+        stage: "TEST",
+        eventTime: new Date().toISOString(),
+        type,
+        value: true,
+      }),
+  }
+);
 
 const strike: MarkSpec = {
   parseDOM: [{ tag: "s" }, { tag: "del" }, { tag: "strike" }],

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@guardian/src-layout": "^3.8.0",
     "@guardian/src-select": "^3.7.0",
     "@guardian/src-text-input": "^3.7.0",
+    "@guardian/user-telemetry-client": "^1.0.1",
     "@popperjs/core": "^2.10.2",
     "@types/prosemirror-collab": "^1.1.1",
     "emotion": "^9.2.10",

--- a/src/elements/helpers/types/TelemetryEvents.ts
+++ b/src/elements/helpers/types/TelemetryEvents.ts
@@ -7,14 +7,6 @@ export enum CommandTelemetryType {
   PMESelectButtonPressed = "PME_SELECT_BUTTON_PRESSED",
 }
 
-export interface IProseMirrorElementCommandTelemetryEvent
-  extends IUserTelemetryEvent {
-  type: CommandTelemetryType;
-  tags: IUserTelemetryEvent["tags"] & {
-    jump: boolean;
-  };
-}
-
 export type SendTelemetryEvent =
   | undefined
   | ((type: string, tags?: IUserTelemetryEvent["tags"]) => void);

--- a/src/elements/helpers/types/TelemetryEvents.ts
+++ b/src/elements/helpers/types/TelemetryEvents.ts
@@ -1,0 +1,20 @@
+import type { IUserTelemetryEvent } from "@guardian/user-telemetry-client";
+
+export enum CommandTelemetryType {
+  PMEUpButtonPressed = "PME_UP_BUTTON_PRESSED",
+  PMEDownButtonPressed = "PME_DOWN_BUTTON_PRESSED",
+  PMERemoveButtonPressed = "PME_REMOVE_BUTTON_PRESSED",
+  PMESelectButtonPressed = "PME_SELECT_BUTTON_PRESSED",
+}
+
+export interface IProseMirrorElementCommandTelemetryEvent
+  extends IUserTelemetryEvent {
+  type: CommandTelemetryType;
+  tags: IUserTelemetryEvent["tags"] & {
+    jump: boolean;
+  };
+}
+
+export type SendTelemetryEvent =
+  | undefined
+  | ((type: string, tags?: IUserTelemetryEvent["tags"]) => void);

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { space } from "@guardian/src-foundations";
 import { Column, Columns } from "@guardian/src-layout";
-import React, { useEffect, useMemo } from "react";
+import React, { useContext, useEffect, useMemo } from "react";
 import { Button } from "../../editorial-source-components/Button";
 import { Error } from "../../editorial-source-components/Error";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
@@ -19,6 +19,7 @@ import type { CustomField, FieldNameToField } from "../../plugin/types/Element";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import type { Store } from "../../renderers/react/store";
+import { TelemetryContext } from "../../renderers/react/TelemetryContext";
 import { useCustomFieldState } from "../../renderers/react/useCustomFieldViewState";
 import { htmlLength } from "../helpers/validation";
 import type {
@@ -30,6 +31,7 @@ import type {
   SetMedia,
 } from "./ImageElement";
 import { minAssetValidation } from "./ImageElement";
+import { ImageElementTelemetryType } from "./imageElementTelemetryEvents";
 
 type Props = {
   fieldValues: FieldNameToValueMap<ReturnType<typeof createImageFields>>;
@@ -232,6 +234,8 @@ const Errors = ({ errors }: { errors: string[] }) =>
 const ImageView = ({ field, updateFields, errors }: ImageViewProps) => {
   const [imageFields, setImageFields] = useCustomFieldState(field);
 
+  const sendTelemetryEvent = useContext(TelemetryContext);
+
   const setMedia = (previousMediaId: string | undefined) => (
     mediaPayload: MediaPayload
   ) => {
@@ -281,6 +285,7 @@ const ImageView = ({ field, updateFields, errors }: ImageViewProps) => {
         icon={<SvgCrop />}
         iconSide="left"
         onClick={() => {
+          sendTelemetryEvent?.(ImageElementTelemetryType.CropButtonPressed);
           field.description.props.openImageSelector(
             setMedia(imageFields.mediaId),
             imageFields.mediaId

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -63,6 +63,8 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
   fieldValues,
   roleOptionsStore: RoleOptionsStore,
 }) => {
+  const sendTelemetryEvent = useContext(TelemetryContext);
+
   return (
     <div data-cy={ImageElementTestId}>
       <Columns>
@@ -128,7 +130,12 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
                     priority="secondary"
                     size="xsmall"
                     iconSide="left"
-                    onClick={() => fields.alt.update(fieldValues.caption)}
+                    onClick={() => {
+                      sendTelemetryEvent?.(
+                        ImageElementTelemetryType.CopyFromCaptionButtonPressed
+                      );
+                      fields.alt.update(fieldValues.caption);
+                    }}
                   >
                     Copy from caption
                   </Button>

--- a/src/elements/image/imageElementTelemetryEvents.ts
+++ b/src/elements/image/imageElementTelemetryEvents.ts
@@ -1,0 +1,3 @@
+export enum ImageElementTelemetryType {
+  CropButtonPressed = "PME_IMAGE_ELEMENT_CROP_BUTTON_PRESSED",
+}

--- a/src/elements/image/imageElementTelemetryEvents.ts
+++ b/src/elements/image/imageElementTelemetryEvents.ts
@@ -1,3 +1,4 @@
 export enum ImageElementTelemetryType {
   CropButtonPressed = "PME_IMAGE_ELEMENT_CROP_BUTTON_PRESSED",
+  CopyFromCaptionButtonPressed = "PME_IMAGE_ELEMENT_COPY_FROM_CAPTION_BUTTON_PRESSED",
 }

--- a/src/plugin/__tests__/elementSpec.spec.ts
+++ b/src/plugin/__tests__/elementSpec.spec.ts
@@ -113,7 +113,10 @@ describe("mount", () => {
 
     it("should add a custom group if specified", () => {
       const testElement1 = createNoopElement({});
-      const { nodeSpec } = buildElementPlugin({ testElement1 }, "customGroup");
+      const { nodeSpec } = buildElementPlugin(
+        { testElement1 },
+        { groupName: "customGroup" }
+      );
       expect(nodeSpec.get("testElement1")).toMatchObject({
         group: "customGroup",
       });

--- a/src/plugin/element.ts
+++ b/src/plugin/element.ts
@@ -85,7 +85,8 @@ export const buildElementPlugin = <
 
   const plugin = createPlugin(
     elementSpecs,
-    buildCommands(predicate, sendTelemetryEvent)
+    buildCommands(predicate),
+    sendTelemetryEvent
   );
   let nodeSpec: OrderedMap<NodeSpec> = OrderedMap.from({});
   for (const elementName in elementSpecs) {

--- a/src/plugin/elementSpec.ts
+++ b/src/plugin/elementSpec.ts
@@ -1,3 +1,4 @@
+import type { SendTelemetryEvent } from "../elements/helpers/types/TelemetryEvents";
 import type { FieldNameToValueMap } from "./helpers/fieldView";
 import { validateWithFieldAndElementValidators } from "./helpers/validation";
 import type { CommandCreator, Commands } from "./types/Commands";
@@ -59,7 +60,8 @@ export type Renderer<FDesc extends FieldDescriptions<string>> = (
   updateState: (fields: FieldNameToValueMap<FDesc>) => void,
   fieldValues: FieldNameToValueMap<FDesc>,
   commands: Commands,
-  subscribe: (fn: Subscriber<FDesc>) => void
+  subscribe: (fn: Subscriber<FDesc>) => void,
+  sendTelemetryEvent: SendTelemetryEvent | undefined
 ) => void;
 
 export const createElementSpec = <FDesc extends FieldDescriptions<string>>(
@@ -76,7 +78,14 @@ export const createElementSpec = <FDesc extends FieldDescriptions<string>>(
   return {
     fieldDescriptions,
     validate,
-    createUpdator: (dom, fields, updateState, fieldValues, commands) => {
+    createUpdator: (
+      dom,
+      fields,
+      updateState,
+      fieldValues,
+      commands,
+      sendTelemetryEvent
+    ) => {
       const updater = createUpdater<FDesc>();
       render(
         validate,
@@ -85,7 +94,8 @@ export const createElementSpec = <FDesc extends FieldDescriptions<string>>(
         (fields) => updateState(fields),
         fieldValues,
         commands,
-        updater.subscribe
+        updater.subscribe,
+        sendTelemetryEvent
       );
       return updater.update;
     },

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -128,32 +128,23 @@ const moveNode = (consumerPredicate: Predicate) => (
 
 const moveNodeUp = (predicate: Predicate) => (
   getPos: () => number | undefined
-) => (view: EditorView, run = true) => {
-  return moveNode(predicate)(getPos, view.state, run && view.dispatch, "up");
-};
+) => (view: EditorView, run = true) =>
+  moveNode(predicate)(getPos, view.state, run && view.dispatch, "up");
 
 const moveNodeDown = (predicate: Predicate) => (
   getPos: () => number | undefined
-) => (view: EditorView, run = true) => {
-  return moveNode(predicate)(getPos, view.state, run && view.dispatch, "down");
-};
+) => (view: EditorView, run = true) =>
+  moveNode(predicate)(getPos, view.state, run && view.dispatch, "down");
 
 const moveNodeTop = (predicate: Predicate) => (
   getPos: () => number | undefined
-) => (view: EditorView, run = true) => {
-  return moveNode(predicate)(getPos, view.state, run && view.dispatch, "top");
-};
+) => (view: EditorView, run = true) =>
+  moveNode(predicate)(getPos, view.state, run && view.dispatch, "top");
 
 const moveNodeBottom = (predicate: Predicate) => (
   getPos: () => number | undefined
-) => (view: EditorView, run = true) => {
-  return moveNode(predicate)(
-    getPos,
-    view.state,
-    run && view.dispatch,
-    "bottom"
-  );
-};
+) => (view: EditorView, run = true) =>
+  moveNode(predicate)(getPos, view.state, run && view.dispatch, "bottom");
 
 const buildMoveCommands = (predicate: Predicate) => (
   getPos: () => number | undefined,
@@ -176,7 +167,6 @@ const removeNode = (getPos: () => number | undefined) => (
   if (!dispatch) {
     return true;
   }
-
   const pos = getPos();
   if (pos === undefined) {
     return;
@@ -196,7 +186,6 @@ const selectNode = (getPos: () => number | undefined) => (
   if (!dispatch) {
     return true;
   }
-
   const pos = getPos();
   if (pos === undefined) {
     return;

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -3,6 +3,7 @@ import type { Node, Schema } from "prosemirror-model";
 import type { EditorState } from "prosemirror-state";
 import { NodeSelection, Plugin, PluginKey } from "prosemirror-state";
 import type { EditorProps } from "prosemirror-view";
+import type { SendTelemetryEvent } from "../elements/helpers/types/TelemetryEvents";
 import type {
   ElementSpec,
   ElementSpecMap,
@@ -39,7 +40,8 @@ export const createPlugin = <
   elementsSpec: {
     [elementName in ElementNames]: ElementSpec<FDesc>;
   },
-  commands: Commands
+  commands: Commands,
+  sendTelemetryEvent: SendTelemetryEvent
 ): Plugin<PluginState, Schema> => {
   return new Plugin<PluginState, Schema>({
     key: pluginKey,
@@ -106,7 +108,8 @@ export const createPlugin = <
       decorations,
       nodeViews: createNodeViews(
         elementsSpec as ElementSpecMap<FDesc, ElementNames>,
-        commands
+        commands,
+        sendTelemetryEvent
       ),
     },
   });
@@ -119,7 +122,8 @@ const createNodeViews = <
   FDesc extends FieldDescriptions<string>
 >(
   elementsSpec: ElementSpecMap<FDesc, ElementNames>,
-  commands: Commands
+  commands: Commands,
+  sendTelemetryEvent: SendTelemetryEvent
 ): NodeViewSpec => {
   const nodeViews = {} as NodeViewSpec;
   for (const elementName in elementsSpec) {
@@ -127,7 +131,8 @@ const createNodeViews = <
     nodeViews[nodeName] = createNodeView(
       nodeName,
       elementsSpec[elementName],
-      commands
+      commands,
+      sendTelemetryEvent
     );
   }
 
@@ -142,7 +147,8 @@ const createNodeView = <
 >(
   nodeName: NodeName,
   element: ElementSpec<FDesc>,
-  commands: Commands
+  commands: Commands,
+  sendTelemetryEvent: SendTelemetryEvent
 ): NodeViewCreator => (initNode, view, _getPos, _, innerDecos) => {
   const dom = document.createElement("div");
   dom.contentEditable = "false";
@@ -224,7 +230,8 @@ const createNodeView = <
       );
     },
     initValues,
-    initCommands
+    initCommands,
+    sendTelemetryEvent
   );
 
   return {

--- a/src/plugin/types/Element.ts
+++ b/src/plugin/types/Element.ts
@@ -1,4 +1,5 @@
 import type { Schema } from "prosemirror-model";
+import type { SendTelemetryEvent } from "../../elements/helpers/types/TelemetryEvents";
 import type { Validator } from "../elementSpec";
 import type {
   CheckboxFieldDescription,
@@ -85,7 +86,8 @@ export type ElementSpec<FDesc extends FieldDescriptions<string>> = {
     fields: FieldNameToField<FDesc>,
     updateState: (fields: FieldNameToValueMap<FDesc>) => void,
     initFields: FieldNameToValueMap<FDesc>,
-    commands: ReturnType<CommandCreator>
+    commands: ReturnType<CommandCreator>,
+    sendTelemetryEvent: SendTelemetryEvent | undefined
   ) => (
     fields: FieldNameToValueMap<FDesc>,
     commands: ReturnType<CommandCreator>,

--- a/src/renderers/react/ElementProvider.tsx
+++ b/src/renderers/react/ElementProvider.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from "react";
 import React, { Component } from "react";
+import type { SendTelemetryEvent } from "../../elements/helpers/types/TelemetryEvents";
 import type {
   FieldValidationErrors,
   Validator,
@@ -12,6 +13,7 @@ import type {
   FieldNameToField,
 } from "../../plugin/types/Element";
 import { ElementWrapper } from "./ElementWrapper";
+import { TelemetryContext } from "./TelemetryContext";
 
 const fieldErrors = <FDesc extends FieldDescriptions<string>>(
   fields: FieldNameToValueMap<FDesc>,
@@ -39,6 +41,7 @@ type IProps<FDesc extends FieldDescriptions<string>> = {
   validate: Validator<FDesc>;
   consumer: Consumer<ReactElement, FDesc>;
   fields: FieldNameToField<FDesc>;
+  sendTelemetryEvent: SendTelemetryEvent;
 };
 
 type IState<FDesc extends FieldDescriptions<string>> = {
@@ -46,7 +49,6 @@ type IState<FDesc extends FieldDescriptions<string>> = {
   fieldValues: FieldNameToValueMap<FDesc>;
   isSelected: boolean;
 };
-
 export class ElementProvider<
   FDesc extends FieldDescriptions<string>
 > extends Component<IProps<FDesc>, IState<FDesc>> {
@@ -100,16 +102,18 @@ export class ElementProvider<
 
   public render() {
     return (
-      <ElementWrapper
-        {...this.state.commands}
-        isSelected={this.state.isSelected}
-      >
-        <this.Element
-          fields={this.props.fields}
-          fieldValues={this.state.fieldValues}
-          updateFields={this.updateFields}
-        />
-      </ElementWrapper>
+      <TelemetryContext.Provider value={this.props.sendTelemetryEvent}>
+        <ElementWrapper
+          {...this.state.commands}
+          isSelected={this.state.isSelected}
+        >
+          <this.Element
+            fields={this.props.fields}
+            fieldValues={this.state.fieldValues}
+            updateFields={this.updateFields}
+          />
+        </ElementWrapper>
+      </TelemetryContext.Provider>
     );
   }
 

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -9,10 +9,12 @@ import {
   SvgChevronRightDouble,
 } from "@guardian/src-icons";
 import type { ReactElement } from "react";
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import { SvgBin } from "../../editorial-source-components/SvgBin";
 import { SvgHighlightAlt } from "../../editorial-source-components/SvgHighlightAlt";
+import { CommandTelemetryType } from "../../elements/helpers/types/TelemetryEvents";
 import type { CommandCreator } from "../../plugin/types/Commands";
+import { TelemetryContext } from "./TelemetryContext";
 
 const buttonWidth = 32;
 
@@ -206,6 +208,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
   children,
 }) => {
   const [closeClickedOnce, setCloseClickedOnce] = useState(false);
+  const sendTelemetryEvent = useContext(TelemetryContext);
 
   return (
     <Container
@@ -218,7 +221,10 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
             type="button"
             data-cy={selectTestId}
             disabled={!select(false)}
-            onClick={() => select(true)}
+            onClick={() => {
+              sendTelemetryEvent?.(CommandTelemetryType.PMESelectButtonPressed);
+              select(true);
+            }}
             aria-label="Select element"
           >
             <SvgHighlightAlt />
@@ -229,8 +235,12 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
             data-cy={removeTestId}
             disabled={!remove(false)}
             onClick={() => {
-              if (closeClickedOnce) remove(true);
-              else {
+              if (closeClickedOnce) {
+                sendTelemetryEvent?.(
+                  CommandTelemetryType.PMERemoveButtonPressed
+                );
+                remove(true);
+              } else {
                 setCloseClickedOnce(true);
                 setTimeout(() => {
                   setCloseClickedOnce(false);
@@ -252,7 +262,12 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
             type="button"
             data-cy={moveTopTestId}
             disabled={!moveTop(false)}
-            onClick={() => moveTop(true)}
+            onClick={() => {
+              sendTelemetryEvent?.(CommandTelemetryType.PMEUpButtonPressed, {
+                jump: true,
+              });
+              moveTop(true);
+            }}
             aria-label="Move element to top"
           >
             <div
@@ -268,7 +283,12 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
             data-cy={moveUpTestId}
             expanded
             disabled={!moveUp(false)}
-            onClick={() => moveUp(true)}
+            onClick={() => {
+              sendTelemetryEvent?.(CommandTelemetryType.PMEUpButtonPressed, {
+                jump: false,
+              });
+              moveUp(true);
+            }}
             aria-label="Move element up"
           >
             <SvgArrowUpStraight />
@@ -278,7 +298,12 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
             data-cy={moveDownTestId}
             expanded
             disabled={!moveDown(false)}
-            onClick={() => moveDown(true)}
+            onClick={() => {
+              sendTelemetryEvent?.(CommandTelemetryType.PMEDownButtonPressed, {
+                jump: false,
+              });
+              moveDown(true);
+            }}
             aria-label="Move element down"
           >
             <SvgArrowDownStraight />
@@ -287,7 +312,12 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
             type="button"
             data-cy={moveBottomTestId}
             disabled={!moveBottom(false)}
-            onClick={() => moveBottom(true)}
+            onClick={() => {
+              sendTelemetryEvent?.(CommandTelemetryType.PMEDownButtonPressed, {
+                jump: true,
+              });
+              moveBottom(true);
+            }}
             aria-label="Move element to bottom"
           >
             <div

--- a/src/renderers/react/TelemetryContext.ts
+++ b/src/renderers/react/TelemetryContext.ts
@@ -1,0 +1,6 @@
+import React from "react";
+import type { SendTelemetryEvent } from "../../elements/helpers/types/TelemetryEvents";
+
+export const TelemetryContext = React.createContext<
+  SendTelemetryEvent | undefined
+>(undefined);

--- a/src/renderers/react/createReactElementSpec.tsx
+++ b/src/renderers/react/createReactElementSpec.tsx
@@ -19,7 +19,8 @@ export const createReactElementSpec = <FDesc extends FieldDescriptions<string>>(
     updateState,
     fieldValues,
     commands,
-    subscribe
+    subscribe,
+    sendTelemetryEvent
   ) =>
     render(
       <ElementProvider<FDesc>
@@ -30,6 +31,7 @@ export const createReactElementSpec = <FDesc extends FieldDescriptions<string>>(
         commands={commands}
         consumer={consumer}
         fieldValues={fieldValues}
+        sendTelemetryEvent={sendTelemetryEvent}
       />,
       dom
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -665,6 +665,13 @@
     "@guardian/src-helpers" "^3.8.0"
     "@guardian/src-icons" "^3.8.0"
 
+"@guardian/user-telemetry-client@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/user-telemetry-client/-/user-telemetry-client-1.0.1.tgz#1529d660dfdcd3ca1424fef2d5509a11c53bbbc3"
+  integrity sha512-kgJfdiTqhFeYvHbw9ca6tY5sgodOtPp3qZRekWNk+ARbubTxyH3KBh5KRt226Cqy017Rbm1ujNKgXsZ/eDenqw==
+  dependencies:
+    lodash "^4.17.20"
+
 "@hapi/hoek@^9.0.0":
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.0.tgz#f3933a44e365864f4dad5db94158106d511e8131"


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
The PR aims to add some basic telemetry in order to improve the observability of how our users interact with elements.
It makes use of the new [Ed Tools telemetry package](https://github.com/guardian/editorial-tools-user-telemetry-service/pull/10) to achieve this, and adds telemetry events to the element commands only. 

We will likely want to expand this API so users can add their own telemetry events to elements.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Add an element in the sandbox environment, interact with the element using the wrapper buttons (move arrows, select and delete). Observe outgoing network requests to the telemetry endpoint (i.e. "example.com").

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
We have visibility of user's interacting with element commands. 


