### PR TITLE
chore: Add additional plugins to release to npm and github

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -69,4 +69,7 @@ jobs:
         run: yarn build
 
       - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: yarn release

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -14,5 +14,8 @@ module.exports = {
         preset: "conventionalcommits",
       },
     ],
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/npm",
+    "@semantic-release/github",
   ],
 };


### PR DESCRIPTION
## What does this change?

#223 is missing a few plugins in our semantic release configuration that we need to publish to NPM, issue a release in Github, and fancy up our release notes.

This PR adds those changes.

## How to test

Take a look at the `beta` branch., which contains these changes. Is there a new release in `npm` as a result of the push?

## How can we measure success?

Releases work as before.