### PR TITLE
feat: Rearrange standard element

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -125,6 +125,7 @@ const {
 const standardElement = createStandardElement({
   createCaptionPlugins,
   checkThirdPartyTracking: mockThirdPartyTracking,
+  useLargePreview: false,
 });
 
 const telemetryEventService = new UserTelemetryEventSender("example.com");
@@ -161,7 +162,11 @@ const {
     audio: standardElement,
     map: standardElement,
     table: tableElement,
-    document: standardElement,
+    document: createStandardElement({
+      createCaptionPlugins,
+      checkThirdPartyTracking: mockThirdPartyTracking,
+      useLargePreview: true,
+    }),
     membership: membershipElement,
   },
   {
@@ -322,7 +327,6 @@ const createEditor = (server: CollabServer) => {
     { label: "Table", name: tableElementName, values: sampleTable },
     { label: "Audio", name: audioElementName, values: sampleAudio },
     { label: "Map", name: mapElementName, values: sampleMap },
-    { label: "Document", name: documentElementName, values: sampleDocument },
     {
       label: "Membership",
       name: membershipElementName,

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -325,8 +325,6 @@ const createEditor = (server: CollabServer) => {
     { label: "Map", name: mapElementName, values: sampleMap },
     { label: "Document", name: documentElementName, values: sampleDocument },
     { label: "Table", name: tableElementName, values: sampleTable },
-    { label: "Audio", name: audioElementName, values: sampleAudio },
-    { label: "Map", name: mapElementName, values: sampleMap },
     {
       label: "Membership",
       name: membershipElementName,

--- a/src/elements/interactive/InteractiveForm.tsx
+++ b/src/elements/interactive/InteractiveForm.tsx
@@ -32,7 +32,10 @@ export const InteractiveElementForm: React.FunctionComponent<Props> = ({
       headingLabel="Interactive"
       headingContent={
         <span>
-          &nbsp;<Link href={fieldValues.originalUrl}>(original url ↪)</Link>
+          &nbsp;
+          <Link target="_blank" rel="noopener" href={fieldValues.originalUrl}>
+            (original url ↪)
+          </Link>
         </span>
       }
       html={fieldValues.html}

--- a/src/elements/standard/StandardForm.tsx
+++ b/src/elements/standard/StandardForm.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import { Column, Columns } from "@guardian/src-layout";
 import React from "react";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import { InputHeading } from "../../editorial-source-components/InputHeading";
 import { Link } from "../../editorial-source-components/Link";
 import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
 import type { FieldValidationErrors } from "../../plugin/elementSpec";
@@ -49,10 +50,28 @@ const IframeAspectRatioBoxContents = styled.div`
 const IframeAspectRatioContainer: React.FunctionComponent<{
   height: string;
   width: string;
-}> = ({ height, width, children }) => (
-  <IframeAspectRatioBox containerHeight={height} containerWidth={width}>
-    <IframeAspectRatioBoxContents>{children}</IframeAspectRatioBoxContents>
-  </IframeAspectRatioBox>
+  html: string;
+  originalUrl: string;
+}> = ({ height, width, html, originalUrl }) => (
+  <div>
+    <InputHeading
+      headingLabel="Preview"
+      headingContent={
+        <span>
+          &nbsp;<Link href={originalUrl}>(original url ↪)</Link>
+        </span>
+      }
+    />
+    <IframeAspectRatioBox containerHeight={height} containerWidth={width}>
+      <IframeAspectRatioBoxContents>
+        <IframeFullFrameWrapper
+          dangerouslySetInnerHTML={{
+            __html: html,
+          }}
+        />
+      </IframeAspectRatioBoxContents>
+    </IframeAspectRatioBox>
+  </div>
 );
 
 const IframeFullFrameWrapper = styled.div`
@@ -71,21 +90,12 @@ export const StandardForm: React.FunctionComponent<Props> = ({
     <FieldLayoutVertical>
       <Columns>
         <Column width={1 / 3}>
-          <FieldLayoutVertical>
-            <IframeAspectRatioContainer
-              height={fieldValues.height}
-              width={fieldValues.width}
-            >
-              <IframeFullFrameWrapper
-                dangerouslySetInnerHTML={{
-                  __html: fieldValues.html,
-                }}
-              />
-            </IframeAspectRatioContainer>
-            <Link target="_blank" rel="noopener" href={fieldValues.originalUrl}>
-              Go to content ↪
-            </Link>
-          </FieldLayoutVertical>
+          <IframeAspectRatioContainer
+            height={fieldValues.height}
+            width={fieldValues.width}
+            html={fieldValues.html}
+            originalUrl={fieldValues.originalUrl}
+          />
         </Column>
         <Column width={2 / 3}>
           <FieldLayoutVertical>
@@ -104,6 +114,46 @@ export const StandardForm: React.FunctionComponent<Props> = ({
           </FieldLayoutVertical>
         </Column>
       </Columns>
+      <CustomCheckboxView
+        field={fields.isMandatory}
+        errors={errors.isMandatory}
+        label="This element is required for publication"
+      />
+      <TrackingStatusChecks
+        html={fieldValues.html}
+        isMandatory={fieldValues.isMandatory}
+        checkThirdPartyTracking={checkThirdPartyTracking}
+      />
+    </FieldLayoutVertical>
+  </div>
+);
+
+export const StandardFormLargePreview: React.FunctionComponent<Props> = ({
+  errors,
+  fields,
+  fieldValues,
+  checkThirdPartyTracking,
+}) => (
+  <div>
+    <FieldLayoutVertical>
+      <IframeAspectRatioContainer
+        height={fieldValues.height}
+        width={fieldValues.width}
+        html={fieldValues.html}
+        originalUrl={fieldValues.originalUrl}
+      />
+      <FieldWrapper
+        field={fields.caption}
+        errors={errors.caption}
+        headingLabel="Caption"
+        description={`${htmlLength(fieldValues.caption)}/1000 characters`}
+      />
+      <CustomDropdownView
+        field={fields.role}
+        label="Weighting"
+        errors={errors.role}
+        display="inline"
+      />
       <CustomCheckboxView
         field={fields.isMandatory}
         errors={errors.isMandatory}

--- a/src/elements/standard/StandardForm.tsx
+++ b/src/elements/standard/StandardForm.tsx
@@ -82,6 +82,9 @@ export const StandardForm: React.FunctionComponent<Props> = ({
                 }}
               />
             </IframeAspectRatioContainer>
+            <Link target="_blank" rel="noopener" href={fieldValues.originalUrl}>
+              Go to content ↪
+            </Link>
           </FieldLayoutVertical>
         </Column>
         <Column width={2 / 3}>
@@ -98,17 +101,14 @@ export const StandardForm: React.FunctionComponent<Props> = ({
               errors={errors.role}
               display="inline"
             />
-            <CustomCheckboxView
-              field={fields.isMandatory}
-              errors={errors.isMandatory}
-              label="This element is required for publication"
-            />
-            <Link target="_blank" rel="noopener" href={fieldValues.originalUrl}>
-              Go to content ↪
-            </Link>
           </FieldLayoutVertical>
         </Column>
       </Columns>
+      <CustomCheckboxView
+        field={fields.isMandatory}
+        errors={errors.isMandatory}
+        label="This element is required for publication"
+      />
       <TrackingStatusChecks
         html={fieldValues.html}
         isMandatory={fieldValues.isMandatory}

--- a/src/elements/standard/StandardForm.tsx
+++ b/src/elements/standard/StandardForm.tsx
@@ -136,9 +136,10 @@ export const StandardFormLargePreview: React.FunctionComponent<Props> = ({
 }) => (
   <div>
     <FieldLayoutVertical>
+      {/* A fixed width and height gives us a fixed aspect ratio */}
       <IframeAspectRatioContainer
-        height={fieldValues.height}
-        width={fieldValues.width}
+        height="150"
+        width="300"
         html={fieldValues.html}
         originalUrl={fieldValues.originalUrl}
       />

--- a/src/elements/standard/StandardSpec.tsx
+++ b/src/elements/standard/StandardSpec.tsx
@@ -12,7 +12,7 @@ import { createReactElementSpec } from "../../renderers/react/createReactElement
 import type { Asset } from "../helpers/defaultTransform";
 import type { TrackingStatus } from "../helpers/ThirdPartyStatusChecks";
 import { undefinedDropdownValue } from "../helpers/transform";
-import { StandardForm } from "./StandardForm";
+import { StandardForm, StandardFormLargePreview } from "./StandardForm";
 
 /**
  * A standard element represents every element covered by
@@ -55,22 +55,20 @@ export const createStandardFields = (
 export type StandardElementOptions = {
   createCaptionPlugins?: (schema: Schema) => Plugin[];
   checkThirdPartyTracking: (html: string) => Promise<TrackingStatus>;
+  useLargePreview?: boolean;
 };
 
 export const createStandardElement = ({
   createCaptionPlugins,
   checkThirdPartyTracking,
+  useLargePreview,
 }: StandardElementOptions) =>
   createReactElementSpec(
     createStandardFields(createCaptionPlugins),
-    ({ fields, errors, fieldValues }) => {
+    (props) => {
+      const Form = useLargePreview ? StandardFormLargePreview : StandardForm;
       return (
-        <StandardForm
-          fields={fields}
-          errors={errors}
-          fieldValues={fieldValues}
-          checkThirdPartyTracking={checkThirdPartyTracking}
-        />
+        <Form {...props} checkThirdPartyTracking={checkThirdPartyTracking} />
       );
     }
   );


### PR DESCRIPTION
## What does this change?

Makes the 'standard' element a little nicer across the board:

- Moving the fields about to be more consistent with other elements
- Providing a 'preview' heading in line with the interactive and embed elements, which can contain the original content link
- Providing a large preview for documents, which were previously unreadable

|Before|After|
|--|--|
|<img width="1012" alt="Screenshot 2022-03-15 at 15 50 15" src="https://user-images.githubusercontent.com/7767575/158815475-aec20de6-ad29-4be8-916a-0672ffa472cf.png">|<img width="598" alt="Screenshot 2022-03-17 at 13 04 24" src="https://user-images.githubusercontent.com/7767575/158815601-a1e69686-6d0c-404a-b25c-a3e2b89d47f6.png">|
|<img width="974" alt="Screenshot 2022-03-15 at 15 50 24" src="https://user-images.githubusercontent.com/7767575/158815774-1cab36ad-032b-475b-8de4-2cf79dd09d16.png">|<img width="598" alt="Screenshot 2022-03-17 at 13 04 46" src="https://user-images.githubusercontent.com/7767575/158815452-247ef5c9-a745-4cb9-b833-ec5febb5028e.png">|

I would say that the result is that everything is a bit neater, and document element previews are approx ~50% less tragic than before.

Do note that the aspect ratio and size of a document iframe will make it appear very large in wide viewports. In Composer, this should not be a problem because of the fixed width of our elements.

## How to test

Fire it up locally and have a test, or use in Composer.