### PR TITLE
chore: Add a script to sanitise element fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,9 @@ const mySchema = new Schema({
   marks
 });
 ```
+
+## Element-specific docs – for Guardian users only
+
+It's useful to write fixture tests to ensure that the element you're creating doesn't disrupt existing data – see the fixture tests in `src/elements/helpers/__tests__/transformFixtures.spec.ts` for more details.
+
+There's a script available at `./fixtures/parse-element.js` to facilitate transforming element data from the Guardian CMS into a redacted form suitable for fixtures.

--- a/src/elements/helpers/__tests__/fixtures/content-atom.json
+++ b/src/elements/helpers/__tests__/fixtures/content-atom.json
@@ -1,0 +1,12034 @@
+[
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e989b9c5-c311-47cb-a7c1-f23fc243e6d3",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-18",
+    "contentid": "5d590e6f8f084f687f358920"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "efb7bdd0-68cd-42ac-97bd-926f21da1800",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-18",
+    "contentid": "5d590e6f8f084f687f358920"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "097a7793-a3a7-42d3-ba86-cdf3a746982f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-25",
+    "contentid": "5ecb667d8f0864e579f17274"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-25",
+    "contentid": "5ecb667d8f0864e579f17274"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "04574662-ddf5-4057-b62d-e8be8ce9b7bc",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-14",
+    "contentid": "5ebd7a958f08d99d46a170e1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6c797515-4f87-4bf0-992f-d876add9b8b6",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-17",
+    "contentid": "5df8d9128f085eda5c109384"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9a3ec7ab-4e7b-4c97-bb82-f63294f8ced4",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-09",
+    "contentid": "5d4d9b2f8f08aaed8a80cb50"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "552dfdf4-676d-48d6-93d3-025c582213a8",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-14",
+    "contentid": "5df51daf8f08d81610a88316"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "bdebf92a-60ac-4105-989a-390874b13b80",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-12",
+    "contentid": "5da1cc328f080de1653933c0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e8a5d369-ef41-4b4a-adf8-f34313e47e32",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-03",
+    "contentid": "5e86d17c8f0866297e9f62c4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2019/12/design-supp-3-part1",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-20",
+    "contentid": "5dfcad518f08c3972263deb4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d99aea42-b874-4f9a-b9a6-f54f1b16a34c",
+        "atomType": "cta"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-11-03",
+    "contentid": "5fa12a2a8f08d174d5112b49"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/tableizer/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-19",
+    "contentid": "5f3c813c8f0863d6ba0392f7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5f111b24-2c7f-48fa-9ba8-ea3e59f0a01f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-06",
+    "contentid": "5f2c2cc48f08fd092ae74458"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "3090b25a-fa7e-431b-918c-9122fe729835",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-06",
+    "contentid": "5f2c2cc48f08fd092ae74458"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0f910369-0a38-4c0f-900a-c347f20179c0",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-06",
+    "contentid": "5f2c2cc48f08fd092ae74458"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/emea",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-25",
+    "contentid": "5f4558368f08f9fdc758dfc1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "19d50965-f9cc-4dac-87c5-6c1a81e09d2d",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-11",
+    "contentid": "5e4296ad8f086a28115a991a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "798d98c1-761f-4e9e-9173-e1ed6481df11",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-09-19",
+    "contentid": "5d83acad8f0834740f3be762"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a5947407-4f95-41fe-849d-e7d9248ebcb7",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-24",
+    "contentid": "5d3868b08f08b47e53e76c5a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/coronavirus-us-v2/map",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-15",
+    "contentid": "5f0f08718f08995420d27cd7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/coronavirus-us-v2/table",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-15",
+    "contentid": "5f0f08718f08995420d27cd7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-26",
+    "contentid": "5ea5b4248f08e05690dc4ecc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "c88979fd-0882-4bbe-a6f6-81e7cd60d2b1",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-26",
+    "contentid": "5ea5b4248f08e05690dc4ecc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "125edc27-21e6-4a0e-9642-b9971b88917a",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-09-19",
+    "contentid": "5d8395088f0834740f3be5ef"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "2e9dd617-c4a9-4f3e-875e-7eca26d6b96b",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-09-19",
+    "contentid": "5d8395088f0834740f3be5ef"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/02/corona-latest-carousel",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-07",
+    "contentid": "5e8c0b9d8f080bdb9f5358fd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "4c473cae-dd35-473f-a117-fda8384f2ad6",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-06",
+    "contentid": "5e1316cd8f08c39722645938"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "67a3e5fe-7b06-4dbf-b7ab-d2e12cf79925",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-23",
+    "contentid": "5ef1a3cf8f087410d50caed8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/cumulative",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-29",
+    "contentid": "5e80c5748f081e5eda2390d7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "69b35e1e-d1ca-429d-a121-ffdb5a545f09",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-06-14",
+    "contentid": "5d0385448f08faa587054464"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "48718617-39ff-43f6-86a7-0f462acf4b95",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-05-29",
+    "contentid": "5cee9fdf8f0807b455f8a8cf"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0d444848-252a-4d1e-805a-aaee60e4bdf5",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-31",
+    "contentid": "5dbb6f708f08cb84c60a2818"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ef87c618-e766-4c59-879b-b7dac5793614",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-23",
+    "contentid": "5f19b36e8f08f2d75cbc063e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "87c58af6-641b-432b-a972-358818bedc15",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-09-17",
+    "contentid": "5d80ddc68f08f9df5bdd601f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1bf746b1-27c2-48bd-b882-a21140069121",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-24",
+    "contentid": "5db16af78f0859498cfb2f9c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "783d38d7-bf50-42bc-ae36-fc21decf46a2",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-19",
+    "contentid": "5e9be1d08f08bade1f295e22"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "98d86579-a9fa-4200-bac1-28f5308b2dc5",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-05-24",
+    "contentid": "5ce8737f8f0807b455f87e7a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "cdb1c831-e8cb-4563-93e1-45b2e877c5af",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-30",
+    "contentid": "5f2349c88f087ea5c94317df"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "69725b50-deda-420a-9a3c-a452f611ccb8",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-30",
+    "contentid": "5f2349c88f087ea5c94317df"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6fef03be-90e4-4479-a966-6b06ac24f770",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-22",
+    "contentid": "5daf34af8f08eb8f0239b221"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/coronavirus-australia-summary",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-31",
+    "contentid": "5f23a6f88f08bb338d709336"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/tableizer/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-31",
+    "contentid": "5f23a6f88f08bb338d709336"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/aus-vic-corona-map-new4",
+        "role": "immersive",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-31",
+    "contentid": "5f23a6f88f08bb338d709336"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2018/03/interactive-enhancer-master-aus",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-31",
+    "contentid": "5f23a6f88f08bb338d709336"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-24",
+    "contentid": "5f1a8fcd8f08609a03a8e9c4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b395476c-f6e0-426f-9c77-c02abd1aa408",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-09",
+    "contentid": "5f06ccfe8f086e3da7aed77b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-09",
+    "contentid": "5f06ccfe8f086e3da7aed77b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8c8b078c-225e-4b45-ac18-b575b8abe9f5",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-01",
+    "contentid": "5e5bdd008f08e1332474d20d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "4233a192-5def-4e79-9dfe-92eab1a79d5b",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-14",
+    "contentid": "5f36f2bc8f084b2f6067157d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/main-media-hider/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-16",
+    "contentid": "5ee875678f08cea6cb54c807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/totals",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-16",
+    "contentid": "5ee875678f08cea6cb54c807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-16",
+    "contentid": "5ee875678f08cea6cb54c807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths-comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-16",
+    "contentid": "5ee875678f08cea6cb54c807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/asia",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-16",
+    "contentid": "5ee875678f08cea6cb54c807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/emea",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-16",
+    "contentid": "5ee875678f08cea6cb54c807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/02/interactive-coronavirus-trackers/maps",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-16",
+    "contentid": "5ee875678f08cea6cb54c807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/cases",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-16",
+    "contentid": "5ee875678f08cea6cb54c807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-16",
+    "contentid": "5ee875678f08cea6cb54c807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/recovered",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-16",
+    "contentid": "5ee875678f08cea6cb54c807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9baa3001-689f-4242-b6c2-ee32ae20a937",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-31",
+    "contentid": "5e83c2e58f0866297e9f49fe"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6f5b870c-9be8-4b8b-9c1a-997615f56d30",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-09-05",
+    "contentid": "5d70faca8f0891025b4485c9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "03f591e0-0734-45db-8055-31aa0ceb11d4",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-09-05",
+    "contentid": "5d70faca8f0891025b4485c9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "bd1192e8-2383-4f52-a7d4-677ff7ece2b5",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-11-21",
+    "contentid": "5dd694a58f087b800b61e669"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d0156f03-f50e-47be-b6b9-8db221f43de5",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-22",
+    "contentid": "5d3598fb8f08cf92bb7749ac"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e40deb59-d8b4-4c88-9c32-266d3789b135",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-31",
+    "contentid": "5ed394428f08f5e373011c42"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-08",
+    "contentid": "5f5770298f0829a231fe871c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d66d9776-890f-4938-81b1-89b41b2b7c3f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-09-10",
+    "contentid": "5d7749458f08143ee1ae35f9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e989b9c5-c311-47cb-a7c1-f23fc243e6d3",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-15",
+    "contentid": "5d55814d8f084f687f3572c2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/emea",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-22",
+    "contentid": "5ea020428f085a072d3bcff6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/totals",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-22",
+    "contentid": "5ea020428f085a072d3bcff6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "65a9450f-4bec-4555-bdb0-c829a2782b42",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-06",
+    "contentid": "5e8ad2368f08c35a1d11aa1b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/cumulative",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-06",
+    "contentid": "5e8ad2368f08c35a1d11aa1b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-06",
+    "contentid": "5e8ad2368f08c35a1d11aa1b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d21c0843-a0c9-4eeb-83c1-f8c5679e2e52",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-17",
+    "contentid": "5df8f1868f087e8308e5fb7a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7aae4f19-e3dc-4d50-becd-2d1a229b093f",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-07",
+    "contentid": "5e146b3c8f085eda5c11392f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "37912254-39d8-4da4-af8f-4d0155124114",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-08",
+    "contentid": "5e8e08058f085d226cfd56a6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9980d40c-07e2-4e5a-8ae3-5056907866ee",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-08",
+    "contentid": "5e8d8f448f08008f0919f0b3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-14",
+    "contentid": "5ee5d6698f08cea6cb54b139"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/choropleth-regions",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-14",
+    "contentid": "5ee5d6698f08cea6cb54b139"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/05/covid-19-big-map/choropleth",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-14",
+    "contentid": "5ee5d6698f08cea6cb54b139"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/auto-table",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-14",
+    "contentid": "5ee5d6698f08cea6cb54b139"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/emea",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-08",
+    "contentid": "5e8d795b8f08ec70cececa22"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "bc9972ce-2c3b-4148-8466-3fb95159427f",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-06-07",
+    "contentid": "5cfa697d8f084466bb195803"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-28",
+    "contentid": "5ecfcd3b8f087e3ca0f6522a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "77142d5a-0bf3-4a80-b538-c47a11b57f6a",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-28",
+    "contentid": "5ecfcd3b8f087e3ca0f6522a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "c0c10383-dbce-4092-b46b-6744617de78b",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-27",
+    "contentid": "5d3c0ed38f08b47e53e771b9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d5f391f4-cb78-4b11-bb34-552ed97e6b76",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-11-22",
+    "contentid": "5dd7d5968f08c158da105505"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a6d7356c-35df-444b-aa63-782a4127441b",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-01",
+    "contentid": "5e5c074c8f086a28115b59f4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "c41b37d8-cd94-4a9b-a2fc-80d7b35ca21c",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-25",
+    "contentid": "5e7b795b8f081e5eda236910"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b5fafd6e-c787-4ee3-8a48-f84798359870",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-25",
+    "contentid": "5e7b795b8f081e5eda236910"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/new-cases-world-map/summary",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-04",
+    "contentid": "5f5212628f08a919fc87589e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "747d7e6a-15d0-47fa-8084-24575975fcad",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-20",
+    "contentid": "5ec5bacb8f0864e579f14d30"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-24",
+    "contentid": "5eca4d778f0886ce4f5d9628"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/new-cases-world-map/world-table",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-12-02",
+    "contentid": "5fc774bc8f08462fc37ceba6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-12-02",
+    "contentid": "5fc774bc8f08462fc37ceba6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "877b9c6d-7c9c-4a97-827a-1b9af0c16314",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-29",
+    "contentid": "5ed10aa28f087122eca51dc0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a0875c4d-24b9-4a65-ac86-622048c1cd9c",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-12-09",
+    "contentid": "5fd04ed18f084f47a8a42403"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "69bfb681-1f3b-4a6b-890b-6f1ec77ed9bb",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-16",
+    "contentid": "5ee8f0918f089b9083ce3f1f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "340fd79b-ef79-43fa-a2ca-857f59c701fc",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-24",
+    "contentid": "5ea2de7e8f0845d1c895d0e9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7ca82963-173a-4ab6-9487-c8e83bda1b27",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-13",
+    "contentid": "5ee4f7508f08e3e3b74b5b68"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-13",
+    "contentid": "5ee4f7508f08e3e3b74b5b68"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "94ecab34-6db6-4389-8998-42b12e4dc4c9",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-04-02",
+    "contentid": "5ca344f6e4b0b4d18bde49d7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "64f1e4dd-f3f1-4e5e-8457-e966fb6902ee",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-07",
+    "contentid": "5e8beb368f08c35a1d11b4a3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "3849e921-99ee-4b30-87d9-ad45ffd298fb",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-09",
+    "contentid": "5e8f31c68f08008f091a0192"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d4e1cbcb-97e2-4f47-8f00-46eaf1c99251",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-15",
+    "contentid": "5f0f39468f0876acf515ff7d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7a6078f6-5a66-4d3e-9339-5610fe320767",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-09",
+    "contentid": "5e666c908f08507c83bf1310"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e60c6aea-b500-4a5a-b6af-b1d99f7d0511",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-11",
+    "contentid": "5eb911688f0846f9cd556003"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8126ea04-4688-401d-b957-ab95f344f908",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-11",
+    "contentid": "5eb911688f0846f9cd556003"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-11",
+    "contentid": "5eb911688f0846f9cd556003"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-20",
+    "contentid": "5f3e568e8f08bdfe18d9101c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "42387a55-40c6-46d6-b3ff-98b51445fccb",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-21",
+    "contentid": "5e9efcc88f0808a2bea7c947"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/totals",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-10",
+    "contentid": "5e90230a8f08db3109f1ffc8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-10",
+    "contentid": "5e90230a8f08db3109f1ffc8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths-comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-10",
+    "contentid": "5e90230a8f08db3109f1ffc8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/asia",
+        "role": "showcase",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-10",
+    "contentid": "5e90230a8f08db3109f1ffc8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/emea",
+        "role": "showcase",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-10",
+    "contentid": "5e90230a8f08db3109f1ffc8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/02/interactive-coronavirus-trackers/maps",
+        "role": "showcase",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-10",
+    "contentid": "5e90230a8f08db3109f1ffc8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/cases",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-10",
+    "contentid": "5e90230a8f08db3109f1ffc8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-10",
+    "contentid": "5e90230a8f08db3109f1ffc8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/recovered",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-10",
+    "contentid": "5e90230a8f08db3109f1ffc8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2017/02/annotation-enhancer",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-26",
+    "contentid": "5e5681878f0811db2fafeeba"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1c7cf1ad-db3a-47f6-914b-2969dbb2616d",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-16",
+    "contentid": "5da7356c8f08b13ca7c7bbdd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "eb902a54-7c8f-4d35-a3e0-2d35ce2cd790",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-06-21",
+    "contentid": "5d0ce08f8f080e828514ccf9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-21",
+    "contentid": "5f16e77d8f088024316ac273"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/aus-nsw-corona-map-new",
+        "role": "immersive",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-29",
+    "contentid": "5f210a4e8f087e20ee605f33"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "f664f932-a592-4078-88a6-b531a280dfb3",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-07",
+    "contentid": "5deba0a98f084cd7ade461dc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "89e1cae2-0317-49b9-9ce6-38b91b772273",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-25",
+    "contentid": "5ef511678f08a3ad642af1b9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0d97fb7f-4365-439e-acf1-047325eeac52",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-25",
+    "contentid": "5e7ad0758f08af215f6faac5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6e702e3d-1b8d-45b8-be0a-244dbdeaa6c8",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-03-17",
+    "contentid": "5c8e869fe4b016d23425dc3c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "c1e01873-5b5a-478d-ac03-61ab372cc6b9",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-10",
+    "contentid": "5d9f66708f08b13ca7c783df"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "73cf75b0-3175-413c-85aa-a93e6544c07c",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-19",
+    "contentid": "5e4cb7928f08e13324745e4d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/asia",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-22",
+    "contentid": "5ec790cc8f08a1782fa7f7b3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "857831f4-ed8c-4dc5-9e5c-f4e3092b4731",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-16",
+    "contentid": "5e4913248f086a28115aca64"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "eb903f00-7374-421b-b47f-ef6529a1d17a",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-16",
+    "contentid": "5e4913248f086a28115aca64"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ac143b3e-d1f4-43f6-8ac7-90c3343ff846",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-22",
+    "contentid": "5dffde1e8f085eda5c10c880"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "cc2d373e-6733-4a1e-8fc7-75a2a2f515e5",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-22",
+    "contentid": "5ef0819f8f08fe600e528600"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b0d4e44f-6069-41c5-bf19-e0f02cddb7d8",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-02",
+    "contentid": "5efda39e8f0800c87646ee21"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "134c6037-2f86-41ab-a672-1986189fb60e",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-02",
+    "contentid": "5efda39e8f0800c87646ee21"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d68135d5-93e3-4df6-9198-a994ef314dbe",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-24",
+    "contentid": "5d387a758f08b52aabec8bb4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "dd798477-b431-4e32-b488-67eebc804536",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-02",
+    "contentid": "5ed62d238f084df971c8e1fa"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "840f2db1-8a4c-45f9-87df-943e21970090",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-16",
+    "contentid": "5f10298f8f0833bc06f32504"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "241cb373-579d-4c0c-b51e-3538d7dc1b18",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-16",
+    "contentid": "5e9863438f0895d83068f40e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "3cf878a2-fb8d-4946-a918-634844a266a7",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-06-14",
+    "contentid": "5d0371df8f08f0505b6523fd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8287e25d-c04e-4fbe-bd09-34f659540bdc",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-05",
+    "contentid": "5f5409f08f08a919fc876c88"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "51e078fc-d6ad-4b62-ac27-58f865b50746",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-06-13",
+    "contentid": "5d01fa0a8f08b4ffd6496f20"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "af92f097-5ea1-4c10-8eca-0cc596d9acc5",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-06-13",
+    "contentid": "5d01fa0a8f08b4ffd6496f20"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5d700f8b-95e7-4a7e-8829-dee013479bff",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-24",
+    "contentid": "5db1c88a8f08993584c8afdd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "65a9450f-4bec-4555-bdb0-c829a2782b42",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-17",
+    "contentid": "5e99acc38f08b7689b030478"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/tableizer/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-19",
+    "contentid": "5f3c82e08f089b3b72acf625"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a81dbd86-f7c7-4b2d-affa-9a6aff9b9b5f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-19",
+    "contentid": "5f3c82e08f089b3b72acf625"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "69bc2609-b61f-4a43-a042-0af3c62f3de7",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-16",
+    "contentid": "5e7006f68f088d7575594a09"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "eb209d16-d740-4281-8272-7875e7456184",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-16",
+    "contentid": "5e7006f68f088d7575594a09"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "55aaf273-0427-4cad-bfdc-968c3d0dd4ba",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-16",
+    "contentid": "5e7006f68f088d7575594a09"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e7aeeaee-2cef-4dc6-bad1-114f6db15047",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-11-08",
+    "contentid": "5dc5894c8f0844fb5767d033"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "bbaf990c-6d5b-45a6-aaca-77f96280a943",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-13",
+    "contentid": "5f34fb578f086badb5561c49"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9ba86514-c046-4e9c-b36f-2c1303e08d52",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-19",
+    "contentid": "5daba35e8f08aae28ee52e45"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/world",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-16",
+    "contentid": "5e6fb4a38f085e564ad85307"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "390864ba-7333-413b-b543-c4a1db248881",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-26",
+    "contentid": "5e569b8f8f08e1332474aa31"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-17",
+    "contentid": "5f11aaf38f08c52937e2e852"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d3da6023-ee35-4f8b-98be-62eb94391c53",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-19",
+    "contentid": "5e4cf2058f0811db2fafa565"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "857831f4-ed8c-4dc5-9e5c-f4e3092b4731",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-20",
+    "contentid": "5e4e447a8f08e13324746a39"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "426162f1-cc4c-49b1-94d2-4695369d6541",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-06-12",
+    "contentid": "5d00e8448f0894f72f41067c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "77142d5a-0bf3-4a80-b538-c47a11b57f6a",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-22",
+    "contentid": "5ec7b2f28f0886ce4f5d86cd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7a8aefc4-c87c-430c-81cd-7b8b5fa27431",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-22",
+    "contentid": "5ec7b2f28f0886ce4f5d86cd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "10a270bd-3d2a-425c-84e7-5112cc08498d",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-10",
+    "contentid": "5f30bb8a8f0803fbf9404164"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e8a5d369-ef41-4b4a-adf8-f34313e47e32",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-29",
+    "contentid": "5e80bdf48f081e5eda239092"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0a09a661-0ee2-41ea-b0a0-9e1deefd9268",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-28",
+    "contentid": "5e304a358f0811db2faeccbc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-12",
+    "contentid": "5f33943b8f08fd092ae7889e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/06/covid-case-change/uk-choropleth",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-12",
+    "contentid": "5f33943b8f08fd092ae7889e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/auto-table",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-12",
+    "contentid": "5f33943b8f08fd092ae7889e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6d5b0dcd-f29a-4444-832e-f668f9bc337d",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-29",
+    "contentid": "5e3156fb8f086a28115a1729"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "783d38d7-bf50-42bc-ae36-fc21decf46a2",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-29",
+    "contentid": "5ea8c5b68f08db9df42df3bd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "38a2b340-e00e-41bd-b8cd-ae47e9c3c554",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-31",
+    "contentid": "5e33e2eb8f086a28115a2d9e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "72a02dab-b30f-43de-948e-85f9b73088f5",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-31",
+    "contentid": "5e33e2eb8f086a28115a2d9e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "660d4f99-cecb-418c-8151-efb76b052846",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-31",
+    "contentid": "5e33e2eb8f086a28115a2d9e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9a19fac5-8dff-4125-9ba7-ba08f2c09fa7",
+        "atomType": "profile"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-04-30",
+    "contentid": "5cc8768c8f088888885afa79"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d91784ea-cadc-4af5-80bc-f0953ad9b5e6",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-20",
+    "contentid": "5f15b1268f08a89a8afee8f0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-21",
+    "contentid": "5f16a1688f088024316abec0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/05/covid-19-big-map/choropleth",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-21",
+    "contentid": "5f16a1688f088024316abec0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/auto-table",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-21",
+    "contentid": "5f16a1688f088024316abec0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "acf5fd97-28ab-4971-96f2-2acaab08b5e9",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-07",
+    "contentid": "5e3d09868f0811db2faf3129"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "269f2d88-03d7-4abd-aae9-0cc49f828e4a",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2018-11-26",
+    "contentid": "5bfbf97ee4b045afb442427d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "eecbd794-6af8-4163-85f6-2b5e7d6be37e",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-14",
+    "contentid": "5df4bb6b8f08c3972263a309"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5a246ca8-1e20-4968-bb76-17c1e0b01c45",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-05-29",
+    "contentid": "5ceea1ec8f08ad67f1a835e6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0c4b05cb-c5b5-4a70-bd83-b53b51aea4d7",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-26",
+    "contentid": "5ef568d68f0869ad3a3f10cd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "36e59380-3340-4baf-9357-5e283b2b8ca3",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-23",
+    "contentid": "5db08fd28f08aae28ee5331f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6c5f28d5-308d-4c5a-99f1-0b1c1af34ac1",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-15",
+    "contentid": "5d5579ed8f08791c9216e7c1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9faaa2df-e92c-4a2e-a83a-e1a1284fe1d4",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-10-12",
+    "contentid": "5f8457f38f08c6dc95cf4bc5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "783d38d7-bf50-42bc-ae36-fc21decf46a2",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-10",
+    "contentid": "5eb7aaa08f08464cd429766d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a5947407-4f95-41fe-849d-e7d9248ebcb7",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-16",
+    "contentid": "5e207d8e8f082f37c01eb0f1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "de1e570f-8e72-48f9-983d-ecd6187d4d1e",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-22",
+    "contentid": "5dae9d638f08142786c4fc3d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "4308f776-76ab-4148-936a-2cf79e451ed9",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-22",
+    "contentid": "5dae9d638f08142786c4fc3d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "93a412a8-7ad0-428d-818a-c67e60e2b6e9",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-18",
+    "contentid": "5e9afbd08f08bade1f2959d7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/main-media-hider/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-12",
+    "contentid": "5ee340958f0839df653848dd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/totals",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-12",
+    "contentid": "5ee340958f0839df653848dd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-12",
+    "contentid": "5ee340958f0839df653848dd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths-comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-12",
+    "contentid": "5ee340958f0839df653848dd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/asia",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-12",
+    "contentid": "5ee340958f0839df653848dd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/emea",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-12",
+    "contentid": "5ee340958f0839df653848dd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/02/interactive-coronavirus-trackers/maps",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-12",
+    "contentid": "5ee340958f0839df653848dd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/cases",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-12",
+    "contentid": "5ee340958f0839df653848dd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-12",
+    "contentid": "5ee340958f0839df653848dd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/recovered",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-12",
+    "contentid": "5ee340958f0839df653848dd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "060992ee-7a92-4f2f-8c47-c4bb6e46dedb",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-29",
+    "contentid": "5ea9fb858f0874558631828d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7360f4b1-8acf-4df2-9d66-54ffd4608f9c",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-29",
+    "contentid": "5ea9fb858f0874558631828d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e5e0736b-e1e9-4d22-a9e3-934052929b7d",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-29",
+    "contentid": "5ea9fb858f0874558631828d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "929b537e-e49f-44e0-9138-3a7a4ec49c3e",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-24",
+    "contentid": "5f1a841d8f08609a03a8e95c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b5c42063-e9a0-49a2-92c5-24ba2021a269",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-05-03",
+    "contentid": "5ccc5cfb8f0875cf5e3b5057"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "543c8aac-b71a-4ca2-8ac9-7bd857df0aa7",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-11-18",
+    "contentid": "5fb530b78f08161b0b9c7762"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "783d38d7-bf50-42bc-ae36-fc21decf46a2",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-14",
+    "contentid": "5e953ffd8f08db3109f21efe"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ea9661e9-292c-4ae0-877f-54dbadee8f57",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2018-07-07",
+    "contentid": "5b403e1be4b074b334551d8e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "4f11585c-a248-44a5-b1b6-53b0493c1a59",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-13",
+    "contentid": "5df3959b8f08895152f9cb2d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6397723a-89fe-4de7-80bc-982c5aa7f79f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-29",
+    "contentid": "5e80ad1e8f081e5eda238fed"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "fb1b1673-7f08-4a17-9903-35657563c582",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-29",
+    "contentid": "5e80ad1e8f081e5eda238fed"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7a6078f6-5a66-4d3e-9339-5610fe320767",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-26",
+    "contentid": "5e5626828f086a28115b2bab"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8bed6d2c-bda9-45cd-812a-476e9c6ea1c5",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-19",
+    "contentid": "5f3da36c8f089b3b72ad0310"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8bed6d2c-bda9-45cd-812a-476e9c6ea1c5",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-19",
+    "contentid": "5f3da36c8f089b3b72ad0310"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-10",
+    "contentid": "5eb7a9578f08464cd4297666"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7bb26bfc-05df-4557-a9be-5e1c95185a79",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-10",
+    "contentid": "5eb7a9578f08464cd4297666"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "2d4c72e2-ada1-429c-ac00-dff0e7b17ed5",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-03",
+    "contentid": "5ed749518f087122eca548d1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "bcf03fe2-4826-49f4-9cea-866466cc3125",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-03",
+    "contentid": "5ed749518f087122eca548d1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "f70e1aa9-a123-4f7d-b39e-98bda70490a7",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-07",
+    "contentid": "5f04541b8f088a08ad539fdd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0c018b4f-eddc-4af4-b7d9-215afe06c75a",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-08",
+    "contentid": "5eb547cd8f08464cd429692d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ba9786c6-c779-4063-8bf9-1d3009eb7c70",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-17",
+    "contentid": "5e9973d98f0895d83068fc4b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/01/interactive-coronavirus-tracker",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-03",
+    "contentid": "5e5dc47e8f0811db2fb0278e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7a6078f6-5a66-4d3e-9339-5610fe320767",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-26",
+    "contentid": "5e5614a48f086a28115b2b57"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/totals",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-29",
+    "contentid": "5e809ebc8f0878a2a48ac6e0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ddcbeca5-b80f-4b61-9615-d7cfd2f5cd4c",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-18",
+    "contentid": "5d594e9c8f08aaed8a80d67b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-17",
+    "contentid": "5e99a17c8f08bade1f29508f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7ccbdd00-8401-4ff1-ba29-e045db544ac4",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-01",
+    "contentid": "5e0cb1618f085eda5c1107d4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0cad4eae-5e75-419e-a2e4-9343e8933a02",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-01",
+    "contentid": "5e0cb1618f085eda5c1107d4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6cf4eb43-7b62-41fa-b2b9-c6f6b02f4466",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-01",
+    "contentid": "5e0cb1618f085eda5c1107d4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "3289f51d-eba9-471e-8d3d-20b4b257b473",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-30",
+    "contentid": "5e32e44a8f086a28115a25fc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b6a88cfd-b2e6-4fd3-8f89-acac9e98eb10",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-30",
+    "contentid": "5e32e44a8f086a28115a25fc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "3aa2d33a-ec52-4abb-94d4-21572a61a965",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-15",
+    "contentid": "5d5584038f0896be8f8f9db2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e3001853-be65-4f21-b5b5-4fa7e2194c4c",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-12",
+    "contentid": "5e1ba80a8f08bb9179e03f25"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "90c33573-5b65-45eb-b87c-8e4faf7a5f8c",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2018-01-14",
+    "contentid": "5a5ba01de4b0fe5e06bfa033"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "15d8153a-f7bc-4caa-a491-e78120cfecda",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-05-03",
+    "contentid": "5ccc11908f086f179813a48f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7bf50f5a-00cc-4dc6-9170-a9b50529196e",
+        "atomType": "cta"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-30",
+    "contentid": "5e82458f8f08a8efb3ba92cd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e8a5d369-ef41-4b4a-adf8-f34313e47e32",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-23",
+    "contentid": "5e7887a78f08dcc95cc2164f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e27781c8-618b-474b-9889-56cea80fdfca",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-20",
+    "contentid": "5dac51a08f08eb8f0239af09"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/aus-vic-corona-map-new4",
+        "role": "immersive",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-29",
+    "contentid": "5f210bbb8f085e929a8a709e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "694eca0f-6d8c-491d-b329-2be5c5bcc847",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-16",
+    "contentid": "5e983a748f08cf571cdb2167"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "51dbdd87-bfe4-4e3b-b20b-fbc3e5e7e0d8",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-18",
+    "contentid": "5f3b5b948f08b5d07520dd7f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e7005108-65b1-4809-a31d-2d6aaf5bfd4b",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-18",
+    "contentid": "5f3b5b948f08b5d07520dd7f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e2e2ab22-d61b-4cc6-82ce-31b9f85e0fff",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-18",
+    "contentid": "5f3b5b948f08b5d07520dd7f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "76b041b2-082f-44a0-aaf9-3e9b213bd0f3",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-06-07",
+    "contentid": "5cfa9fb28f0894c2e0991f25"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "33c12bfc-8edd-4367-95be-f8be94dfd89f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-23",
+    "contentid": "5d6019938f0878710458789b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "2bbf415c-4f41-4ff3-959f-02069544b284",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-19",
+    "contentid": "5d5ac5e68f0896be8f8fbf87"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "595ad543-7850-49f7-8470-48787e1461f4",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-23",
+    "contentid": "5ea13ced8f084784dca585ec"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "15ba1c07-a175-467d-89ed-756d44480b14",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-23",
+    "contentid": "5ea13ced8f084784dca585ec"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b4d652eb-fe3f-462c-8bc3-386058308726",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-23",
+    "contentid": "5ea13ced8f084784dca585ec"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "783d38d7-bf50-42bc-ae36-fc21decf46a2",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-25",
+    "contentid": "5ea395288f08fa2bdcb1b200"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "20dcd9a8-009d-4f16-8865-ff3f957ad192",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-14",
+    "contentid": "5df515248f087e8308e5e206"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "f7113245-a1e6-4c4c-85fe-7bd1340955d7",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-14",
+    "contentid": "5df515248f087e8308e5e206"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e7dfc227-94c9-446c-9aad-bd8b32f85e81",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-14",
+    "contentid": "5df515248f087e8308e5e206"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8e42ce84-d7eb-4256-ac8b-09b84a6c26c9",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-31",
+    "contentid": "5e346dc98f08e1332473ac0b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-14",
+    "contentid": "5ebd20de8f08d99d46a16be3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "cfee56d3-053e-46e7-9d03-ec0704b3d476",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-05",
+    "contentid": "5eda38618f083999a26da779"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "65a9450f-4bec-4555-bdb0-c829a2782b42",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-26",
+    "contentid": "5e7c7fc98f081e5eda2370e0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-10-23",
+    "contentid": "5f92e4448f086891532b7837"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "4f76106d-503e-4c71-9f19-8933c6228042",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-10-23",
+    "contentid": "5f92e4448f086891532b7837"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "76ecb2e1-d843-41f6-8e05-8151306c4429",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-21",
+    "contentid": "5e75f67b8f08dcc95cc20924"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1b56a6e9-3ba9-4c70-b5d1-9782bf154f2b",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-10",
+    "contentid": "5d9eea308f08b13ca7c77cf2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6d4887fe-e4b5-45b0-9050-78e8c6021de1",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-10",
+    "contentid": "5d9eea308f08b13ca7c77cf2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ec111dec-74bc-48b9-bd85-a7fc7b1041eb",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-10",
+    "contentid": "5d9eea308f08b13ca7c77cf2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1e9dfa89-73a8-4525-8f1a-ada46b1bd6be",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-10",
+    "contentid": "5d9eea308f08b13ca7c77cf2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "153a7380-7340-434b-9c11-4318c867fbcb",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-04-23",
+    "contentid": "5cbf2c418f08c89bd9066e07"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d568499c-365b-4012-972b-cb61d9c33bf5",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-28",
+    "contentid": "5e594c048f0811db2fb00a02"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "f3bbbb9d-be3c-4279-b024-e5c7f85bdc65",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-24",
+    "contentid": "5f1acfd48f08609a03a8ed8a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/tableizer/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-26",
+    "contentid": "5f45bd938f08c26134254380"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a81dbd86-f7c7-4b2d-affa-9a6aff9b9b5f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-26",
+    "contentid": "5f45bd938f08c26134254380"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/aus-nsw-corona-map-new",
+        "role": "immersive",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-31",
+    "contentid": "5f2379168f08f42f5d72a6b7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "fe98ef6f-999f-417e-a537-b11a2d5efb34",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-16",
+    "contentid": "5f10d0888f083da22b9a0378"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "082b262e-331d-4df2-abc4-6f42173084ff",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-01",
+    "contentid": "5e35ec988f080eac902442ef"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "783d38d7-bf50-42bc-ae36-fc21decf46a2",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-17",
+    "contentid": "5e9923ae8f08cf571cdb2a19"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "22cad6d9-aa8a-4a07-b688-680ccac266c6",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-20",
+    "contentid": "5e2586438f0879d539efb72b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a8bd8536-d489-4b09-b3fe-10451522b903",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-20",
+    "contentid": "5e2586438f0879d539efb72b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "edb25c0f-328d-4fb1-ac51-b66d285ff532",
+        "atomType": "chart"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-01",
+    "contentid": "5f4e34778f086326a159859b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "51ff943f-e72a-405b-8587-54ef351d6bc2",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-03",
+    "contentid": "5e86ece28f0866297e9f6369"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0e4b5e5f-9e74-429d-8d59-fa20ec98489c",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-19",
+    "contentid": "5f6581548f083ee3ac1f25eb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/01/interactive-coronavirus-tracker",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-31",
+    "contentid": "5e3412d08f08e1332473a729"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b071dd12-4af2-44df-a75c-2a7c83d52035",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-17",
+    "contentid": "5f11cf5f8f08c52937e2eaca"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "2276fad4-82d0-4293-adcd-fbdfc1542e44",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-15",
+    "contentid": "5d556aa78f0896be8f8f9c28"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "fc9d5493-e583-487b-a944-351a3fed08b6",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-23",
+    "contentid": "5db08cc98f08993584c8aaf2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1bf746b1-27c2-48bd-b882-a21140069121",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-23",
+    "contentid": "5db08cc98f08993584c8aaf2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0a09a661-0ee2-41ea-b0a0-9e1deefd9268",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-26",
+    "contentid": "5e7d0adb8f08af215f6fc0b4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/02/corona-latest-carousel",
+        "role": "supporting",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-02",
+    "contentid": "5e85977c8f08532a0e6666ed"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "bde155c3-43e7-4929-8506-bb043a798a88",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-02",
+    "contentid": "5e85977c8f08532a0e6666ed"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7a6078f6-5a66-4d3e-9339-5610fe320767",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-28",
+    "contentid": "5e5906548f0811db2fb00617"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "f6c353a6-9f4b-4e0f-9ff0-5bdcbf9f9b02",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-24",
+    "contentid": "5db142378f0898437061b829"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0465c878-b37f-426e-b911-e3cd74dd975e",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-24",
+    "contentid": "5db142378f0898437061b829"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1bf746b1-27c2-48bd-b882-a21140069121",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-24",
+    "contentid": "5db142378f0898437061b829"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5444d786-7ca6-4ade-bd48-bca210f886c6",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-23",
+    "contentid": "5d5ff04d8f084061ab38b577"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/coronavirus-us-new/map",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-23",
+    "contentid": "5e7894178f08e0999e6b870a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/coronavirus-australia-summary",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-10",
+    "contentid": "5ee029f78f087583352290cb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/tableizer/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-10",
+    "contentid": "5ee029f78f087583352290cb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2018/03/interactive-enhancer-master-aus",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-10",
+    "contentid": "5ee029f78f087583352290cb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7a6078f6-5a66-4d3e-9339-5610fe320767",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-04",
+    "contentid": "5e5f6b748f08e1332474eec2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d1955a5f-e232-4621-bab1-9bef4789a10d",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-23",
+    "contentid": "5f19ad728f08f2d75cbc05cc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "130724d9-7d5b-4d8f-9473-5ff88e639af2",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-23",
+    "contentid": "5f19ad728f08f2d75cbc05cc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5780baaa-63b9-440f-bc80-31b8840e932c",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-30",
+    "contentid": "5efb38f28f0800c87646d3e4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0f910369-0a38-4c0f-900a-c347f20179c0",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-07",
+    "contentid": "5f2ce4338f08da3d16037294"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "83a6bdbb-1c81-4e83-bdb1-db6355369fa2",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-19",
+    "contentid": "5e7332f08f085c6327bc2d70"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/emea",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-19",
+    "contentid": "5e7332f08f085c6327bc2d70"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/totals",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-19",
+    "contentid": "5e7332f08f085c6327bc2d70"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "37d8df52-5195-42cd-a877-bb137e79b56d",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-11-15",
+    "contentid": "5dce9e558f08eeb483f1818c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-02",
+    "contentid": "5e85e3788f087564da1e46f0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "783d38d7-bf50-42bc-ae36-fc21decf46a2",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-28",
+    "contentid": "5ecf70438f084e882655a2db"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "2276fad4-82d0-4293-adcd-fbdfc1542e44",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-15",
+    "contentid": "5d555be68f0896be8f8f9b5b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0a09a661-0ee2-41ea-b0a0-9e1deefd9268",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-03",
+    "contentid": "5e37ccee8f089499319c3c3d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "efd89ada-9d44-4598-ab39-32f1c0398b0a",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-03",
+    "contentid": "5e37ccee8f089499319c3c3d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2019/09/alchemy",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-09-27",
+    "contentid": "5d8e0cae8f084ab84172e538"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e29aae1e-5fad-4195-a0e4-d8d02934845e",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-06-13",
+    "contentid": "5d0220be8f08a5ec1de45f25"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9cd86439-9730-4d31-9420-04159eb9e36f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-16",
+    "contentid": "5e6eca408f085e564ad84af1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "04fecb04-934a-4af1-baee-358948ad8ba5",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-16",
+    "contentid": "5e6eca408f085e564ad84af1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e35a366c-8c8d-49d2-8017-1120beea26de",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-16",
+    "contentid": "5e6eca408f085e564ad84af1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "813b8139-288d-4297-9591-f6f2be6d4d7d",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-27",
+    "contentid": "5ea6df8f8f0827bced4156ee"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ccd6bc3c-247b-428b-ab4e-349a27619759",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-27",
+    "contentid": "5ea6df8f8f0827bced4156ee"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "50baa290-7c2f-4e3d-af0e-76d0e8d4e9a9",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-05",
+    "contentid": "5e8977b98f08c9eaf0daeb00"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5de66503-c807-432d-a489-607f9d6996a9",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-16",
+    "contentid": "5ee94a568f089b9083ce42ec"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "efcce6bc-7d16-4b58-a7b9-522b3d4eafe0",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-16",
+    "contentid": "5ee94a568f089b9083ce42ec"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9dd3d512-4cc0-4c1e-a575-db6589608cc7",
+        "atomType": "cta"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-11-08",
+    "contentid": "5dc584698f08c2d1f80dc2d4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b5d46630-ffe4-4f18-972f-127154b9432a",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-15",
+    "contentid": "5ee76c458f08bc1dd58e3012"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "60c2a5c9-4e1b-4526-bc86-d03c812c7736",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-28",
+    "contentid": "5ecfe6848f087e3ca0f65392"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0c26d6a8-d3b9-4bec-90a9-ea48a3b700a7",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-29",
+    "contentid": "5ed094248f0898700351e549"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9c0ea818-293d-4321-bd1f-dc76202136fa",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-29",
+    "contentid": "5ed094248f0898700351e549"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ec3df472-0ffb-4116-a17e-d726b32a766d",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-21",
+    "contentid": "5dfe297a8f08d81610a88c90"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "3167ddba-f4e4-4d75-8422-7d20ce0a231e",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-28",
+    "contentid": "5ecf63ef8f0898700351dacf"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "913a2e08-6c0a-4bcc-9086-ca3bc148865a",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-04",
+    "contentid": "5e884a028f08c9eaf0dae57e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9c984017-e252-457b-9c1c-05ed904b759b",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-22",
+    "contentid": "5ef08b268f082875f448fb71"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "130724d9-7d5b-4d8f-9473-5ff88e639af2",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-22",
+    "contentid": "5ef08b268f082875f448fb71"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9c984017-e252-457b-9c1c-05ed904b759b",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-22",
+    "contentid": "5ef08b268f082875f448fb71"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "77bf5e5d-fe7b-471f-97bd-6c09a54965c1",
+        "atomType": "cta"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-11",
+    "contentid": "5f32aed58f0803fbf9405610"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a5947407-4f95-41fe-849d-e7d9248ebcb7",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-19",
+    "contentid": "5d5a60de8f0896be8f8fbae1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/10/election-month/default",
+        "role": "immersive",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-30",
+    "contentid": "5f74d03f8f08865dbde10bb8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "39a7bf25-5d7e-46a7-9fb4-8347f8787212",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-05",
+    "contentid": "5e3ab3ec8f08b46fee3f7b48"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ff768fb7-7f71-4080-8a6d-1f3958eeb391",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-19",
+    "contentid": "5ec3a9928f0864e579f139b0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1aec41bb-4bb2-43a8-8422-685e21f4685f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-16",
+    "contentid": "5ee8ce728f089a4ae3aff9e1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/main-media-hider/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-20",
+    "contentid": "5ec4dfcb8f08a1782fa7dfe2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-20",
+    "contentid": "5ec4dfcb8f08a1782fa7dfe2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/choropleth-regions",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-20",
+    "contentid": "5ec4dfcb8f08a1782fa7dfe2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/choropleth",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-20",
+    "contentid": "5ec4dfcb8f08a1782fa7dfe2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/auto-table",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-20",
+    "contentid": "5ec4dfcb8f08a1782fa7dfe2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "759465e2-377f-43f1-80be-3dd2ccee09f0",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-23",
+    "contentid": "5d36e7dd8f08d0b6ca536083"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "f7723320-4111-4d4c-926c-a9c3fc415245",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-24",
+    "contentid": "5f443cc68f08c2613425344d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/emea",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-14",
+    "contentid": "5e9590bd8f08213494be645b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6fef03be-90e4-4479-a966-6b06ac24f770",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-09-19",
+    "contentid": "5d83551a8f0848e3184df267"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "f8afb6a3-ea27-4fc6-bb8e-3d2df82b6aea",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-19",
+    "contentid": "5f3d56318f089b3b72acffa1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "74223bc6-4cac-4ae7-8c60-9ffa43535ad0",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-30",
+    "contentid": "5f228a9c8f08bb338d708c5e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "67bc25af-d30a-4465-a1d8-320ae27b3588",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-06-12",
+    "contentid": "5d01245a8f08337517863759"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d7166fbd-53e1-4a06-a5b1-6b956740acec",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2021-02-16",
+    "contentid": "602bd2d48f085a938bcf16e6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "dbefd615-3a3a-42d6-ba32-25d1000dda85",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-06",
+    "contentid": "5edc2c778f08b31c971055e3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/02/delegate-tracker/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-18",
+    "contentid": "5e71d4248f088d757559580e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b39bb81e-38ef-4172-b244-be4b783fe803",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-04",
+    "contentid": "5e10ddad8f08d81610a89ef7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5f14a2a6-e77a-40df-bf43-2eada1e364dc",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-19",
+    "contentid": "5e4d72fd8f086a28115aeb81"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0d9c7a50-aad5-4ea7-9a90-41bc164e610d",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-05",
+    "contentid": "5f014e0b8f0832109a71938c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2021/04/aus-vaccine-received-tracker/article",
+        "role": "showcase",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2021-04-14",
+    "contentid": "60763b338f0873e56c1b4042"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9b6c3f85-d42b-454b-83be-5921e37c7916",
+        "atomType": "cta"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-03",
+    "contentid": "5e38529a8f086a28115a4cb4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "3ad8b0d2-dd9c-45c8-8f8e-bff377dc2e91",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-25",
+    "contentid": "5d39b1a48f08d0b6ca5379f9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "4526de28-dc35-45b6-9d1c-f8cc3503d580",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-11-01",
+    "contentid": "5f9f3ed48f080c5c2d378449"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e3554e3c-0b5d-49a7-ba95-1b1ab3f69e3a",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-16",
+    "contentid": "5e6faa778f088d7575594667"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d66de100-82d3-4bd8-baf5-bafd0978ee4d",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-14",
+    "contentid": "5df529488f08594a8c22544a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6ffb7398-083c-4995-ba51-34f386b0a012",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-14",
+    "contentid": "5df529488f08594a8c22544a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "36145103-0318-4539-bb8d-0ea42af47f36",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2021-02-01",
+    "contentid": "6017d1268f085e2bcdae3306"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "fb08f938-97c9-4c8a-a8ba-15120ac30ad3",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-09",
+    "contentid": "5e4093988f08e133247402d2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "84bc9467-b305-47b3-a96b-4efb3b9f8eeb",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-27",
+    "contentid": "5ef792c38f0837885469836d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "69b35e1e-d1ca-429d-a121-ffdb5a545f09",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-23",
+    "contentid": "5d6011868f0875ebf830cfe2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a87e5a73-3cf2-45cc-a8c2-d291ecf7e764",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-23",
+    "contentid": "5d6011868f0875ebf830cfe2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "68d5eb48-4080-4cda-8936-81b46d069399",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-18",
+    "contentid": "5eeb9be58f08cf3f3513681d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9a19fac5-8dff-4125-9ba7-ba08f2c09fa7",
+        "atomType": "profile"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-04",
+    "contentid": "5e396d798f080eac9024467c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "48718617-39ff-43f6-86a7-0f462acf4b95",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-05-29",
+    "contentid": "5cee915e8f08cb618337833e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "54b467cc-34ab-43c7-91e3-e5337efb4466",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-09-19",
+    "contentid": "5d839f6c8f08f30dc5bbe8b3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9961c176-1d89-4c75-8f96-beaa3aaf9ea6",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-19",
+    "contentid": "5e4dc7b08f0811db2fafad58"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "67bc25af-d30a-4465-a1d8-320ae27b3588",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-06-12",
+    "contentid": "5d0101c38f0894f72f4107d1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "752593a9-6c28-4c30-baff-de120446801f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2018-12-05",
+    "contentid": "5c07e60ae4b04b34b3e61406"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ef407e03-79e5-43ca-9595-819b6fe989c1",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2018-12-05",
+    "contentid": "5c07e60ae4b04b34b3e61406"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "752593a9-6c28-4c30-baff-de120446801f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2018-12-05",
+    "contentid": "5c07e60ae4b04b34b3e61406"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e291949b-d02c-4d8c-b925-5fb770beb4ef",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-13",
+    "contentid": "5e1c52308f085eda5c116f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "86fe9e9a-af72-4432-8b15-3f3d79c7a216",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-13",
+    "contentid": "5e1c52308f085eda5c116f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "074f099f-66d4-4593-afa5-9ae43434a7fa",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-08",
+    "contentid": "5e15b7808f08c39722646ca1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830f7948-c436-4a8d-9361-e4220444d49f",
+        "atomType": "profile"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-04",
+    "contentid": "5f0037c68f0832109a718c57"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a10c1968-908d-4ec5-86ef-05b45468c0de",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-04",
+    "contentid": "5f0037c68f0832109a718c57"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9c0ea818-293d-4321-bd1f-dc76202136fa",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-28",
+    "contentid": "5ed039e58f084e882655ab09"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d6804595-e6a8-4e15-828c-f20215aa2d65",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-28",
+    "contentid": "5ed039e58f084e882655ab09"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "783d38d7-bf50-42bc-ae36-fc21decf46a2",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-21",
+    "contentid": "5ec6223d8f0864e579f14f16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d50300cf-2636-4c44-ad3d-e8751ea2816a",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-29",
+    "contentid": "5d67d6e88f08ea59f447b43d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "68be1ef3-115e-4304-bfc4-441cb3896047",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-29",
+    "contentid": "5d67d6e88f08ea59f447b43d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "59c346e4-e8ae-45fe-b314-4694de4da2f3",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-09-01",
+    "contentid": "5d6bd9bd8f08ae9af53e4990"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e21b0030-2435-4815-b303-d324062e6d9e",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-04",
+    "contentid": "5f5222578f08a919fc8759a9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "85ea51f0-0910-47df-acd9-62b37b70f914",
+        "atomType": "chart"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-04",
+    "contentid": "5f5222578f08a919fc8759a9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8113512b-8ee0-49dc-80d3-0b56df87e441",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-23",
+    "contentid": "5db028ad8f08993584c8a846"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7a8aefc4-c87c-430c-81cd-7b8b5fa27431",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-09",
+    "contentid": "5edf61498f08bd75dbb64d44"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "bbdedea8-3745-42f9-a4fe-eb53a8598b4f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-14",
+    "contentid": "5e9534c58f081a236f192d48"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1304d12f-d400-4a9a-84e6-cea786eca713",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-28",
+    "contentid": "5e5944278f086a28115b4954"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7a98b795-e636-4e75-b443-22e9e6429f26",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-28",
+    "contentid": "5e5944278f086a28115b4954"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a5947407-4f95-41fe-849d-e7d9248ebcb7",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-17",
+    "contentid": "5d2f14448f08d0b6ca5324f9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/totals",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-17",
+    "contentid": "5e70eb808f085e564ad85cd4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7a6078f6-5a66-4d3e-9339-5610fe320767",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-17",
+    "contentid": "5e70eb808f085e564ad85cd4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a01c98ee-1da8-4dbb-b816-af3dabe22d9b",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-11",
+    "contentid": "5e91297e8f08db3109f20952"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "783d38d7-bf50-42bc-ae36-fc21decf46a2",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-19",
+    "contentid": "5e9bde628f080ee110447961"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d3da6023-ee35-4f8b-98be-62eb94391c53",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-18",
+    "contentid": "5e4c02798f08e133247458d0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7b35fae4-23b3-4ecb-b3d2-4397af6de948",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-07",
+    "contentid": "5e8cfa398f08008f0919edab"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "96b88911-0634-461d-9628-144a87e65baa",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-08",
+    "contentid": "5d23340d8f08cf92bb76b937"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/bubble/black-history",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-03",
+    "contentid": "5eff4ad68f0804b96dd6dedc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/bubble/non-europe-america",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-03",
+    "contentid": "5eff4ad68f0804b96dd6dedc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/bubble/empire",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-03",
+    "contentid": "5eff4ad68f0804b96dd6dedc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/bubble/topic",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-03",
+    "contentid": "5eff4ad68f0804b96dd6dedc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2021-02-22",
+    "contentid": "6033e7178f088c613adcf618"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ba1cd7c2-878c-4332-8844-2c34b3b29f43",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-20",
+    "contentid": "5e9d0c508f080ee110447f5e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ba9786c6-c779-4063-8bf9-1d3009eb7c70",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-18",
+    "contentid": "5e9ad3128f08bade1f2958c9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7a6078f6-5a66-4d3e-9339-5610fe320767",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-13",
+    "contentid": "5e6b50968f08c2df6d278dd1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9b6c179e-450d-4075-bd00-4d6b9111275b",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-13",
+    "contentid": "5e6b50968f08c2df6d278dd1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/09/election-enhancer-2020",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-23",
+    "contentid": "5f6b1bd18f0880c5546ea519"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/08/us-poll-tracker/swing-states",
+        "role": "showcase",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-23",
+    "contentid": "5f6b1bd18f0880c5546ea519"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/08/us-poll-tracker/national-chart",
+        "role": "showcase",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-23",
+    "contentid": "5f6b1bd18f0880c5546ea519"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/08/us-poll-tracker/more-content",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-23",
+    "contentid": "5f6b1bd18f0880c5546ea519"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "08b8960f-4556-460f-aa40-601083c90627",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-22",
+    "contentid": "5d5e7f898f081cf11cf1b05b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b146305d-32c1-4dc9-9f4d-b60ce025264f",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-22",
+    "contentid": "5d5e7f898f081cf11cf1b05b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "005ff716-7738-4d1b-b0e0-47b9ace27954",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-06-12",
+    "contentid": "5d010a478f08d5122c6885fa"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2019/10/us-campaign-finance-richest-zips",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-16",
+    "contentid": "5da779998f083d8b3b9dd428"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2019/10/us-campaign-finance-occupations",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-16",
+    "contentid": "5da779998f083d8b3b9dd428"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7a6078f6-5a66-4d3e-9339-5610fe320767",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-18",
+    "contentid": "5e4c017c8f086a28115adf90"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "73cf75b0-3175-413c-85aa-a93e6544c07c",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-18",
+    "contentid": "5e4c017c8f086a28115adf90"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e65aa09a-8daf-422d-95ce-b6d29369f1c4",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-15",
+    "contentid": "5e6e07d98f0831a9c46f279c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9a19fac5-8dff-4125-9ba7-ba08f2c09fa7",
+        "atomType": "profile"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-31",
+    "contentid": "5e83293c8f08a8efb3ba9871"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d3b7f24b-2281-4563-8116-8fbdcc6b24da",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-06-19",
+    "contentid": "5d09efee8f08374cc5790ef4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/06/covid-case-change/choropleth",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-16",
+    "contentid": "5ee878da8f08e3e3b74b77d4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/06/covid-19-stats-local-authority/highest",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-16",
+    "contentid": "5ee878da8f08e3e3b74b77d4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/06/covid-19-stats-local-authority/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-16",
+    "contentid": "5ee878da8f08e3e3b74b77d4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/06/covid-19-stats-local-authority/deaths",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-16",
+    "contentid": "5ee878da8f08e3e3b74b77d4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "aae8a9e0-c4f1-438d-b883-fa10f29e9bbc",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-16",
+    "contentid": "5ee8e2a98f0850c4cdec529e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0a09a661-0ee2-41ea-b0a0-9e1deefd9268",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-31",
+    "contentid": "5e33ee8b8f0811db2faeea7c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "cfdf0e57-592b-4f76-ad35-f210d0c08493",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-06",
+    "contentid": "5eb27c578f08da022712b52f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/08/uk-coronavirus-dashboard-v2/choropleth-combined",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-10-12",
+    "contentid": "5f8483c08f08affd42c85f1c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e60c6aea-b500-4a5a-b6af-b1d99f7d0511",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-08",
+    "contentid": "5ede770e8f08bd75dbb645e2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5d25beb5-14fb-47b4-bd06-0714dbfabc04",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-08",
+    "contentid": "5ede770e8f08bd75dbb645e2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d6c9f0e8-6307-4b0c-96a3-c76b801cbf53",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-31",
+    "contentid": "5d41660f8f0845f89e317b10"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "783d38d7-bf50-42bc-ae36-fc21decf46a2",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-16",
+    "contentid": "5e97f47c8f08ea7431f43bac"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "710b54fa-b43c-4e63-a1af-fa2289807d71",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-14",
+    "contentid": "5e46b85c8f086a28115abd00"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/new-cases-world-map/summary",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-12",
+    "contentid": "5f3396498f0803fbf9405ead"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/new-cases-world-map/world-recent-cases",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-12",
+    "contentid": "5f3396498f0803fbf9405ead"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-12",
+    "contentid": "5f3396498f0803fbf9405ead"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths-comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-12",
+    "contentid": "5f3396498f0803fbf9405ead"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5dd78891-e3db-4501-9452-9c2dbfa77686",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-09",
+    "contentid": "5edf66408f0883ec2fc1dbe0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "532df0a3-11ca-4d4e-8f76-d04fd6d181ce",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-09",
+    "contentid": "5edf66408f0883ec2fc1dbe0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/cumulative",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-29",
+    "contentid": "5e80d7ca8f081e5eda239179"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "fb1b1673-7f08-4a17-9903-35657563c582",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-29",
+    "contentid": "5e80d7ca8f081e5eda239179"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1fa04d24-2eca-4858-8d87-a079db0f852b",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-29",
+    "contentid": "5f72e3908f08693b177506e1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "cae9b219-4d47-4d04-a06c-a8930ce5a119",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-29",
+    "contentid": "5f72e3908f08693b177506e1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "2ee2cffb-799a-493a-8c11-53d4f7bd66f7",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-07",
+    "contentid": "5eb4a06e8f08464cd42964a9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "540e071c-de7e-4403-bd98-884975b4559a",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-07",
+    "contentid": "5eb4a06e8f08464cd42964a9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0185b5d8-655b-4317-9685-cb1217f6a2b8",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-07",
+    "contentid": "5eb4a06e8f08464cd42964a9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "93dfa0b9-a532-4699-a6bf-8396c9e8d91c",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-10-08",
+    "contentid": "5f7e881f8f08aa9a835362c6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7ea64f24-6c8a-4b54-8eee-9988d2929e86",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-29",
+    "contentid": "5f21d8f68f088e9f6f92cf65"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "c791bdc2-7f07-44d2-b6f4-9be6aee1de6b",
+        "atomType": "cta"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-16",
+    "contentid": "5da775528f084862358ff6ce"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "4087c58b-68a4-4338-8eb6-2982a8672a76",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-11",
+    "contentid": "5ee1f5b18f08beee219d9807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9d6297a9-acc3-46e5-97f6-0c53659f3028",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-11",
+    "contentid": "5ee1f5b18f08beee219d9807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "fb77a87d-c986-4247-b91e-3144d73b7471",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-11",
+    "contentid": "5ee1f5b18f08beee219d9807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "532e8393-b5fb-4cb9-9af1-f0ab3c7a0cbb",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-15",
+    "contentid": "5d551fd18f08aaed8a80d25e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/02/testing-liveblog-football",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-20",
+    "contentid": "5e4e81d08f08e13324746c87"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e3353ea1-2718-498c-9d39-1492a6ab6de5",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-31",
+    "contentid": "5dbab3208f08d669cdab0328"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/totals",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-14",
+    "contentid": "5e6ceaed8f085e564ad841d9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7a6078f6-5a66-4d3e-9339-5610fe320767",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-14",
+    "contentid": "5e6ceaed8f085e564ad841d9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ab2038e6-1a2f-4a05-81de-67c2b1cad9b2",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-10",
+    "contentid": "5e18390c8f085eda5c11571a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "30accade-e85c-40f7-9f19-22f88db3001a",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-10",
+    "contentid": "5e18390c8f085eda5c11571a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-28",
+    "contentid": "5ef894f68f08b429949259e0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "de18fcc7-291a-44b2-a7ff-f706023d8027",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-26",
+    "contentid": "5e5637b78f0811db2fafeba8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9a3ce4fb-f097-4a7b-8d39-515291bcb9a1",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-23",
+    "contentid": "5d3716fa8f0845f89e312bb2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "73addb86-5298-46c3-b09a-0a29b2c04ffa",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-02",
+    "contentid": "5ed5a4388f084df971c8de4b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "c791bdc2-7f07-44d2-b6f4-9be6aee1de6b",
+        "atomType": "cta"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-09-11",
+    "contentid": "5d793b218f083106f4559ce3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-01",
+    "contentid": "5ed4c87c8f08f5e373012347"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0d9c7a50-aad5-4ea7-9a90-41bc164e610d",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-04",
+    "contentid": "5f0047738f08517dae76cf2b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0ef17842-d0b7-442d-bc22-7669aa652305",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-15",
+    "contentid": "5e1ee66e8f0852212f74e4e2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "233fda81-67c3-4086-9a85-62f5eb8da8b9",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-15",
+    "contentid": "5e1ee66e8f0852212f74e4e2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "92deaa29-9664-41a3-afb0-963d19c17764",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-01-21",
+    "contentid": "5c45e943e4b058cfe6d94500"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7b332116-e1f5-4d7a-9fee-922bf6558b00",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-01-21",
+    "contentid": "5c45e943e4b058cfe6d94500"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "56aee133-08df-46a4-81b7-c5ba629e8857",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-10-27",
+    "contentid": "5f98479e8f08eb5db3f0e8de"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/interactive-vaccine-tracker/default",
+        "role": "showcase",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-06",
+    "contentid": "5f2bafd68f0871f06ad99b8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/interactive-vaccine-tracker/updates",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-06",
+    "contentid": "5f2bafd68f0871f06ad99b8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/interactive-vaccine-tracker/description",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-06",
+    "contentid": "5f2bafd68f0871f06ad99b8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/interactive-vaccine-tracker/table",
+        "role": "showcase",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-06",
+    "contentid": "5f2bafd68f0871f06ad99b8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/02/ireland-latest-results",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-10",
+    "contentid": "5e4153c68f0811db2faf4de2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/02/vote-share-ireland",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-10",
+    "contentid": "5e4153c68f0811db2faf4de2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "95c8ba09-ecce-4bfa-9140-a262990fbdce",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-10",
+    "contentid": "5e4153c68f0811db2faf4de2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e8c725a1-10dc-4e7f-b484-1592439e280d",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-11-06",
+    "contentid": "5dc2b9f58f08c2d1f80da9e0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d91f3d9a-314a-46f5-81f2-615e17877426",
+        "atomType": "profile"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-11-06",
+    "contentid": "5dc2b9f58f08c2d1f80da9e0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b46c16e5-8bac-47e2-9a75-657472154e31",
+        "atomType": "cta"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-16",
+    "contentid": "5da778f88f084862358ff6da"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/totals",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-18",
+    "contentid": "5e9b199e8f080ee11044764b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5b86d89c-98d6-4d80-ba4b-9c7affda275f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-18",
+    "contentid": "5e9b199e8f080ee11044764b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-26",
+    "contentid": "5f463ee48f08c26134254846"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/1/goodbye-brits",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-28",
+    "contentid": "5e300f358f0811db2faec9ce"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0a09a661-0ee2-41ea-b0a0-9e1deefd9268",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-21",
+    "contentid": "5e75fed68f08e0999e6b7991"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "f8afb6a3-ea27-4fc6-bb8e-3d2df82b6aea",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-17",
+    "contentid": "5f3a78c98f08f8e2a854ae0c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "aa775e2c-588a-46f1-af5a-4f414593747f",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-20",
+    "contentid": "5dac3d848f08c78d1cb4ee66"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "94c4e350-0930-4a26-b3d8-4c2d1ed6fe3b",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-20",
+    "contentid": "5dac3d848f08c78d1cb4ee66"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9dbb9176-2631-4a68-b258-9f5ce3632bf0",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-09",
+    "contentid": "5edf5e808f0883ec2fc1db59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "dbefd615-3a3a-42d6-ba32-25d1000dda85",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-09",
+    "contentid": "5edf5e808f0883ec2fc1db59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ddc4ba48-47b8-4b2b-91d2-081cd3e143d1",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-05",
+    "contentid": "5e60b28d8f085f0b8d94277d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "05ef8c1c-b4d9-4cc0-a5fb-60ba6bdf369e",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-05",
+    "contentid": "5e112f168f08d81610a89f44"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b39bb81e-38ef-4172-b244-be4b783fe803",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-05",
+    "contentid": "5e112f168f08d81610a89f44"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6a7ec113-d2ae-43d2-bca0-a01620d55f7a",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-01",
+    "contentid": "5eab81b38f08a459b658577a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "dd0e5a58-ea5e-4e76-89be-5885aa2e665c",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-22",
+    "contentid": "5ec7cc278f08164604dc262f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7cc43d0a-076b-44a8-a596-2ef8deded41a",
+        "atomType": "cta"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-16",
+    "contentid": "5da777508f083d8b3b9dd41e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5cf8a4d1-3f7f-420b-9d0f-551632c48434",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-22",
+    "contentid": "5daecbdd8f08993584c8a252"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "783d38d7-bf50-42bc-ae36-fc21decf46a2",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-29",
+    "contentid": "5ea8de818f083c68c23b9341"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "02840bc9-b517-4218-9b4c-dccde822f639",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-18",
+    "contentid": "5f3b90608f08504022d43b85"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "12da897b-2587-4cf0-a974-48466c48a579",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-26",
+    "contentid": "5d3aff7a8f08d0b6ca5384e1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "04ef9426-1e24-45bb-8df1-a23cdfabaece",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-30",
+    "contentid": "5f234ac48f087ea5c94317e3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "eb6ce02b-b2f4-4f96-b06b-05c0769cb7c6",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-30",
+    "contentid": "5f234ac48f087ea5c94317e3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0bd8a8c0-6088-4523-8351-c62581382de0",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-30",
+    "contentid": "5f234ac48f087ea5c94317e3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9a19fac5-8dff-4125-9ba7-ba08f2c09fa7",
+        "atomType": "profile"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-09",
+    "contentid": "5d248a888f08b47e53e751da"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1e78347b-f930-4c6c-b607-a7196aad1c10",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-16",
+    "contentid": "5e49d6b48f08e1332474498c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "783d38d7-bf50-42bc-ae36-fc21decf46a2",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-16",
+    "contentid": "5ebf7fe58f0864e579f11f96"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "eb0b78f3-cc56-4e4b-843c-d9444b31351d",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-14",
+    "contentid": "5df51ef38f08594a8c22543f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/interactive-vaccine-tracker/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-12",
+    "contentid": "5f3396e38f08fd092ae788bb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/interactive-vaccine-tracker/updates",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-12",
+    "contentid": "5f3396e38f08fd092ae788bb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/interactive-vaccine-tracker/description",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-12",
+    "contentid": "5f3396e38f08fd092ae788bb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/interactive-vaccine-tracker/table",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-12",
+    "contentid": "5f3396e38f08fd092ae788bb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2021-02-05",
+    "contentid": "601d0f078f0800bd7848eb4f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/08/uk-coronavirus-dashboard-v2/choropleth-combined",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2021-02-05",
+    "contentid": "601d0f078f0800bd7848eb4f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/08/uk-coronavirus-dashboard-v2/column-chart-cases",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2021-02-05",
+    "contentid": "601d0f078f0800bd7848eb4f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/08/uk-coronavirus-dashboard-v2/column-chart-hospital",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2021-02-05",
+    "contentid": "601d0f078f0800bd7848eb4f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/08/uk-coronavirus-dashboard-v2/column-chart-deaths",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2021-02-05",
+    "contentid": "601d0f078f0800bd7848eb4f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/08/uk-coronavirus-dashboard-v2/column-chart-vaccine",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2021-02-05",
+    "contentid": "601d0f078f0800bd7848eb4f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/08/uk-coronavirus-dashboard-v2/line-chart-vaccine",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2021-02-05",
+    "contentid": "601d0f078f0800bd7848eb4f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/08/uk-coronavirus-dashboard-v2/stacked-chart-tests",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2021-02-05",
+    "contentid": "601d0f078f0800bd7848eb4f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5dcf6ac9-0a4d-4716-a3a4-658f78a8853f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2021-02-05",
+    "contentid": "601d0f078f0800bd7848eb4f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/08/uk-coronavirus-dashboard-v2/table",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2021-02-05",
+    "contentid": "601d0f078f0800bd7848eb4f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/12/covid-enhancer-2020",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2021-02-05",
+    "contentid": "601d0f078f0800bd7848eb4f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6c5f28d5-308d-4c5a-99f1-0b1c1af34ac1",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-15",
+    "contentid": "5d556bc98f083eddf3e0d726"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "65a9450f-4bec-4555-bdb0-c829a2782b42",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-28",
+    "contentid": "5e7f1a138f0878a2a48abf27"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/totals",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-28",
+    "contentid": "5e7f1a138f0878a2a48abf27"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "040ff5be-1096-432e-9dfc-b8b5ef7c1766",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-28",
+    "contentid": "5e7f1a138f0878a2a48abf27"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d945d375-94af-4d98-be6d-8f9fbcc2828e",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-26",
+    "contentid": "5ecd234f8f0852d72995011a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8916ff74-85ec-4f07-8bde-2380c05d3146",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2021-01-28",
+    "contentid": "601268008f08bf384c76471d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/emea",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-09",
+    "contentid": "5f302f948f08fd092ae767c2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "134c6037-2f86-41ab-a672-1986189fb60e",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-09",
+    "contentid": "5f302f948f08fd092ae767c2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5dd78891-e3db-4501-9452-9c2dbfa77686",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-28",
+    "contentid": "5e2ff0ed8f086a28115a0b61"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/01/interactive-coronavirus-tracker",
+        "role": "showcase",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-12",
+    "contentid": "5e69c9128f087df56e4c70b0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/main-media-hider/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-05",
+    "contentid": "5eb119378f08a69c6c689f73"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-05",
+    "contentid": "5eb119378f08a69c6c689f73"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/choropleth",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-05",
+    "contentid": "5eb119378f08a69c6c689f73"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/auto-table",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-05",
+    "contentid": "5eb119378f08a69c6c689f73"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d7d82465-99e0-4483-af66-9adf3eeb5805",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-07",
+    "contentid": "5d21d82f8f08b47e53e74dba"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7bb26bfc-05df-4557-a9be-5e1c95185a79",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-29",
+    "contentid": "5ed100568f087122eca51d3a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "257ef0df-01b1-4c93-8054-5dd0a0bd057f",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2021-04-22",
+    "contentid": "6081d9128f08080a7ae69012"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a1ebe213-74a9-4699-a8a9-3dfd082c1679",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-03",
+    "contentid": "5f51158f8f08a919fc874ec3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "39ca141a-8671-42da-adfb-5d9812ce2a94",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-27",
+    "contentid": "5f47b68f8f08767dd7f105ce"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8bf9fb8d-65d5-47b4-8f97-a7e560b39f23",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-21",
+    "contentid": "5dfe16fb8f085eda5c10bef9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d8659a1d-e026-4358-a8b9-a6d44c737715",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-16",
+    "contentid": "5f6209f68f08bc8778ef1b21"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "f6145851-a41a-4267-adcd-354b8af75bd5",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-27",
+    "contentid": "5e2f71378f08e13324738089"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8b9d86c7-644d-4cbd-bb4f-9751a251c28b",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-31",
+    "contentid": "5ed4330e8f08f5e373011ff3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2019/12/design-supp-3-part-3",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-07",
+    "contentid": "5e1455d98f085eda5c11385d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "230b496a-be12-47ee-b719-feeabd8aed50",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-28",
+    "contentid": "5ef928de8f08116127119381"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b1843afe-6655-423c-b3db-25f2dfa46215",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-30",
+    "contentid": "5f749a6b8f08865dbde107dc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b51e4e64-536a-491f-a168-e503474c1c2d",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-24",
+    "contentid": "5ecb08308f08a1782fa80dbf"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d780e4ad-c967-4afa-baf2-4b536af5c190",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-24",
+    "contentid": "5ecb08308f08a1782fa80dbf"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "134c6037-2f86-41ab-a672-1986189fb60e",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-29",
+    "contentid": "5f211ef28f085e929a8a7149"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "3821a50c-d199-456f-8a48-bff9a26ca326",
+        "atomType": "cta"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-28",
+    "contentid": "5e590f8e8f0811db2fb0067b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0fd1e3d1-d078-46ab-b545-296a9b1ddd49",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-23",
+    "contentid": "5ea168488f08a1178d5b0400"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "479ee39b-c156-451d-9de4-df2ab084dbd8",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-18",
+    "contentid": "5f64cb6e8f083ee3ac1f1f9f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8e67c071-56ff-4b1d-b3a2-06d985caed84",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-30",
+    "contentid": "5eab15de8f08f76ffc19f020"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9d4ecb7f-b90f-49ca-8845-03c28551fa09",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-27",
+    "contentid": "5ece51628f0808ead19b722a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "3167ddba-f4e4-4d75-8422-7d20ce0a231e",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-27",
+    "contentid": "5ece51628f0808ead19b722a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5315bfeb-9203-4ec4-a26a-d8bec406d6a8",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-12",
+    "contentid": "5da2068a8f084862358fce60"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "f8c51756-dc49-4f39-930e-723c5c55821b",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-12",
+    "contentid": "5da2068a8f084862358fce60"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-11",
+    "contentid": "5f324dfe8f0803fbf94050dc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/06/covid-case-change/uk-choropleth",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-11",
+    "contentid": "5f324dfe8f0803fbf94050dc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/auto-table",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-11",
+    "contentid": "5f324dfe8f0803fbf94050dc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ad1d7c74-9669-4287-b714-d1266ecbecde",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-11-16",
+    "contentid": "5dd00be18f08012e5363c2e8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "783d38d7-bf50-42bc-ae36-fc21decf46a2",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-21",
+    "contentid": "5ec714de8f08a1782fa7f516"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d8b08dd9-ab97-4299-b0bd-4a4621e26069",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-15",
+    "contentid": "5d2c50b58f0845f89e30d5aa"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6fef03be-90e4-4479-a966-6b06ac24f770",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-13",
+    "contentid": "5da333d98f088666e395dbb2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/main-media-hider/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-04",
+    "contentid": "5ed8a1be8f0893539f4cfcd5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/totals",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-04",
+    "contentid": "5ed8a1be8f0893539f4cfcd5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-04",
+    "contentid": "5ed8a1be8f0893539f4cfcd5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths-comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-04",
+    "contentid": "5ed8a1be8f0893539f4cfcd5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/asia",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-04",
+    "contentid": "5ed8a1be8f0893539f4cfcd5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/emea",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-04",
+    "contentid": "5ed8a1be8f0893539f4cfcd5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/02/interactive-coronavirus-trackers/maps",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-04",
+    "contentid": "5ed8a1be8f0893539f4cfcd5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/cases",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-04",
+    "contentid": "5ed8a1be8f0893539f4cfcd5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-04",
+    "contentid": "5ed8a1be8f0893539f4cfcd5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/recovered",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-04",
+    "contentid": "5ed8a1be8f0893539f4cfcd5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-10-02",
+    "contentid": "5f7734508f080b5d569e2f3b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8113512b-8ee0-49dc-80d3-0b56df87e441",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-24",
+    "contentid": "5e2ac5768f08e97ed21297ac"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2019/03/contact-box",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-06",
+    "contentid": "5f2b902d8f0871f06ad99a94"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/tableizer/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-15",
+    "contentid": "5f0e4a468f08e16b6a1e73df"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a81dbd86-f7c7-4b2d-affa-9a6aff9b9b5f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-15",
+    "contentid": "5f0e4a468f08e16b6a1e73df"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "74223bc6-4cac-4ae7-8c60-9ffa43535ad0",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-10",
+    "contentid": "5ee0faf98f087583352299dc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "34a7f30c-540e-4e31-90a4-485d8746bdf8",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-10",
+    "contentid": "5d25c6498f08d0b6ca52daea"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b514212d-3920-4777-b01a-e93365afcab0",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-17",
+    "contentid": "5f3b00ee8f08504022d43708"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "c006aa91-f45d-433d-83bc-bf423825e286",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-17",
+    "contentid": "5f3b00ee8f08504022d43708"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7539560e-eeca-4ea3-9731-9560ad5ae8bf",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-09-19",
+    "contentid": "5d8329c48f08f9df5bdd739d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6afdb1d6-5a0a-421f-9867-ab78b1262728",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-14",
+    "contentid": "5ebd6f5f8f08a55ecde5a12f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "c340f590-e142-40ae-b1e7-8b060b68dbdb",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-09-18",
+    "contentid": "5d825bc38f08f9df5bdd6e15"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a317d7c0-e94f-487b-899b-d1584cb73ded",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-24",
+    "contentid": "5e2ac4da8f08a6950eb48128"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7181c82d-f06e-481e-9368-c70de70396ce",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-24",
+    "contentid": "5e2ac4da8f08a6950eb48128"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0ef07a90-fe6f-465a-a2be-25f02d442252",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-11-24",
+    "contentid": "5fbd3e228f08850ef86c55fb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths-comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-18",
+    "contentid": "5f12fc378f0852a9868eb83c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "c9374a55-904f-40fa-b34f-162464ffb319",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-05",
+    "contentid": "5e60d5b78f087df56e4c2a31"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "dd0e5a58-ea5e-4e76-89be-5885aa2e665c",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-14",
+    "contentid": "5ee5fb048f08e3e3b74b61e3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-14",
+    "contentid": "5ee5fb048f08e3e3b74b61e3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d3a54aeb-ee50-47e0-bcff-d897927fa0fb",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-01",
+    "contentid": "5d19d5158f087f38aa1f2c4f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "3e62a1a5-8917-4090-84bb-3208da4be798",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-06",
+    "contentid": "5eb331a68f08597eeb1b756e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "add36158-d9d3-4161-9998-43c3635550cd",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-10",
+    "contentid": "5ee0d2748f08beee219d8cd7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/main-media-hider/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-03",
+    "contentid": "5efe80de8f087cbba7980d61"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/totals",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-03",
+    "contentid": "5efe80de8f087cbba7980d61"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-03",
+    "contentid": "5efe80de8f087cbba7980d61"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths-comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-03",
+    "contentid": "5efe80de8f087cbba7980d61"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/asia",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-03",
+    "contentid": "5efe80de8f087cbba7980d61"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/emea",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-03",
+    "contentid": "5efe80de8f087cbba7980d61"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/02/interactive-coronavirus-trackers/maps",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-03",
+    "contentid": "5efe80de8f087cbba7980d61"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/cases",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-03",
+    "contentid": "5efe80de8f087cbba7980d61"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-03",
+    "contentid": "5efe80de8f087cbba7980d61"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/recovered",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-03",
+    "contentid": "5efe80de8f087cbba7980d61"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0087a946-f47d-4e35-9230-08237ff747aa",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-04",
+    "contentid": "5e10a4e88f08bb9179e0345b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8d896982-b46d-4530-ade5-fdf7de440017",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-15",
+    "contentid": "5d55655e8f084f687f357115"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "84366fa6-3014-4c76-a415-2ea1a430119f",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-13",
+    "contentid": "5f354ff58f08899e2e66d9c1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/tableizer/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-22",
+    "contentid": "5f1792188f088024316aca45"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a81dbd86-f7c7-4b2d-affa-9a6aff9b9b5f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-22",
+    "contentid": "5f1792188f088024316aca45"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "65a9450f-4bec-4555-bdb0-c829a2782b42",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-24",
+    "contentid": "5e79d6b18f0887f6e2b5c7a3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6d4d70a7-6f8e-462d-afa9-45cc93956cb5",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-25",
+    "contentid": "5f6e320a8f088d8c714e93b8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/02/corona-carousel",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-29",
+    "contentid": "5e5a29e48f086a28115b4efd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "3a8b2f54-2808-4418-9626-36781aba8d18",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-16",
+    "contentid": "5f3954ee8f0804029130ffc1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "2feca939-5c6b-4cb2-b0b2-4824b0510a50",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-17",
+    "contentid": "5ee9f4588f08cb2c65082afc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "60c2a5c9-4e1b-4526-bc86-d03c812c7736",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-17",
+    "contentid": "5ee9f4588f08cb2c65082afc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "67bc25af-d30a-4465-a1d8-320ae27b3588",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-21",
+    "contentid": "5e26fbc38f0879d539efc33c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7f74639a-3ed5-40bd-821d-6a8c1ad5b47a",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-02",
+    "contentid": "5e0e0c868f085eda5c111035"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-28",
+    "contentid": "5e7f1c0f8f08af215f6fcfd9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/uk-map",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-28",
+    "contentid": "5e7f1c0f8f08af215f6fcfd9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/cumulative",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-28",
+    "contentid": "5e7f1c0f8f08af215f6fcfd9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/casesbyday",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-28",
+    "contentid": "5e7f1c0f8f08af215f6fcfd9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/auto-table",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-28",
+    "contentid": "5e7f1c0f8f08af215f6fcfd9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6871f4f4-377d-4da6-8670-05c508507d28",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-08",
+    "contentid": "5e15a7f38f08c39722646c2e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5a6e5813-e390-4550-bed4-350cdccf4e5d",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-10",
+    "contentid": "5d2623b78f08d0b6ca52e123"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/06/australian_momentum/default",
+        "role": "supporting",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-16",
+    "contentid": "5f0fc8368f0876acf5160487"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "45ebd9c5-bd4c-474d-841f-c6ce5565eafa",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-09",
+    "contentid": "5dee55158f08be0cbf46d008"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "91024276-e96e-48e2-ad1f-d6e9090cbf93",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-09",
+    "contentid": "5dee55158f08be0cbf46d008"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "f192372c-a5f0-4a69-8c0b-3444fa078b52",
+        "atomType": "cta"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-09",
+    "contentid": "5e174c908f085eda5c1150f2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/cumulative",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-21",
+    "contentid": "5e7690108f08dcc95cc20c65"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "02435c27-b2b6-4c12-8c68-e7408b381e9f",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-10",
+    "contentid": "5d262bb98f08b47e53e753a6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "62171215-4feb-4fca-b7a1-0127b489ea25",
+        "atomType": "profile"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-14",
+    "contentid": "5e9593128f08213494be6476"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6853ddc3-3652-416b-a4b9-e786797fb2ad",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-08",
+    "contentid": "5d2378658f08d0b6ca52c8d3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/09/propublica-ballot/default",
+        "role": "immersive",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-15",
+    "contentid": "5f6112fe8f08bc8778ef1304"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b2378cc1-8e9c-4558-992d-05fbf2532016",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-06-12",
+    "contentid": "5d010d2e8f08d5122c6885ff"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/emea",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-25",
+    "contentid": "5e7bb2698f0878a2a48aa354"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "3d81efdc-a0c9-40a2-9c02-6cb01022e157",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-01",
+    "contentid": "5e84e19f8f08532a0e66634f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b501292c-f96c-417a-8f40-1d534da48c15",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-01",
+    "contentid": "5e84e19f8f08532a0e66634f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-06",
+    "contentid": "5f552cb78f08c5bb9a75608d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "4db03301-5c76-45a0-bd0e-c95c37ed3a24",
+        "atomType": "chart"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-10-13",
+    "contentid": "5f8541898f08f7f7041486d1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "615938c9-d62c-4624-9c03-a31b92e5915e",
+        "atomType": "chart"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-10-13",
+    "contentid": "5f8541898f08f7f7041486d1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "70f90a1c-105d-4feb-8693-fbd9c996f86a",
+        "atomType": "chart"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-10-13",
+    "contentid": "5f8541898f08f7f7041486d1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "eb143d4a-349e-4341-bea5-3ba1eff459e0",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-26",
+    "contentid": "5f1d9f2c8f0823e23bc8b2a8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/new-cases-world-map/summary",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-07",
+    "contentid": "5f5643a58f0829a231fe7d5c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "134c6037-2f86-41ab-a672-1986189fb60e",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-10",
+    "contentid": "5ee0dfca8f087583352297f3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5d25beb5-14fb-47b4-bd06-0714dbfabc04",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-10",
+    "contentid": "5ee0dfca8f087583352297f3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "73ca869d-1df7-4b30-b106-44a867d11b83",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-20",
+    "contentid": "5e9d662c8f08bade1f296671"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "47d8d873-ffa4-4c96-83ff-157c9f6c45d4",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-09",
+    "contentid": "5edfc9a28f08beee219d8353"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d4d69bfd-15d9-4d96-b0bf-9aac84d963fc",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-09",
+    "contentid": "5edfc9a28f08beee219d8353"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "dbf851ff-8baf-4248-938b-9937b7867104",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-11-03",
+    "contentid": "5dbed4aa8f08cb84c60a3d85"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0de324fa-24f3-4a5b-807d-89bd89938b6d",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-12",
+    "contentid": "5ee3ff238f08cea6cb54a4c2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "f5adcd7d-a3df-40e4-9bd5-c7e05ad88658",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-12",
+    "contentid": "5ee3ff238f08cea6cb54a4c2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "bdb158db-0008-4cdb-812b-ed7ac70df663",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-21",
+    "contentid": "5f16849c8f088024316abe29"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e03fc3f7-7dbf-4761-bf52-d7464ab0e036",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-21",
+    "contentid": "5f16849c8f088024316abe29"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/emea",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-15",
+    "contentid": "5e6e49798f085e564ad8481d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/new-cases-world-map/summary",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-10-14",
+    "contentid": "5f86d9a48f08d5b102ab974a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/new-cases-world-map/summary",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-11",
+    "contentid": "5f32501e8f08da3d1603a248"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/new-cases-world-map/world-recent-cases",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-11",
+    "contentid": "5f32501e8f08da3d1603a248"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-11",
+    "contentid": "5f32501e8f08da3d1603a248"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths-comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-11",
+    "contentid": "5f32501e8f08da3d1603a248"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/new-cases-world-map/world-table",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-11",
+    "contentid": "5f32501e8f08da3d1603a248"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/tableizer/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-03",
+    "contentid": "5f2780ef8f08f42f5d72b390"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a81dbd86-f7c7-4b2d-affa-9a6aff9b9b5f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-03",
+    "contentid": "5f2780ef8f08f42f5d72b390"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "cac93cb9-b0df-4654-9b18-e1069169b9c8",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-28",
+    "contentid": "5e073bf78f08594a8c22667b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0d9c7a50-aad5-4ea7-9a90-41bc164e610d",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-09",
+    "contentid": "5f077af08f088ce85a338b6c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a91085f2-f15e-4b22-887a-c793bce01c95",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-18",
+    "contentid": "5eeb0b1d8f08cf3f35135fe0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e7642457-48c0-4a5e-84f2-13bb23e85ca1",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-11-07",
+    "contentid": "5dc3ee158f0867dcebfd04cd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a89ff619-5fe9-4915-818a-aabb40a0ca99",
+        "atomType": "chart"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-10-07",
+    "contentid": "5f7ddcde8f083f5c162c2865"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9c21a5cc-2a90-4c07-810d-05e8149a8c27",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-04",
+    "contentid": "5f5204848f08a919fc87580e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "2ecd9889-1bfb-4490-8f32-cfd1d269ef84",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-16",
+    "contentid": "5f39b8028f084b2f606729ea"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ac6d5631-79a8-41ad-ae75-42dddc804976",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-13",
+    "contentid": "5e452cb28f08e13324742834"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/06/protest-photo-essay",
+        "role": "immersive",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-17",
+    "contentid": "5ee992cc8f0850c4cdec5971"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "fe4b2ad2-f971-45bb-a9fa-11c258c1ea8a",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-15",
+    "contentid": "5e6ea5dc8f088d7575593e44"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/main-media-hider/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-30",
+    "contentid": "5eaa86d28f0882b206dcfcf5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/totals",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-30",
+    "contentid": "5eaa86d28f0882b206dcfcf5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-30",
+    "contentid": "5eaa86d28f0882b206dcfcf5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths-comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-30",
+    "contentid": "5eaa86d28f0882b206dcfcf5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/asia",
+        "role": "showcase",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-30",
+    "contentid": "5eaa86d28f0882b206dcfcf5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/asia",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-30",
+    "contentid": "5eaa86d28f0882b206dcfcf5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/02/interactive-coronavirus-trackers/maps",
+        "role": "showcase",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-30",
+    "contentid": "5eaa86d28f0882b206dcfcf5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/cases",
+        "role": "showcase",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-30",
+    "contentid": "5eaa86d28f0882b206dcfcf5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/cases",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-30",
+    "contentid": "5eaa86d28f0882b206dcfcf5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-30",
+    "contentid": "5eaa86d28f0882b206dcfcf5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/recovered",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-30",
+    "contentid": "5eaa86d28f0882b206dcfcf5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-09",
+    "contentid": "5e8f21ea8f085d226cfd5f3e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/london-map",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-05",
+    "contentid": "5e89a4138f08e85a74724de8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "403e0ec9-e744-4b7d-bad5-10533d2f2832",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-14",
+    "contentid": "5ee5cb378f08e3e3b74b60bc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "403e0ec9-e744-4b7d-bad5-10533d2f2832",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-14",
+    "contentid": "5ee5cb378f08e3e3b74b60bc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "45a64e26-7e67-407d-ae9b-8e68daf6b518",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-14",
+    "contentid": "5ee5cb378f08e3e3b74b60bc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "c34f79ea-ddfe-4938-9868-ae2980699111",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-14",
+    "contentid": "5ee5cb378f08e3e3b74b60bc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "c34f79ea-ddfe-4938-9868-ae2980699111",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-14",
+    "contentid": "5ee5cb378f08e3e3b74b60bc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0d848baa-0849-492d-b02d-474406f2e3e3",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-14",
+    "contentid": "5ee5cb378f08e3e3b74b60bc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1e6fc3b3-1a4f-4fbb-af49-53e6e0ba1df8",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-13",
+    "contentid": "5da307308f088fe41647d9a0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "2140ccd5-1401-49e0-a61a-2df30204d33e",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-27",
+    "contentid": "5ece52d78f08498203f3ce1e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "770decd4-9257-4050-a836-d3708e070870",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-30",
+    "contentid": "5eaa1c248f0882b206dcfabc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "fc246208-90f7-4fc3-b46e-2c91922529f2",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-21",
+    "contentid": "5f16da7e8f08f2d75cbbe6a2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0ae5db58-51ae-43c2-8582-80cfd40a95ee",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-12-02",
+    "contentid": "5fc8158b8f08c1b9f1358e28"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/main-media-hider/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-08",
+    "contentid": "5edde7758f083999a26dbff0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/totals",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-08",
+    "contentid": "5edde7758f083999a26dbff0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-08",
+    "contentid": "5edde7758f083999a26dbff0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths-comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-08",
+    "contentid": "5edde7758f083999a26dbff0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/asia",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-08",
+    "contentid": "5edde7758f083999a26dbff0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/emea",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-08",
+    "contentid": "5edde7758f083999a26dbff0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/02/interactive-coronavirus-trackers/maps",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-08",
+    "contentid": "5edde7758f083999a26dbff0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/cases",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-08",
+    "contentid": "5edde7758f083999a26dbff0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-08",
+    "contentid": "5edde7758f083999a26dbff0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/recovered",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-08",
+    "contentid": "5edde7758f083999a26dbff0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "aecdb7cc-a3b0-4788-8371-0a7019b27bba",
+        "atomType": "cta"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-06",
+    "contentid": "5e8ae20d8f08c9eaf0daf2d0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-26",
+    "contentid": "5e7c69988f08af215f6fb7ef"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/uk-map",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-26",
+    "contentid": "5e7c69988f08af215f6fb7ef"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/cumulative",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-26",
+    "contentid": "5e7c69988f08af215f6fb7ef"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/casesbyday",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-26",
+    "contentid": "5e7c69988f08af215f6fb7ef"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/auto-table",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-26",
+    "contentid": "5e7c69988f08af215f6fb7ef"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b9ab3214-e0be-407e-9e45-2c7d5e2a4f26",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-18",
+    "contentid": "5e727c7e8f085c6327bc2901"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "dabfe7fe-9f83-481d-9ef0-018be9d47cef",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-17",
+    "contentid": "5d2f58098f08cf92bb771cc2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "68bc874c-c080-4efb-98c1-cd42665645cc",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-17",
+    "contentid": "5d2f58098f08cf92bb771cc2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5c67cd99-9df0-4fa5-a51a-cc065d5dd0e7",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-16",
+    "contentid": "5f61d2658f0813c76598542c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "516c0063-aa4d-4d22-a12f-b89905d3ba23",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-05-31",
+    "contentid": "5cf149428f08e31adbc8e9f4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7bb26bfc-05df-4557-a9be-5e1c95185a79",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-04",
+    "contentid": "5eaffe638f0884a76e10cad4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-04",
+    "contentid": "5eaffe638f0884a76e10cad4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "47c454ec-1f5b-4abb-ac70-f5d70d5e8e28",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-22",
+    "contentid": "5e2815a78f08e97ed2127f87"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "47c454ec-1f5b-4abb-ac70-f5d70d5e8e28",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-22",
+    "contentid": "5e2815a78f08e97ed2127f87"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6a1e7ff8-2611-4d20-ac03-5dcfc95e4caf",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-22",
+    "contentid": "5e2815a78f08e97ed2127f87"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7a6078f6-5a66-4d3e-9339-5610fe320767",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-26",
+    "contentid": "5e569de68f08e1332474aa5a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "f46052a9-acaa-4473-b8a4-65831a96a890",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-26",
+    "contentid": "5e569de68f08e1332474aa5a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/lost-of-the-frontline-4/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-20",
+    "contentid": "5f15a11d8f08a89a8afee7fd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "da6e7b30-c83b-43bf-8d5e-772e3e686b5a",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-09",
+    "contentid": "5e8ecaf68f085d226cfd5b0a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "04fcb605-dc6b-400f-9a32-dea28497dcee",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-09",
+    "contentid": "5e8ecaf68f085d226cfd5b0a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7a6078f6-5a66-4d3e-9339-5610fe320767",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-04",
+    "contentid": "5e5f94c18f087df56e4c1e99"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/01/interactive-coronavirus-tracker",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-04",
+    "contentid": "5e5f94c18f087df56e4c1e99"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b9f28b86-7354-4754-9feb-fa1f2cde233a",
+        "atomType": "profile"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-04",
+    "contentid": "5e5f94c18f087df56e4c1e99"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7540827f-8d02-4b46-ae70-ad770c434265",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-08",
+    "contentid": "5eddf6c78f0883ec2fc1cca4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "3410449e-4b95-4a00-9ee7-a21039851d03",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-30",
+    "contentid": "5f2302f08f08f42f5d72a4b0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9ee37c80-8b48-4f54-b95b-753fa4de7acb",
+        "atomType": "explainer"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-06-04",
+    "contentid": "5cf6c5a48f08d22e907f0540"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "48718617-39ff-43f6-86a7-0f462acf4b95",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-05-30",
+    "contentid": "5cefddf38f08d4e6b70daf24"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b8b050f2-7484-487c-adc9-b48903770d86",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-18",
+    "contentid": "5e9a6fc58f080ee1104472b0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b547ab04-9a4f-4f6c-8c17-c8f14a632205",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-18",
+    "contentid": "5e9a6fc58f080ee1104472b0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ed15e784-ed78-4adb-9aff-7a6193907fa5",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-17",
+    "contentid": "5f11b0d58f08c52937e2e8ac"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-17",
+    "contentid": "5f11b0d58f08c52937e2e8ac"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0a09a661-0ee2-41ea-b0a0-9e1deefd9268",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-01",
+    "contentid": "5e845c158f0866297e9f4d32"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0a09a661-0ee2-41ea-b0a0-9e1deefd9268",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-24",
+    "contentid": "5e2ac0b68f08e97ed212978c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "621d2741-83fa-48aa-923b-d1e9cc8d15d3",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-10-05",
+    "contentid": "5f7af1858f0883329fc6fec0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "fc246208-90f7-4fc3-b46e-2c91922529f2",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-23",
+    "contentid": "5ec8f4888f0886ce4f5d9032"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5bed5cb0-b526-4fc7-a2ff-39998ebcf56c",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-23",
+    "contentid": "5ec8f4888f0886ce4f5d9032"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/02/corona-carousel",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-07",
+    "contentid": "5e637bdc8f085f0b8d943e34"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e3bd96d4-d590-49fb-b906-b08b174170dd",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-07",
+    "contentid": "5e637bdc8f085f0b8d943e34"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "71e542df-022c-4806-92a3-089811c29cb7",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-05-30",
+    "contentid": "5cf006c88f0860df1a021a60"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-08",
+    "contentid": "5edde9698f08bd75dbb63e27"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/choropleth-regions",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-08",
+    "contentid": "5edde9698f08bd75dbb63e27"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/05/covid-19-big-map/choropleth",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-08",
+    "contentid": "5edde9698f08bd75dbb63e27"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/auto-table",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-08",
+    "contentid": "5edde9698f08bd75dbb63e27"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "23698b44-e77d-4d2c-8305-6abd748046af",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-03",
+    "contentid": "5e37a7df8f086a28115a4639"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-03",
+    "contentid": "5ed786d08f084df971c8edc8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-12-17",
+    "contentid": "5fdba7958f08c97e60387d07"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/08/uk-coronavirus-dashboard-v2/choropleth-combined",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-12-17",
+    "contentid": "5fdba7958f08c97e60387d07"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "67789f5e-88e3-4e18-9be3-992837b3fce5",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-08",
+    "contentid": "5e8dfa308f08ec70ceced0a4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e59a9f6f-4cec-4af6-bcc4-d9016ab785b0",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-20",
+    "contentid": "5dac5f1f8f08eb8f0239af16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6fef03be-90e4-4479-a966-6b06ac24f770",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-20",
+    "contentid": "5dac5f1f8f08eb8f0239af16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ba9786c6-c779-4063-8bf9-1d3009eb7c70",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-19",
+    "contentid": "5e9bff7d8f08bade1f295e93"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "04fcb605-dc6b-400f-9a32-dea28497dcee",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-19",
+    "contentid": "5e9bff7d8f08bade1f295e93"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "28f9c4c8-d8b6-4f17-bdd6-1264330215a7",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-24",
+    "contentid": "5ea28a7e8f08eb2f433f5973"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/aus-vic-corona-map-new4",
+        "role": "immersive",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-20",
+    "contentid": "5f3efec08f0863d6ba03adfd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8d657e44-4de7-4987-9844-ed824a0aa3e6",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-07",
+    "contentid": "5e3d9f548f0811db2faf37a1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "166615a1-ed30-43e9-9201-083a41ce7713",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-19",
+    "contentid": "5d31ed788f08cf92bb7733bb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "05256f0a-7454-4e45-93b6-b0d905690a3f",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-30",
+    "contentid": "5d6929708f082209d32247a8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a1d2d12c-ae47-4fc3-9ff1-8a9633f2f40c",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-30",
+    "contentid": "5d6929708f082209d32247a8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a9703002-f276-4990-b372-2d71a276ddbd",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-20",
+    "contentid": "5f160e3b8f08b5ab6db75454"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "25a35263-59a7-4eb5-8ade-a36ef2175cb7",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-10-12",
+    "contentid": "5f84ce288f08f7f704148296"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9a19fac5-8dff-4125-9ba7-ba08f2c09fa7",
+        "atomType": "profile"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-25",
+    "contentid": "5e5545cc8f080eac90246382"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7ca82963-173a-4ab6-9487-c8e83bda1b27",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-22",
+    "contentid": "5ec7e3ad8f08a1782fa7fbfb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8b75e85e-6cb5-45d6-af2d-607693fa3b84",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-19",
+    "contentid": "5f3d63e68f089b3b72ad006d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "65a9450f-4bec-4555-bdb0-c829a2782b42",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-26",
+    "contentid": "5e7c647e8f08af215f6fb7d3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/totals",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-26",
+    "contentid": "5e7c647e8f08af215f6fb7d3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "bc562a86-4914-4dfc-bd0c-7ab60c7a26e1",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-11",
+    "contentid": "5d275cfa8f08d0b6ca52ebdb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "c3dc92f8-9b66-4c99-b0b2-64553a6a54e6",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-22",
+    "contentid": "5d5e7c748f08a0805bcc27ac"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ea9df1c1-9bda-4db9-a7a4-b990c646843e",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-17",
+    "contentid": "5ee9efa38f08cb2c65082ab1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6fef03be-90e4-4479-a966-6b06ac24f770",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-13",
+    "contentid": "5da2fd028f080de1653934ee"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "c177eacc-2d18-4d56-b9f9-de9bb5cc0079",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-15",
+    "contentid": "5ee7117d8f08e3e3b74b6a1b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ee3ef30c-f17d-4f81-9d78-dd8049869abd",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-20",
+    "contentid": "5dac26258f0859498cfb1b7f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "f4e4403f-895e-4545-957a-6e7b7679c365",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-20",
+    "contentid": "5dac26258f0859498cfb1b7f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a26483c0-c71e-4829-bf70-ed937c14f6d4",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-05",
+    "contentid": "5e11a0e68f085eda5c112615"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/06/100-coronavirus-deaths/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-04",
+    "contentid": "5ed92d108f08b1e5da86a0fd"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7dfe33c1-31fd-4105-88a5-502574b2ba4d",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-09",
+    "contentid": "5e6589c88f08c2df6d275ba0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/lost-of-the-frontline/default",
+        "role": "immersive",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-05",
+    "contentid": "5f29ff608f089d9b758a6dba"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "783d38d7-bf50-42bc-ae36-fc21decf46a2",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-22",
+    "contentid": "5e9fd7608f087a826b68adc6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8fc794f6-6c22-4e95-a3ae-649a767888fb",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-22",
+    "contentid": "5daf04258f0859498cfb261d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "3c387973-310d-4b96-876e-3b883c4ed1d1",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-14",
+    "contentid": "5ebd7fa78f08a55ecde5a22f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "f9070bec-de80-47bd-be89-f02ef5cabf90",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-17",
+    "contentid": "5f11900f8f0833bc06f3355e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/main-media-hider/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-18",
+    "contentid": "5ec2367c8f0864e579f12db6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/totals",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-18",
+    "contentid": "5ec2367c8f0864e579f12db6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-18",
+    "contentid": "5ec2367c8f0864e579f12db6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths-comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-18",
+    "contentid": "5ec2367c8f0864e579f12db6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/asia",
+        "role": "showcase",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-18",
+    "contentid": "5ec2367c8f0864e579f12db6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/emea",
+        "role": "showcase",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-18",
+    "contentid": "5ec2367c8f0864e579f12db6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/02/interactive-coronavirus-trackers/maps",
+        "role": "showcase",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-18",
+    "contentid": "5ec2367c8f0864e579f12db6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/cases",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-18",
+    "contentid": "5ec2367c8f0864e579f12db6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-18",
+    "contentid": "5ec2367c8f0864e579f12db6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/recovered",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-18",
+    "contentid": "5ec2367c8f0864e579f12db6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "825b1954-f343-46fe-99cb-2c989e4fae60",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-05",
+    "contentid": "5de8f3ed8f08bacaf000a970"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2019/08/trump-database",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-15",
+    "contentid": "5d558aeb8f08c7e177d4b286"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b97735d8-9e5a-4e92-b8ce-33e04d5c29f7",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-25",
+    "contentid": "5e2c40138f08bae83e51df05"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9664deac-57f3-4937-ade3-3156cc70e187",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-25",
+    "contentid": "5e2c2a6a8f0879d539efee94"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-28",
+    "contentid": "5ed020e08f0898700351e2da"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d3b7f24b-2281-4563-8116-8fbdcc6b24da",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-08",
+    "contentid": "5f57771a8f08c22252dfe0bb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "3c387973-310d-4b96-876e-3b883c4ed1d1",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-14",
+    "contentid": "5ebdc6f48f08d99d46a172d7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0e9d21fc-1faa-4993-958e-f60ce5110447",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-23",
+    "contentid": "5d36eb448f0845f89e31297d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a81dbd86-f7c7-4b2d-affa-9a6aff9b9b5f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-04",
+    "contentid": "5e87ec3c8f080bdb9f533fee"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/main-media-hider/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-18",
+    "contentid": "5ec238bb8f0886ce4f5d57e5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-18",
+    "contentid": "5ec238bb8f0886ce4f5d57e5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/choropleth",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-18",
+    "contentid": "5ec238bb8f0886ce4f5d57e5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/auto-table",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-18",
+    "contentid": "5ec238bb8f0886ce4f5d57e5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "f55d9703-4864-4aaf-bc7a-ead19cbb44f8",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-25",
+    "contentid": "5f44ace28f08c26134253788"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9b6c3f85-d42b-454b-83be-5921e37c7916",
+        "atomType": "cta"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-09",
+    "contentid": "5e66665e8f085f0b8d94504f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8a39b463-7320-4628-818e-45b446ca2bcc",
+        "atomType": "profile"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-17",
+    "contentid": "5f3a6bad8f08b5d07520d3aa"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/cumulative",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-02",
+    "contentid": "5e85d9698f0866297e9f5a6f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7a6078f6-5a66-4d3e-9339-5610fe320767",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-20",
+    "contentid": "5e4e5ca68f0811db2fafb0c0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "752145f8-c219-4e7f-b659-c3ce9574a22f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-11",
+    "contentid": "5f3265ba8f0803fbf94051f5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "c2b8a51c-cb3d-41e7-bb79-1d9a091d0c28",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-17",
+    "contentid": "5e219f308f088d80a182c9e2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ba9786c6-c779-4063-8bf9-1d3009eb7c70",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-10",
+    "contentid": "5e9034e08f082dfd549d3fb2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a81dbd86-f7c7-4b2d-affa-9a6aff9b9b5f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-10",
+    "contentid": "5e9034e08f082dfd549d3fb2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "f858fc12-df2f-4627-ae21-65c00ba6ce6c",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-10",
+    "contentid": "5e9034e08f082dfd549d3fb2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "82beeb58-e861-4575-90dd-2b879d1a3a65",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-20",
+    "contentid": "5ec4dcc68f08a1782fa7dfd6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7a8aefc4-c87c-430c-81cd-7b8b5fa27431",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-20",
+    "contentid": "5ec4dcc68f08a1782fa7dfd6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "69b35e1e-d1ca-429d-a121-ffdb5a545f09",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-06-12",
+    "contentid": "5d0112998f08b4ffd6496832"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/new-cases-world-map/summary",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-11-27",
+    "contentid": "5fc0cbc38f0872410b2a010f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "fa264caa-e502-46c2-baf5-44a38521dddd",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-11-27",
+    "contentid": "5fc0cbc38f0872410b2a010f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b5102fa2-edeb-425c-bda4-a0eb6c7a03b1",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-13",
+    "contentid": "5f0c6d0c8f08a2bb7d3db853"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "bde155c3-43e7-4929-8506-bb043a798a88",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-28",
+    "contentid": "5e7f1ed38f081e5eda238784"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "310af49f-8f14-490b-bb69-d20037e56c3c",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-05-30",
+    "contentid": "5cf014e68f0860df1a021a76"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "74223bc6-4cac-4ae7-8c60-9ffa43535ad0",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-20",
+    "contentid": "5f1534508f08c52937e304f8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "fad45d97-9b7c-4bfa-9fe2-a2668e846bd8",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-20",
+    "contentid": "5eedd3178f08cb2c65085683"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "429927ae-d5f6-4294-9345-b635df4091ac",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-11",
+    "contentid": "5f09bec28f088ce85a339f25"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "c9830685-7f1a-4273-bc45-f7dd1b1064d7",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-11",
+    "contentid": "5f09bec28f088ce85a339f25"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "09b34ac1-9fee-43b6-90b6-acac0d1a02ad",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-11",
+    "contentid": "5f09bec28f088ce85a339f25"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "35951c84-156b-4f58-8a36-ce3ef1bf434d",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-11",
+    "contentid": "5f09bec28f088ce85a339f25"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0a09a661-0ee2-41ea-b0a0-9e1deefd9268",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-28",
+    "contentid": "5e58bbd48f0811db2fb00392"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/tableizer/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-29",
+    "contentid": "5f2113df8f087e20ee605f8f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/aus-nsw-corona-map-new",
+        "role": "immersive",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-20",
+    "contentid": "5f3f00368f089b3b72ad11a7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "64a9a8c1-3d6b-4425-8051-6858e21bd6ea",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-06-21",
+    "contentid": "5d0ce65d8f081e872734c250"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-09",
+    "contentid": "5edf373f8f0883ec2fc1d994"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/choropleth-regions",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-09",
+    "contentid": "5edf373f8f0883ec2fc1d994"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/05/covid-19-big-map/choropleth",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-09",
+    "contentid": "5edf373f8f0883ec2fc1d994"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/auto-table",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-09",
+    "contentid": "5edf373f8f0883ec2fc1d994"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "877b9c6d-7c9c-4a97-827a-1b9af0c16314",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-29",
+    "contentid": "5ed109388f087122eca51da6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ed0c7506-4995-4b10-996c-3b63ae953ac7",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-10",
+    "contentid": "5e4174668f080eac90244ede"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "69c5f22c-bd29-4749-ac5c-f300d05b948c",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-30",
+    "contentid": "5e0988a08f085eda5c10f708"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a3c33c37-5ead-48bd-bfa3-2648f2a7ebfa",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-23",
+    "contentid": "5f1a09118f08f2d75cbc0a0c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "31c54d99-1786-47e4-acd6-0e8d45f14d2a",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-08",
+    "contentid": "5f5814b68f087ba78e10bd29"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/coronavirus-australia-summary",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-15",
+    "contentid": "5ee6fdee8f08bc1dd58e2b5b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/tableizer/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-15",
+    "contentid": "5ee6fdee8f08bc1dd58e2b5b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2018/03/interactive-enhancer-master-aus",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-15",
+    "contentid": "5ee6fdee8f08bc1dd58e2b5b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "783d38d7-bf50-42bc-ae36-fc21decf46a2",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-05",
+    "contentid": "5eb0bd478f0809d50dbe67b4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9ec1715b-913f-435d-90f5-4810e05569de",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-15",
+    "contentid": "5ee74ab48f08bc1dd58e2e3b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/tableizer/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-29",
+    "contentid": "5f210eca8f087e20ee605f62"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a81dbd86-f7c7-4b2d-affa-9a6aff9b9b5f",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-29",
+    "contentid": "5f210eca8f087e20ee605f62"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "51d1869b-840b-437c-b2a9-c547fe0a96dc",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-26",
+    "contentid": "5ea5cbb68f08fa2bdcb1bc61"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "f49584aa-3397-4e23-a908-7feee9cb0b42",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-09",
+    "contentid": "5e6639b78f087df56e4c4f8e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "634b5ed6-bc05-4cf6-9564-3cf587cdcfc3",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-19",
+    "contentid": "5f14c7278f0852a9868ec673"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-01",
+    "contentid": "5eac34068f082b32fdd6b8ab"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "fbb96cc0-be99-47f0-8544-bb0a39f4fbe1",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-01",
+    "contentid": "5eac34068f082b32fdd6b8ab"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b8f8ab49-e521-4ab8-9834-de08bd0e34d0",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-12",
+    "contentid": "5e43ca358f08e13324741c1f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7beb8c78-c0d4-4de7-96e2-ab7860116d4e",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-12",
+    "contentid": "5e43ca358f08e13324741c1f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "af9b883b-7975-49d0-8218-735126850c78",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-12",
+    "contentid": "5e43ca358f08e13324741c1f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9b6c3f85-d42b-454b-83be-5921e37c7916",
+        "atomType": "cta"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-12",
+    "contentid": "5e43ca358f08e13324741c1f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "39a7bf25-5d7e-46a7-9fb4-8347f8787212",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-10-28",
+    "contentid": "5f9984ed8f0866fbe9e44881"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "28f9c4c8-d8b6-4f17-bdd6-1264330215a7",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-13",
+    "contentid": "5ebc5a298f08d99d46a1671e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-13",
+    "contentid": "5ebc5a298f08d99d46a1671e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2019/07/interactive-co2-widget",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-31",
+    "contentid": "5e0b49828f08bb9179e02ef4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2021-03-17",
+    "contentid": "605209948f0832395ae58404"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5a1ffa3f-6978-4219-b120-57b87ad96a02",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-11",
+    "contentid": "5ee20be28f08ae5a19260dec"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "783d38d7-bf50-42bc-ae36-fc21decf46a2",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-01",
+    "contentid": "5eabe1ce8f08f76ffc19f4e3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5cbcbde4-7d9d-483d-8e45-a338b368aeef",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-02",
+    "contentid": "5e85f2f28f087564da1e47c8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a5ab45a9-41e2-4c7d-a64f-3a9f6140d4c2",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-10-28",
+    "contentid": "5f998fef8f0866fbe9e44928"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-31",
+    "contentid": "5ed373178f084df971c8ce25"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0d9c7a50-aad5-4ea7-9a90-41bc164e610d",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-12",
+    "contentid": "5f0af6418f086d25e4630272"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "187f4c35-1ed0-4149-8696-fb8abd390178",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-29",
+    "contentid": "5e31a3dc8f086a28115a1ac7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0637767b-8c6b-4fc7-85f6-e79e03e750d7",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-06",
+    "contentid": "5f2c55eb8f08da3d16036de0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-19",
+    "contentid": "5e9c04178f08bade1f295eaa"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/uk-map",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-19",
+    "contentid": "5e9c04178f08bade1f295eaa"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/auto-table",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-19",
+    "contentid": "5e9c04178f08bade1f295eaa"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d0156f03-f50e-47be-b6b9-8db221f43de5",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-24",
+    "contentid": "5d3893918f0845f89e313a92"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "c2253fd8-4042-4931-a778-1e5df3ffe61d",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-29",
+    "contentid": "5ed1882f8f087122eca52330"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7a8aefc4-c87c-430c-81cd-7b8b5fa27431",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-08",
+    "contentid": "5eb5cf9a8f0858b1a8106c84"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e299a7f3-c36b-4565-aeb3-0f89c8c5cbf5",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-07",
+    "contentid": "5e8bfbb18f08c35a1d11b501"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e85d9417-f04a-4c11-b3b8-61c89754e1f9",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-19",
+    "contentid": "5e72b8318f085e564ad86c85"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "3aa97539-d81b-40f2-9859-40b7d96d4aeb",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-24",
+    "contentid": "5e53cba58f08e133247491b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2019/03/contact-box",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-02",
+    "contentid": "5ed61a2e8f087122eca53e6f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/interactive-vaccine-tracker/default",
+        "role": "showcase",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-21",
+    "contentid": "5f16ab728f088024316abf22"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/interactive-vaccine-tracker/updates",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-21",
+    "contentid": "5f16ab728f088024316abf22"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/interactive-vaccine-tracker/description",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-21",
+    "contentid": "5f16ab728f088024316abf22"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/interactive-vaccine-tracker/table",
+        "role": "showcase",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-21",
+    "contentid": "5f16ab728f088024316abf22"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "15523fda-040b-4f14-94de-0203d9e69774",
+        "atomType": "profile"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-04",
+    "contentid": "5f5209ee8f08c5bb9a754433"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8d896982-b46d-4530-ade5-fdf7de440017",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-04",
+    "contentid": "5f5209ee8f08c5bb9a754433"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "30dbd695-69dc-431e-8426-c53b535d1a5e",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-25",
+    "contentid": "5e7b337a8f08af215f6fad26"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6fef03be-90e4-4479-a966-6b06ac24f770",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-09-19",
+    "contentid": "5d83d8e78f0823dd241ff714"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8113512b-8ee0-49dc-80d3-0b56df87e441",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-15",
+    "contentid": "5d551b3c8f084f687f356d98"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/main-media-hider/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-27",
+    "contentid": "5ece132d8f087412dad112f4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/totals",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-27",
+    "contentid": "5ece132d8f087412dad112f4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-27",
+    "contentid": "5ece132d8f087412dad112f4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths-comparison",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-27",
+    "contentid": "5ece132d8f087412dad112f4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/asia",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-27",
+    "contentid": "5ece132d8f087412dad112f4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/emea",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-27",
+    "contentid": "5ece132d8f087412dad112f4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/02/interactive-coronavirus-trackers/maps",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-27",
+    "contentid": "5ece132d8f087412dad112f4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/cases",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-27",
+    "contentid": "5ece132d8f087412dad112f4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/deaths",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-27",
+    "contentid": "5ece132d8f087412dad112f4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/interactive-coronavirus-live/recovered",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-27",
+    "contentid": "5ece132d8f087412dad112f4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b768d0a9-0396-458b-be59-8c1f042adefe",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-14",
+    "contentid": "5ebcf1208f08d99d46a16a13"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "28f9c4c8-d8b6-4f17-bdd6-1264330215a7",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-14",
+    "contentid": "5ebcf1208f08d99d46a16a13"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5d25beb5-14fb-47b4-bd06-0714dbfabc04",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-14",
+    "contentid": "5ebcf1208f08d99d46a16a13"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "783d38d7-bf50-42bc-ae36-fc21decf46a2",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-28",
+    "contentid": "5ea790b38f0869484d9442cf"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b46a7043-44ea-4fe3-a994-395319b5c515",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-23",
+    "contentid": "5d5fb6788f08a0805bcc315e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "cfd4c869-990c-4eea-916f-9299e07842f6",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-24",
+    "contentid": "5d3886ae8f08b52aabec8bc5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "748e03b0-c6f6-409f-b876-99ea6484beb0",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-17",
+    "contentid": "5e996e948f08ea7431f4486e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "b7aa1e12-fafb-42c5-8428-ad74431c2b8c",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-06-14",
+    "contentid": "5d03bd4e8f08532f138d1b9a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7a6078f6-5a66-4d3e-9339-5610fe320767",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-15",
+    "contentid": "5e6df9338f085e564ad84660"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "04fecb04-934a-4af1-baee-358948ad8ba5",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-15",
+    "contentid": "5e6e1b1e8f0831a9c46f27b5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "605a2b89-d56c-4f38-b329-705d2f498091",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-01",
+    "contentid": "5e5bc1668f08e1332474d10a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "44fe55b8-ff26-43e1-b96f-1d745c565e01",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-01",
+    "contentid": "5e5bc1668f08e1332474d10a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7a6078f6-5a66-4d3e-9339-5610fe320767",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-26",
+    "contentid": "5e5696a08f08e1332474a9de"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "76ef9a11-a5c0-4804-86f0-c335e2dd8d4b",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-11-27",
+    "contentid": "5ddeb3a38f08dcf251b4a37d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "cdc75a09-b01e-44c2-b873-a004d8d89056",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-16",
+    "contentid": "5f6247548f0867352829ce69"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0e358578-7072-4cc4-b8e8-9bae22cceff0",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-17",
+    "contentid": "5f6350748f08d66f78b8031f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "783d38d7-bf50-42bc-ae36-fc21decf46a2",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-17",
+    "contentid": "5ee9b2708f08d35d3d64225a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/08/uk-coronavirus-dashboard-v2/line-chart-local",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-09-15",
+    "contentid": "5f61013c8f0891dfedfaa04c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9322d7c1-a13a-4678-bbbf-c554a93226a9",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-13",
+    "contentid": "5e94e5f68f081a236f192bdc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "6df3104e-7f88-4cac-957c-780c438a0e3d",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-13",
+    "contentid": "5e94e5f68f081a236f192bdc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "965a3c64-7ed3-4ec5-84d3-2e9d7530ffad",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-13",
+    "contentid": "5e94e5f68f081a236f192bdc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0db2b763-1e71-44e6-91fc-ab8d6d4befb8",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-13",
+    "contentid": "5e94e5f68f081a236f192bdc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "0c53946d-0bd1-49df-a354-b0de1635bb27",
+        "atomType": "cta"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-05-24",
+    "contentid": "5ce814a58f08cb6183375764"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7bb26bfc-05df-4557-a9be-5e1c95185a79",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-26",
+    "contentid": "5eccdf858f0864e579f17c3c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "f750d2ba-beda-413e-9d75-4f34351248bb",
+        "atomType": "timeline"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-24",
+    "contentid": "5d385e638f0845f89e31373c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "bdca7714-ef97-4924-9e80-55d42853ff98",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-13",
+    "contentid": "5f0c4a008f0824a2adb0664f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "50baa290-7c2f-4e3d-af0e-76d0e8d4e9a9",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-06",
+    "contentid": "5e8a72888f08bad2b313031b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e299a7f3-c36b-4565-aeb3-0f89c8c5cbf5",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-06",
+    "contentid": "5e8a72888f08bad2b313031b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e299a7f3-c36b-4565-aeb3-0f89c8c5cbf5",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-06",
+    "contentid": "5e8a72888f08bad2b313031b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "4af8be86-dc1b-4666-af23-c1070dcf9511",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-12",
+    "contentid": "5f3466b78f086badb556176f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7c4830bb-7c30-49a3-9757-d64b9e12cf2d",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-08-22",
+    "contentid": "5d5e78378f081cf11cf1afde"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ab50f18e-214d-4c28-969c-41bf768a5d12",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-15",
+    "contentid": "5e6e13a78f085e564ad846c9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "226904a1-a01f-4cb7-93a7-1e5a99448ba8",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-12-15",
+    "contentid": "5df6750a8f08c3972263acba"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "f55d9703-4864-4aaf-bc7a-ead19cbb44f8",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-24",
+    "contentid": "5f43628e8f08f9fdc758c956"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a1347ced-6bc5-4c6f-81f5-71c59b0e47b2",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-23",
+    "contentid": "5e299c908f08fda07d73c34b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-10",
+    "contentid": "5eb7b0f48f08c0a2409baf0f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "fd97b9db-562f-40a6-8269-728192dd5c2e",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-17",
+    "contentid": "5ee9f51a8f08cb2c65082b03"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/02/corona-carousel",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-06",
+    "contentid": "5e6218d28f085f0b8d943414"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "e3bd96d4-d590-49fb-b906-b08b174170dd",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-06",
+    "contentid": "5e6218d28f085f0b8d943414"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7061068d-e498-47f2-a60e-80f929232cca",
+        "atomType": "profile"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-07-10",
+    "contentid": "5d25d4518f0845f89e30a44e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9a19fac5-8dff-4125-9ba7-ba08f2c09fa7",
+        "atomType": "profile"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-06-04",
+    "contentid": "5cf676308f08e31adbc8efba"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/interactive-vaccine-tracker/default",
+        "role": "showcase",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-02",
+    "contentid": "5f2668e98f08bb338d709c27"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/interactive-vaccine-tracker/updates",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-02",
+    "contentid": "5f2668e98f08bb338d709c27"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/interactive-vaccine-tracker/description",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-02",
+    "contentid": "5f2668e98f08bb338d709c27"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/07/interactive-vaccine-tracker/table",
+        "role": "showcase",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-02",
+    "contentid": "5f2668e98f08bb338d709c27"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "fd97b9db-562f-40a6-8269-728192dd5c2e",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-14",
+    "contentid": "5f0d85668f08a59604b63429"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-28",
+    "contentid": "5ecfc7158f087e3ca0f651b0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "da6e7b30-c83b-43bf-8d5e-772e3e686b5a",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-28",
+    "contentid": "5ecfc7158f087e3ca0f651b0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a7d2a9fb-acf9-447b-8e4f-ad6e7afbfc15",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-04",
+    "contentid": "5f29497f8f0871f06ad9825c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-27",
+    "contentid": "5ea6dd798f08e0a8b0de0db7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "134c6037-2f86-41ab-a672-1986189fb60e",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-27",
+    "contentid": "5ea6dd798f08e0a8b0de0db7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/02/corona-carousel",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-08",
+    "contentid": "5e64ce528f085f0b8d944562"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "62abcb96-fbcc-45a2-92ca-a7816dfda67c",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-17",
+    "contentid": "5e215d7f8f08ac96b21186a7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/tableizer/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-04",
+    "contentid": "5f29d89b8f08ab0eb3400476"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-03",
+    "contentid": "5ed791928f08f5e373013bc2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/main-media-hider/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-13",
+    "contentid": "5ebba29a8f08d99d46a15e44"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-13",
+    "contentid": "5ebba29a8f08d99d46a15e44"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/choropleth",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-13",
+    "contentid": "5ebba29a8f08d99d46a15e44"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/auto-table",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-13",
+    "contentid": "5ebba29a8f08d99d46a15e44"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ab0d2a46-53aa-4a66-9221-f80241688979",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-10-06",
+    "contentid": "5d99e7fc8f08fbb0c1721ea1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-05",
+    "contentid": "5eda0a5c8f0854eb54d99473"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/choropleth-regions",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-05",
+    "contentid": "5eda0a5c8f0854eb54d99473"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/05/covid-19-big-map/choropleth",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-05",
+    "contentid": "5eda0a5c8f0854eb54d99473"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/auto-table",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-06-05",
+    "contentid": "5eda0a5c8f0854eb54d99473"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "d9bee753-7d1a-4e80-ba20-84475dc07eea",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-16",
+    "contentid": "5e6ee5578f088d7575593f57"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7a6078f6-5a66-4d3e-9339-5610fe320767",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-16",
+    "contentid": "5e6ee5578f088d7575593f57"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7d651a43-dd03-4ba8-ae3a-b90635420c0c",
+        "atomType": "guide"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-30",
+    "contentid": "5f2289248f088e9f6f92d528"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5c6d9645-06a4-4871-82b7-05474b139101",
+        "atomType": "qanda"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-02-14",
+    "contentid": "5e467a958f086a28115aba4a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "a53db395-7b6d-45ff-8c0b-78e439cf0fbf",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-30",
+    "contentid": "5e3290f78f0811db2faedf21"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "7f39a161-61c8-4dbf-a690-404df4ff9b9d",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-05",
+    "contentid": "5e8a5d678f080bdb9f534bb6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/coronavirus-australia-summary",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-11",
+    "contentid": "5eb8b80e8f08464cd4297c0f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/04/tableizer/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-11",
+    "contentid": "5eb8b80e8f08464cd4297c0f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2018/03/interactive-enhancer-master-aus",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-11",
+    "contentid": "5eb8b80e8f08464cd4297c0f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "c9009b6d-ae96-4160-b5f4-817a73e18fd9",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-12",
+    "contentid": "5ebabf5b8f080c7274539881"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/03/covid-19-uk/default",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-02",
+    "contentid": "5e8608e78f08532a0e666c73"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8b4ea4bd-46d6-4a5e-9285-211659c10737",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2019-11-25",
+    "contentid": "5ddbf7228f087b800b620d4b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "8076fe72-7f08-4a11-8c6d-c87c7701bb40",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-05-06",
+    "contentid": "5eb2e5f68f086792686d9dd9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "interactives/2020/06/australian_momentum/default",
+        "role": "supporting",
+        "atomType": "interactive"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-07-02",
+    "contentid": "5efe703b8f08a1c3db3f8392"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "5306cde2-d552-4f8d-ae42-b9153a7c5d96",
+        "atomType": "audio"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-01-21",
+    "contentid": "5e26d5d38f08bae83e51d97c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "9a19fac5-8dff-4125-9ba7-ba08f2c09fa7",
+        "atomType": "profile"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-08-04",
+    "contentid": "5f293b578f08ab0eb33ffca0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "53a75223-6bc9-482d-8156-6036f84ca4aa",
+        "atomType": "media"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-03-11",
+    "contentid": "5e68b9e98f087df56e4c64f8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "ee424b1d-a36e-4e72-91cb-8454a5207950",
+        "atomType": "quiz"
+      },
+      "elementType": "content-atom"
+    },
+    "created": "2020-04-21",
+    "contentid": "5e9eb3d28f08119751c7613b"
+  }
+]

--- a/src/elements/helpers/__tests__/fixtures/parse-element.js
+++ b/src/elements/helpers/__tests__/fixtures/parse-element.js
@@ -1,0 +1,53 @@
+import fs from "fs";
+
+const description = `
+Process and sanitize fixture data, parsing out JSON and removing
+data from fields that contain content we'd like to remove.
+
+Usage: \`node parse-element.js file1.json[,file2.json,...]\`
+`
+
+const [_, __, csFileNames] = process.argv;
+
+if (!csFileNames) {
+  console.log(description);
+  console.log("Incorrect arguments: no files provided.");
+  process.exit(22)
+}
+
+const fileNames = csFileNames.split(",")
+
+const processFile = (fileName) => {
+  const sensitiveFields = ["caption", "description", "html", "authorName"];
+  const filePath = `./${fileName}`;
+
+  let redactCount = 0;
+
+  const elementArr = JSON.parse(fs.readFileSync(filePath));
+  const newData = elementArr.map((elementData) => {
+    const newElement = JSON.parse(elementData.element);
+
+
+    sensitiveFields.forEach((sensitiveField) => {
+      if (newElement.fields?.[sensitiveField]) {
+        redactCount++;
+        newElement.fields[sensitiveField] = "<<REDACTED>>";
+      }
+    });
+
+    return {
+      ...elementData,
+      element: newElement,
+    };
+  });
+
+  console.log(`Redacted ${redactCount} fields from ${fileName}`)
+
+  const newPath = `${filePath.split(".json")[0]}-sanitized.json`;
+
+  console.log(`Writing to ${newPath}`);
+
+  fs.writeFileSync(newPath, JSON.stringify(newData, null, 2));
+}
+
+fileNames.forEach(processFile);


### PR DESCRIPTION
## What does this change?

Adds a script to sanitise element fixtures as we generate them, parsing the element data out of string format and redacting certain fields that we'd prefer not to commit to a public repository.

Also includes data for the `content-atom` element, currently WIP.

## How to test

- Does the script describe itself adequately?
- Stretch goal – can you use it on a given dataset? (Happy to supply example data! It's been used to create all of the fixtures we currently have)
