### PR TITLE
fix: Reset white-space for iFrame layout component

### DIFF
--- a/src/elements/standard/StandardForm.tsx
+++ b/src/elements/standard/StandardForm.tsx
@@ -58,6 +58,7 @@ const IframeAspectRatioContainer: React.FunctionComponent<{
 const IframeFullFrameWrapper = styled.div`
   height: 100%;
   width: 100%;
+  white-space: initial;
 `;
 
 export const StandardForm: React.FunctionComponent<Props> = ({


### PR DESCRIPTION
## What does this change?

... because our consuming CMS has CSS opinions about white-space that break the layout.

|Before|After|
|--|--|
|<img width="728" alt="Screenshot 2022-03-16 at 15 46 16" src="https://user-images.githubusercontent.com/7767575/158630661-b1b9f63d-f570-49d6-9665-3c378fa77eb5.png">|<img width="728" alt="Screenshot 2022-03-16 at 15 44 08" src="https://user-images.githubusercontent.com/7767575/158630258-71ea0fcb-94f0-424f-9d7d-763333b873df.png">|

## How to test

Via `yarn yalc`, use this package in Composer. Does the layout bug disappear?