### PR TITLE
Add tweet element

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -27,6 +27,7 @@ import {
 } from "../src/elements/helpers/transform";
 import type { MediaPayload } from "../src/elements/image/ImageElement";
 import { createStandardElement } from "../src/elements/standard/StandardSpec";
+import { createTweetElement } from "../src/elements/tweet/TweetSpec";
 import { buildElementPlugin } from "../src/plugin/element";
 import {
   createParsers,
@@ -55,6 +56,7 @@ import {
   samplePullquote,
   sampleRichLink,
   sampleTable,
+  sampleTweet,
   sampleVideo,
   sampleVine,
 } from "./sampleElements";
@@ -79,6 +81,7 @@ const membershipElementName = "membership";
 const witnessElementName = "witness";
 const instagramElementName = "instagram";
 const vineElementName = "vine";
+const tweetElementName = "tweet";
 
 type Name =
   | typeof embedElementName
@@ -96,7 +99,8 @@ type Name =
   | typeof membershipElementName
   | typeof witnessElementName
   | typeof instagramElementName
-  | typeof vineElementName;
+  | typeof vineElementName
+  | typeof tweetElementName;
 
 const createCaptionPlugins = (schema: Schema) => exampleSetup({ schema });
 const mockThirdPartyTracking = (html: string) =>
@@ -179,6 +183,10 @@ const {
     witness: deprecatedElement,
     vine: deprecatedElement,
     instagram: deprecatedElement,
+    tweet: createTweetElement({
+      checkThirdPartyTracking: mockThirdPartyTracking,
+      createCaptionPlugins,
+    }),
   },
   {
     sendTelemetryEvent: (type: string, tags) =>
@@ -349,6 +357,7 @@ const createEditor = (server: CollabServer) => {
     { label: "Pullquote", name: pullquoteElementName, values: samplePullquote },
     { label: "Code", name: codeElementName, values: sampleCode },
     { label: "Vine", name: vineElementName, values: sampleVine },
+    { label: "Tweet", name: tweetElementName, values: sampleTweet },
   ] as const;
 
   buttonData.map(({ label, name, values }) =>

--- a/demo/sampleElements.ts
+++ b/demo/sampleElements.ts
@@ -340,3 +340,15 @@ export const sampleVine = {
   type: "vine",
   data: `{"fields": {"alt":"Clinton shimmying","html":"<<REDACTED>>","title":"💃 #HillaryClinton #DebateNight #cnn","width":"600","height":"600","source":"Vine","authorUrl":"https://vine.co/u/1038266807917965312","authorName":"<<REDACTED>>","isMandatory":"true","originalUrl":"https://vine.co/v/5rz0naaaEJP"},"assets":[{"url":"https://v.cdn.vine.co/r/thumbs/FE1264FB421392386538297552896_54f5af670bb.31.0.C52609C2-9D12-40AB-BDAD-6B628DE40259.mp4.jpg?versionId=Doo_Qq2hMbJZGgI44BU5RbfRouNNZQSY","fields":{"width":"480","height":"480"},"mimeType":"image/jpeg","assetType":"image"}]}`,
 };
+
+export const sampleTweet = {
+  source: "Twitter",
+  isMandatory: "true",
+  role: "inline",
+  url: "https://twitter.com/js_herbert/status/1495470075062767627",
+  originalUrl:
+    "https://twitter.com/js_herbert/status/1495470075062767627?ref_src=twsrc%5Etfw",
+  id: "1495470075062767627",
+  html: `<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Gosh Github support for <a href="https://t.co/Giw3LjKthH">https://t.co/Giw3LjKthH</a> is lovely :)))</p>&mdash; Jonathon Herbert (@js_herbert) <a href="https://twitter.com/js_herbert/status/1495470075062767627?ref_src=twsrc%5Etfw">February 20, 2022</a></blockquote>`,
+  authorName: "Jonathan Herbert",
+};

--- a/src/elements/helpers/__tests__/fixtures/index.ts
+++ b/src/elements/helpers/__tests__/fixtures/index.ts
@@ -5,6 +5,7 @@ import map from "./map.json";
 import membership from "./membership.json";
 import richLink from "./rich-link.json";
 import table from "./table.json";
+import tweet from "./tweet.json";
 import vine from "./vine.json";
 import witness from "./witness.json";
 
@@ -22,4 +23,5 @@ export const allElementFixtures = {
   witness,
   vine,
   instagram,
+  tweet,
 };

--- a/src/elements/helpers/__tests__/fixtures/tweet.json
+++ b/src/elements/helpers/__tests__/fixtures/tweet.json
@@ -1,0 +1,18807 @@
+[
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1214521447357591556",
+        "url": "https://twitter.com/thanos_sk/status/1214521447357591556",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/thanos_sk/status/1214521447357591556"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-01-03",
+    "contentid": "5e0f50f08f085eda5c1118d2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1214519388373684224",
+        "url": "https://twitter.com/DerekBrosnan/status/1214519388373684224",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/DerekBrosnan/status/1214519388373684224"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-01-03",
+    "contentid": "5e0f50f08f085eda5c1118d2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1214524935571492865",
+        "url": "https://twitter.com/Mattskating/status/1214524935571492865",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Mattskating/status/1214524935571492865"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-01-03",
+    "contentid": "5e0f50f08f085eda5c1118d2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130918543204192257",
+        "url": "https://twitter.com/lisaocarroll/status/1130918543204192257",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/lisaocarroll/status/1130918543204192257"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130919734004912131",
+        "url": "https://twitter.com/lisaocarroll/status/1130919734004912131",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/lisaocarroll/status/1130919734004912131"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130918877955796994",
+        "url": "https://twitter.com/lisaocarroll/status/1130918877955796994",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/lisaocarroll/status/1130918877955796994"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130905094382325760",
+        "url": "https://twitter.com/BorisJohnson/status/1130905094382325760",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BorisJohnson/status/1130905094382325760"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130899833680814081",
+        "url": "https://twitter.com/bbclaurak/status/1130899833680814081",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bbclaurak/status/1130899833680814081"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130899960868872193",
+        "url": "https://twitter.com/SebastianEPayne/status/1130899960868872193",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SebastianEPayne/status/1130899960868872193"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130900913563029504",
+        "url": "https://twitter.com/BethRigby/status/1130900913563029504",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BethRigby/status/1130900913563029504"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130892286068498432",
+        "url": "https://twitter.com/DominicRaab/status/1130892286068498432",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/DominicRaab/status/1130892286068498432"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130890846730108929",
+        "url": "https://twitter.com/SteveBakerHW/status/1130890846730108929",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SteveBakerHW/status/1130890846730108929"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130872404916559872",
+        "url": "https://twitter.com/Jacob_Rees_Mogg/status/1130872404916559872",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Jacob_Rees_Mogg/status/1130872404916559872"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130887305881899013",
+        "url": "https://twitter.com/bbclaurak/status/1130887305881899013",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bbclaurak/status/1130887305881899013"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130874600362041344",
+        "url": "https://twitter.com/NicolaSturgeon/status/1130874600362041344",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/NicolaSturgeon/status/1130874600362041344"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130856806916345856",
+        "url": "https://twitter.com/SimonClarkeMP/status/1130856806916345856",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SimonClarkeMP/status/1130856806916345856"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130857562667069442",
+        "url": "https://twitter.com/SimonClarkeMP/status/1130857562667069442",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SimonClarkeMP/status/1130857562667069442"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130874444950528000",
+        "url": "https://twitter.com/PaulBrandITV/status/1130874444950528000",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/PaulBrandITV/status/1130874444950528000"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130876753088585728",
+        "url": "https://twitter.com/mariacaulfield/status/1130876753088585728",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/mariacaulfield/status/1130876753088585728"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130874542723883008",
+        "url": "https://twitter.com/alexwickham/status/1130874542723883008",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/alexwickham/status/1130874542723883008"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130870690343735303",
+        "url": "https://twitter.com/BrexitCentral/status/1130870690343735303",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BrexitCentral/status/1130870690343735303"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130865708735303681",
+        "url": "https://twitter.com/bbclaurak/status/1130865708735303681",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bbclaurak/status/1130865708735303681"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130872609569214464",
+        "url": "https://twitter.com/halfon4harlowMP/status/1130872609569214464",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/halfon4harlowMP/status/1130872609569214464"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130866154518568960",
+        "url": "https://twitter.com/ZacGoldsmith/status/1130866154518568960",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ZacGoldsmith/status/1130866154518568960"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130852258504093697",
+        "url": "https://twitter.com/AndyWoodcock/status/1130852258504093697",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AndyWoodcock/status/1130852258504093697"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130851932770168832",
+        "url": "https://twitter.com/GuardianHeather/status/1130851932770168832",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GuardianHeather/status/1130851932770168832"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130850636948430848",
+        "url": "https://twitter.com/Steven_Swinford/status/1130850636948430848",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Steven_Swinford/status/1130850636948430848"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130849930350718976",
+        "url": "https://twitter.com/Peston/status/1130849930350718976",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Peston/status/1130849930350718976"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130849932326256641",
+        "url": "https://twitter.com/Peston/status/1130849932326256641",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Peston/status/1130849932326256641"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130849934716985346",
+        "url": "https://twitter.com/Peston/status/1130849934716985346",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Peston/status/1130849934716985346"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130845183883431936",
+        "url": "https://twitter.com/Steven_Swinford/status/1130845183883431936",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Steven_Swinford/status/1130845183883431936"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130845840245788674",
+        "url": "https://twitter.com/joncraig/status/1130845840245788674",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/joncraig/status/1130845840245788674"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130847608010752001",
+        "url": "https://twitter.com/rowenamason/status/1130847608010752001",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/rowenamason/status/1130847608010752001"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130539316348968961",
+        "url": "https://twitter.com/andreajenkyns/status/1130539316348968961",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/andreajenkyns/status/1130539316348968961"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130817181850243074",
+        "url": "https://twitter.com/NSoames/status/1130817181850243074",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/NSoames/status/1130817181850243074"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130827253066207232",
+        "url": "https://twitter.com/andreajenkyns/status/1130827253066207232",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/andreajenkyns/status/1130827253066207232"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130830091272019970",
+        "url": "https://twitter.com/Sandbach/status/1130830091272019970",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Sandbach/status/1130830091272019970"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130830460853149697",
+        "url": "https://twitter.com/andreajenkyns/status/1130830460853149697",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/andreajenkyns/status/1130830460853149697"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130824215068839937",
+        "url": "https://twitter.com/KateEMcCann/status/1130824215068839937",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/KateEMcCann/status/1130824215068839937"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130818830475902977",
+        "url": "https://twitter.com/bbclaurak/status/1130818830475902977",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bbclaurak/status/1130818830475902977"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130805828330639360",
+        "url": "https://twitter.com/JGForsyth/status/1130805828330639360",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/JGForsyth/status/1130805828330639360"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130817804431745024",
+        "url": "https://twitter.com/JGForsyth/status/1130817804431745024",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/JGForsyth/status/1130817804431745024"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130799213166546944",
+        "url": "https://twitter.com/MrHarryCole/status/1130799213166546944",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MrHarryCole/status/1130799213166546944"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130799706433576961",
+        "url": "https://twitter.com/MrHarryCole/status/1130799706433576961",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MrHarryCole/status/1130799706433576961"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130799977905774592",
+        "url": "https://twitter.com/MrHarryCole/status/1130799977905774592",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MrHarryCole/status/1130799977905774592"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130800614659756034",
+        "url": "https://twitter.com/MrHarryCole/status/1130800614659756034",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MrHarryCole/status/1130800614659756034"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130801634559369216",
+        "url": "https://twitter.com/MrHarryCole/status/1130801634559369216",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MrHarryCole/status/1130801634559369216"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130797130937962497",
+        "url": "https://twitter.com/paulwaugh/status/1130797130937962497",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/paulwaugh/status/1130797130937962497"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130797540868337666",
+        "url": "https://twitter.com/bbclaurak/status/1130797540868337666",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bbclaurak/status/1130797540868337666"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130796345881780224",
+        "url": "https://twitter.com/PaulBrandITV/status/1130796345881780224",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/PaulBrandITV/status/1130796345881780224"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130796139853352965",
+        "url": "https://twitter.com/PaulBrandITV/status/1130796139853352965",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/PaulBrandITV/status/1130796139853352965"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130794494755057665",
+        "url": "https://twitter.com/bbclaurak/status/1130794494755057665",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bbclaurak/status/1130794494755057665"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130788259284619266",
+        "url": "https://twitter.com/PaulBrandITV/status/1130788259284619266",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/PaulBrandITV/status/1130788259284619266"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130788514289848321",
+        "url": "https://twitter.com/Steven_Swinford/status/1130788514289848321",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Steven_Swinford/status/1130788514289848321"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130595759768920065",
+        "url": "https://twitter.com/BorisJohnson/status/1130595759768920065",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BorisJohnson/status/1130595759768920065"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130733880225468417",
+        "url": "https://twitter.com/bbclaurak/status/1130733880225468417",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bbclaurak/status/1130733880225468417"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130734080713273344",
+        "url": "https://twitter.com/bbclaurak/status/1130734080713273344",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bbclaurak/status/1130734080713273344"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130734333181014016",
+        "url": "https://twitter.com/bbclaurak/status/1130734333181014016",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bbclaurak/status/1130734333181014016"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130734715898605568",
+        "url": "https://twitter.com/bbclaurak/status/1130734715898605568",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bbclaurak/status/1130734715898605568"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130735293076840448",
+        "url": "https://twitter.com/bbclaurak/status/1130735293076840448",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bbclaurak/status/1130735293076840448"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130749813631463424",
+        "url": "https://twitter.com/rosskempsell/status/1130749813631463424",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/rosskempsell/status/1130749813631463424"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130739817262866433",
+        "url": "https://twitter.com/JasonGroves1/status/1130739817262866433",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/JasonGroves1/status/1130739817262866433"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130735505988104195",
+        "url": "https://twitter.com/BethRigby/status/1130735505988104195",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BethRigby/status/1130735505988104195"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1130585152122368001",
+        "url": "https://twitter.com/TimesPictures/status/1130585152122368001",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TimesPictures/status/1130585152122368001"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-21",
+    "contentid": "5ce3a9918f08ad67f1a7e100"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829140370059567104",
+        "url": "https://twitter.com/SenWarren/status/829140370059567104",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SenWarren/status/829140370059567104"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-08",
+    "contentid": "589a9386e4b09739e65f542a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829162525711282178",
+        "url": "https://twitter.com/ChrisMurphyCT/status/829162525711282178",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ChrisMurphyCT/status/829162525711282178"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-08",
+    "contentid": "589a9386e4b09739e65f542a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829025562421235712",
+        "url": "https://twitter.com/StarkTTT/status/829025562421235712",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/StarkTTT/status/829025562421235712"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-07",
+    "contentid": "589a456ce4b09739e65f530e"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4FwpYTVcAA_ufQ.jpg",
+          "fields": {
+            "width": "1125",
+            "height": "969",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4FwpYTVcAA_ufQ.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829067678274961409",
+        "url": "https://twitter.com/StevenTDennis/status/829067678274961409",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/StevenTDennis/status/829067678274961409"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-07",
+    "contentid": "589a456ce4b09739e65f530e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829079057266593794",
+        "url": "https://twitter.com/WillOremus/status/829079057266593794",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/WillOremus/status/829079057266593794"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-07",
+    "contentid": "589a456ce4b09739e65f530e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "828983271014936576",
+        "url": "https://twitter.com/MEPFuller/status/828983271014936576",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MEPFuller/status/828983271014936576"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-07",
+    "contentid": "589a456ce4b09739e65f530e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829007910277636097",
+        "url": "https://twitter.com/SteveKopack/status/829007910277636097",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SteveKopack/status/829007910277636097"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-07",
+    "contentid": "589a456ce4b09739e65f530e"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4FfQVtWIAAyKHs.jpg",
+          "fields": {
+            "width": "768",
+            "height": "1024",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4FfQVtWIAAyKHs.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829048542660550657",
+        "url": "https://twitter.com/SmithInAmerica/status/829048542660550657",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SmithInAmerica/status/829048542660550657"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-07",
+    "contentid": "589a456ce4b09739e65f530e"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4F2B7nWQAALTIS.jpg",
+          "fields": {
+            "width": "2000",
+            "height": "1000",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4F2B7nWQAALTIS.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829073584760971270",
+        "url": "https://twitter.com/HuffingtonPost/status/829073584760971270",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/HuffingtonPost/status/829073584760971270"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-07",
+    "contentid": "589a456ce4b09739e65f530e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829089736354570240",
+        "url": "https://twitter.com/UlrikaModeer/status/829089736354570240",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/UlrikaModeer/status/829089736354570240"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-08",
+    "contentid": "589ae8dee4b09739e65f5548"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829080384021393414",
+        "url": "https://twitter.com/davidnabarro/status/829080384021393414",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/davidnabarro/status/829080384021393414"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-08",
+    "contentid": "589ae8dee4b09739e65f5548"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829260647888195584",
+        "url": "https://twitter.com/Ms_Haston/status/829260647888195584",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Ms_Haston/status/829260647888195584"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-08",
+    "contentid": "589ae8dee4b09739e65f5548"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/CxRv4dYWQAEX6qD.jpg",
+          "fields": {
+            "width": "600",
+            "height": "640",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/CxRv4dYWQAEX6qD.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "798386072594083841",
+        "url": "https://twitter.com/EricLiptonNYT/status/798386072594083841",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/EricLiptonNYT/status/798386072594083841?ref_src=twsrc%5Etfw"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-07",
+    "contentid": "5899f670e4b09739e65f51b4"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829113409530642433",
+        "url": "https://twitter.com/emilybell/status/829113409530642433",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/emilybell/status/829113409530642433"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-07",
+    "contentid": "589a4bd8e4b09739e65f5326"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/825715154742423552/pu/img/Eg9jBpk-eg9GTF4u.jpg",
+          "fields": {
+            "width": "630",
+            "height": "360",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/825715154742423552/pu/img/Eg9jBpk-eg9GTF4u.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "825716300282548225",
+        "url": "https://twitter.com/AustinKellerman/status/825716300282548225",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AustinKellerman/status/825716300282548225"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-07",
+    "contentid": "589a4bd8e4b09739e65f5326"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829120479147474944",
+        "url": "https://twitter.com/imillhiser/status/829120479147474944",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/imillhiser/status/829120479147474944"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-07",
+    "contentid": "589a4bd8e4b09739e65f5326"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829119826190880768",
+        "url": "https://twitter.com/tribelaw/status/829119826190880768",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tribelaw/status/829119826190880768"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-07",
+    "contentid": "589a4bd8e4b09739e65f5326"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829120357646868480",
+        "url": "https://twitter.com/neal_katyal/status/829120357646868480",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/neal_katyal/status/829120357646868480"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-07",
+    "contentid": "589a4bd8e4b09739e65f5326"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829115466299932672",
+        "url": "https://twitter.com/briangoldman/status/829115466299932672",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/briangoldman/status/829115466299932672"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-07",
+    "contentid": "589a4bd8e4b09739e65f5326"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829113853749260288",
+        "url": "https://twitter.com/AlanYuhas/status/829113853749260288",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AlanYuhas/status/829113853749260288"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-07",
+    "contentid": "589a4bd8e4b09739e65f5326"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829112459961237505",
+        "url": "https://twitter.com/AriMelber/status/829112459961237505",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AriMelber/status/829112459961237505"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-07",
+    "contentid": "589a4bd8e4b09739e65f5326"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829112580434182144",
+        "url": "https://twitter.com/briangoldman/status/829112580434182144",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/briangoldman/status/829112580434182144"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-07",
+    "contentid": "589a4bd8e4b09739e65f5326"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829107652126846976",
+        "url": "https://twitter.com/DavidColeACLU/status/829107652126846976",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/DavidColeACLU/status/829107652126846976"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-07",
+    "contentid": "589a4bd8e4b09739e65f5326"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829106777430093826",
+        "url": "https://twitter.com/ACLU/status/829106777430093826",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ACLU/status/829106777430093826"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-07",
+    "contentid": "589a4bd8e4b09739e65f5326"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600991979296653312",
+        "url": "https://twitter.com/Hantsfedchair/statuses/600991979296653312",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/Hantsfedchair/status/600991979296653312"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600990066488512513",
+        "url": "https://twitter.com/DyfedPowysFed/statuses/600990066488512513",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/DyfedPowysFed/status/600990066488512513"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600984873340424194",
+        "url": "https://twitter.com/grahamwettone/statuses/600984873340424194",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/grahamwettone/status/600984873340424194"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600991350792790016",
+        "url": "https://twitter.com/ConstableChaos/statuses/600991350792790016",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/ConstableChaos/status/600991350792790016"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600989904915562496",
+        "url": "https://twitter.com/CheshirePolFed/statuses/600989904915562496",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/CheshirePolFed/status/600989904915562496"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600986289555505154",
+        "url": "https://twitter.com/PFEW_HQ/statuses/600986289555505154",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/PFEW_HQ/status/600986289555505154"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600987805431549952",
+        "url": "https://twitter.com/PFEW_HQ/statuses/600987805431549952",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/PFEW_HQ/status/600987805431549952"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600988213881262081",
+        "url": "https://twitter.com/PFEW_HQ/statuses/600988213881262081",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/PFEW_HQ/status/600988213881262081"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600987148804878336",
+        "url": "https://twitter.com/DannyShawBBC/statuses/600987148804878336",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/DannyShawBBC/status/600987148804878336"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600978785786273792",
+        "url": "https://twitter.com/theousherwood/statuses/600978785786273792",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/theousherwood/status/600978785786273792"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600979068113317888",
+        "url": "https://twitter.com/theousherwood/statuses/600979068113317888",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/theousherwood/status/600979068113317888"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600978690588155904",
+        "url": "https://twitter.com/DannyShawBBC/statuses/600978690588155904",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/DannyShawBBC/status/600978690588155904"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600981472758075392",
+        "url": "https://twitter.com/DannyShawBBC/statuses/600981472758075392",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/DannyShawBBC/status/600981472758075392"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600982287468109824",
+        "url": "https://twitter.com/DannyShawBBC/statuses/600982287468109824",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/DannyShawBBC/status/600982287468109824"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600982565164609536",
+        "url": "https://twitter.com/DannyShawBBC/statuses/600982565164609536",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/DannyShawBBC/status/600982565164609536"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600979402739032064",
+        "url": "https://twitter.com/theousherwood/statuses/600979402739032064",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/theousherwood/status/600979402739032064"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600979619525820416",
+        "url": "https://twitter.com/theousherwood/statuses/600979619525820416",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/theousherwood/status/600979619525820416"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600979754536296449",
+        "url": "https://twitter.com/theousherwood/statuses/600979754536296449",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/theousherwood/status/600979754536296449"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600980177749938177",
+        "url": "https://twitter.com/theousherwood/statuses/600980177749938177",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/theousherwood/status/600980177749938177"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600980415470555136",
+        "url": "https://twitter.com/DannyShawBBC/statuses/600980415470555136",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/DannyShawBBC/status/600980415470555136"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600982727274401792",
+        "url": "https://twitter.com/DannyShawBBC/statuses/600982727274401792",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/DannyShawBBC/status/600982727274401792"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600978286907400193",
+        "url": "https://twitter.com/theousherwood/statuses/600978286907400193",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/theousherwood/status/600978286907400193"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/CFcbHvwWoAAA460.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "1365",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/CFcbHvwWoAAA460.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "600978895261835264",
+        "url": "https://twitter.com/xtophercook/statuses/600978895261835264",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/xtophercook/status/600978895261835264"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600954742647422976",
+        "url": "https://twitter.com/nickeardley/statuses/600954742647422976",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/nickeardley/status/600954742647422976"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600934492795248640",
+        "url": "https://twitter.com/nickeardley/statuses/600934492795248640",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/nickeardley/status/600934492795248640"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600934937072640000",
+        "url": "https://twitter.com/nickeardley/statuses/600934937072640000",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/nickeardley/status/600934937072640000"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600924349911171072",
+        "url": "https://twitter.com/WikiGuido/statuses/600924349911171072",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/WikiGuido/status/600924349911171072"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/CFby5jEWYAAajEx.jpg",
+          "fields": {
+            "width": "620",
+            "height": "413",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/CFby5jEWYAAajEx.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "600934678816759808",
+        "url": "https://twitter.com/bbcnickrobinson/statuses/600934678816759808",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/bbcnickrobinson/status/600934678816759808"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600935419447005184",
+        "url": "https://twitter.com/bbcnickrobinson/statuses/600935419447005184",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/bbcnickrobinson/status/600935419447005184"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600924207711653888",
+        "url": "https://twitter.com/MichaelWhite/statuses/600924207711653888",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/MichaelWhite/status/600924207711653888"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600923534509105152",
+        "url": "https://twitter.com/ShippersUnbound/statuses/600923534509105152",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/ShippersUnbound/status/600923534509105152"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600923428611317760",
+        "url": "https://twitter.com/JeyyLowe/statuses/600923428611317760",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/JeyyLowe/status/600923428611317760"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "600924207149617152",
+        "url": "https://twitter.com/IsabelHardman/statuses/600924207149617152",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/IsabelHardman/status/600924207149617152"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "588288353008803840",
+        "url": "https://twitter.com/ShippersUnbound/statuses/588288353008803840",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/shippersunbound/status/588288353008803840"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-05-20",
+    "contentid": "555c3302e4b02b13e9d84a6a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1035498358813745152",
+        "url": "https://twitter.com/SamJDean/status/1035498358813745152",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SamJDean/status/1035498358813745152"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-08-30",
+    "contentid": "5b87f3ade4b0c18ca380a43e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "674934005725331456",
+        "url": "https://twitter.com/realDonaldTrump/statuses/674934005725331456",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/realDonaldTrump/status/674934005725331456"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-12-10",
+    "contentid": "5669396ee4b0ca35d33000fa"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "674936832010887168",
+        "url": "https://twitter.com/realDonaldTrump/statuses/674936832010887168",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/realDonaldTrump/status/674936832010887168"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-12-10",
+    "contentid": "5669396ee4b0ca35d33000fa"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "674888532293525504",
+        "url": "https://twitter.com/JakubKrupa/statuses/674888532293525504",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/JakubKrupa/status/674888532293525504"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-12-10",
+    "contentid": "5669396ee4b0ca35d33000fa"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "674888842839728128",
+        "url": "https://twitter.com/JakubKrupa/statuses/674888842839728128",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/JakubKrupa/status/674888842839728128"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-12-10",
+    "contentid": "5669396ee4b0ca35d33000fa"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "674889000637829120",
+        "url": "https://twitter.com/JakubKrupa/statuses/674889000637829120",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/JakubKrupa/status/674889000637829120"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-12-10",
+    "contentid": "5669396ee4b0ca35d33000fa"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "674889642538369024",
+        "url": "https://twitter.com/JakubKrupa/statuses/674889642538369024",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/JakubKrupa/status/674889642538369024"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-12-10",
+    "contentid": "5669396ee4b0ca35d33000fa"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "674889801154338817",
+        "url": "https://twitter.com/JakubKrupa/statuses/674889801154338817",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/JakubKrupa/status/674889801154338817"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-12-10",
+    "contentid": "5669396ee4b0ca35d33000fa"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "674890007170195456",
+        "url": "https://twitter.com/JakubKrupa/statuses/674890007170195456",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/JakubKrupa/status/674890007170195456"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-12-10",
+    "contentid": "5669396ee4b0ca35d33000fa"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "674890756750995456",
+        "url": "https://twitter.com/JakubKrupa/statuses/674890756750995456",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/JakubKrupa/status/674890756750995456"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-12-10",
+    "contentid": "5669396ee4b0ca35d33000fa"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/CV0OAwVXAAETRJc.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "1700",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/CV0OAwVXAAETRJc.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "674710930110853120",
+        "url": "https://twitter.com/suttonnick/statuses/674710930110853120",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/suttonnick/status/674710930110853120"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-12-10",
+    "contentid": "5669396ee4b0ca35d33000fa"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "674871684499947520",
+        "url": "https://twitter.com/BBCNormanS/statuses/674871684499947520",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/BBCNormanS/status/674871684499947520"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-12-10",
+    "contentid": "5669396ee4b0ca35d33000fa"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1020725457745039360",
+        "url": "https://twitter.com/echosportsed/status/1020725457745039360",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/echosportsed/status/1020725457745039360?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E1020725457745039360&ref_url=https%3A%2F%2Fwww.irishexaminer.com%2Fbreakingnews%2Fireland%2Flatest-liam-miller-tribute-match-to-be-played-at-pairc-ui-chaoimh--reports-856791.html"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-07-21",
+    "contentid": "5b53c8c2e4b0b9a0a347ebdf"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DqN90hMWwAEce9Q.jpg",
+          "fields": {
+            "width": "499",
+            "height": "305",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DqN90hMWwAEce9Q.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1054825081795428352",
+        "url": "https://twitter.com/markets/status/1054825081795428352",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/markets/status/1054825081795428352"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1054825289983946752",
+        "url": "https://twitter.com/IGSquawk/status/1054825289983946752",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/IGSquawk/status/1054825289983946752"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1054749403150475265",
+        "url": "https://twitter.com/AngeloCiocca/status/1054749403150475265",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AngeloCiocca/status/1054749403150475265"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1054740621741690882",
+        "url": "https://twitter.com/carlquintanilla/status/1054740621741690882",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/carlquintanilla/status/1054740621741690882"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1054734742334124032",
+        "url": "https://twitter.com/pierremoscovici/status/1054734742334124032",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/pierremoscovici/status/1054734742334124032"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1054734993946230784",
+        "url": "https://twitter.com/pierremoscovici/status/1054734993946230784",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/pierremoscovici/status/1054734993946230784"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1054734693608972289",
+        "url": "https://twitter.com/emanuelebonini/status/1054734693608972289",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/emanuelebonini/status/1054734693608972289"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DqMpgrlWoAAXnQw.jpg",
+          "fields": {
+            "width": "1241",
+            "height": "1154",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DqMpgrlWoAAXnQw.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1054732393993723905",
+        "url": "https://twitter.com/DarrenEuronews/status/1054732393993723905",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/DarrenEuronews/status/1054732393993723905"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DqMLEJSWkAAzNbj.jpg",
+          "fields": {
+            "width": "1912",
+            "height": "1124",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DqMLEJSWkAAzNbj.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1054698908612485120",
+        "url": "https://twitter.com/CNBCnow/status/1054698908612485120",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/CNBCnow/status/1054698908612485120"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DqMOt8nWkAUtA-5.jpg",
+          "fields": {
+            "width": "1292",
+            "height": "730",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DqMOt8nWkAUtA-5.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1054703047593594881",
+        "url": "https://twitter.com/bySamRo/status/1054703047593594881",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bySamRo/status/1054703047593594881"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1054700880262557696",
+        "url": "https://twitter.com/BrianSozzi/status/1054700880262557696",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BrianSozzi/status/1054700880262557696"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1054670418760622080",
+        "url": "https://twitter.com/patrickwintour/status/1054670418760622080",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/patrickwintour/status/1054670418760622080"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1054669170489614342",
+        "url": "https://twitter.com/trpresidency/status/1054669170489614342",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/trpresidency/status/1054669170489614342"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1054670390449061888",
+        "url": "https://twitter.com/GarryWhite/status/1054670390449061888",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GarryWhite/status/1054670390449061888"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DqLp3DqW4AANWGM.jpg",
+          "fields": {
+            "width": "968",
+            "height": "214",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DqLp3DqW4AANWGM.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1054662868245889024",
+        "url": "https://twitter.com/Bob_Loblaw420/status/1054662868245889024",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Bob_Loblaw420/status/1054662868245889024"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1054631991742791680",
+        "url": "https://twitter.com/RoryWSJ/status/1054631991742791680",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/RoryWSJ/status/1054631991742791680"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1054640741492895744",
+        "url": "https://twitter.com/AnujChopra/status/1054640741492895744",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AnujChopra/status/1054640741492895744"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1054626821453549568",
+        "url": "https://twitter.com/michaelkamon/status/1054626821453549568",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/michaelkamon/status/1054626821453549568"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1054627277877710849",
+        "url": "https://twitter.com/michaelkamon/status/1054627277877710849",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/michaelkamon/status/1054627277877710849"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1054457549062373387",
+        "url": "https://twitter.com/KSAmofaEN/status/1054457549062373387",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/KSAmofaEN/status/1054457549062373387"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1054467318808485889",
+        "url": "https://twitter.com/TreasurySpox/status/1054467318808485889",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TreasurySpox/status/1054467318808485889"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1054479292766261248",
+        "url": "https://twitter.com/TreasurySpox/status/1054479292766261248",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TreasurySpox/status/1054479292766261248"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DqIb-2mXcAMduiF.jpg",
+          "fields": {
+            "width": "1878",
+            "height": "2048",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DqIb-2mXcAMduiF.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1054436282280169472",
+        "url": "https://twitter.com/KSAmofaEN/status/1054436282280169472",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/KSAmofaEN/status/1054436282280169472"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1054610704206970880",
+        "url": "https://twitter.com/IGSquawk/status/1054610704206970880",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/IGSquawk/status/1054610704206970880"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-23",
+    "contentid": "5bceb5d0e4b0616e70d41f8c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1076577824360796160",
+        "url": "https://twitter.com/ElevenSports_UK/status/1076577824360796160",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ElevenSports_UK/status/1076577824360796160"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-24",
+    "contentid": "5c20e846e4b0cebe7617aaef"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009765243466199040",
+        "url": "https://twitter.com/samueltombs/status/1009765243466199040",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/samueltombs/status/1009765243466199040"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-21",
+    "contentid": "5b2b3f1ae4b06f2cac880660"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009760878978306048",
+        "url": "https://twitter.com/DharshiniDavid/status/1009760878978306048",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/DharshiniDavid/status/1009760878978306048"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-21",
+    "contentid": "5b2b3f1ae4b06f2cac880660"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009753848267902979",
+        "url": "https://twitter.com/fergalob/status/1009753848267902979",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/fergalob/status/1009753848267902979"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-21",
+    "contentid": "5b2b3f1ae4b06f2cac880660"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009726676870279168",
+        "url": "https://twitter.com/MattWhittakerRF/status/1009726676870279168",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MattWhittakerRF/status/1009726676870279168"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-21",
+    "contentid": "5b2b3f1ae4b06f2cac880660"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009719375954407424",
+        "url": "https://twitter.com/rbrharrison/status/1009719375954407424",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/rbrharrison/status/1009719375954407424"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-21",
+    "contentid": "5b2b3f1ae4b06f2cac880660"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009721243921199104",
+        "url": "https://twitter.com/rbrharrison/status/1009721243921199104",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/rbrharrison/status/1009721243921199104"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-21",
+    "contentid": "5b2b3f1ae4b06f2cac880660"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009721601867337728",
+        "url": "https://twitter.com/rbrharrison/status/1009721601867337728",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/rbrharrison/status/1009721601867337728"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-21",
+    "contentid": "5b2b3f1ae4b06f2cac880660"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009716633051549696",
+        "url": "https://twitter.com/bbckamal/status/1009716633051549696",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bbckamal/status/1009716633051549696"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-21",
+    "contentid": "5b2b3f1ae4b06f2cac880660"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009716166561058816",
+        "url": "https://twitter.com/FraserMunroPSF/status/1009716166561058816",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/FraserMunroPSF/status/1009716166561058816"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-21",
+    "contentid": "5b2b3f1ae4b06f2cac880660"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009724022656036864",
+        "url": "https://twitter.com/CCHQPress/status/1009724022656036864",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/CCHQPress/status/1009724022656036864"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-21",
+    "contentid": "5b2b3f1ae4b06f2cac880660"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009716654861946880",
+        "url": "https://twitter.com/FraserMunroPSF/status/1009716654861946880",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/FraserMunroPSF/status/1009716654861946880"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-21",
+    "contentid": "5b2b3f1ae4b06f2cac880660"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009712306492755968",
+        "url": "https://twitter.com/Miss_Ruya/status/1009712306492755968",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Miss_Ruya/status/1009712306492755968"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-21",
+    "contentid": "5b2b3f1ae4b06f2cac880660"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DgMarXOWAAUdhDP.jpg",
+          "fields": {
+            "width": "1200",
+            "height": "600",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DgMarXOWAAUdhDP.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1009680075619491840",
+        "url": "https://twitter.com/Brexit/status/1009680075619491840",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Brexit/status/1009680075619491840"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-21",
+    "contentid": "5b2b3f1ae4b06f2cac880660"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/DgMeMyAX0AAL_8R.jpg",
+          "fields": {
+            "width": "496",
+            "height": "280",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/DgMeMyAX0AAL_8R.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1009683954990047232",
+        "url": "https://twitter.com/mhewson_CMC/status/1009683954990047232",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/mhewson_CMC/status/1009683954990047232"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-21",
+    "contentid": "5b2b3f1ae4b06f2cac880660"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009672152889659394",
+        "url": "https://twitter.com/carstenbrzeski/status/1009672152889659394",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/carstenbrzeski/status/1009672152889659394"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-21",
+    "contentid": "5b2b3f1ae4b06f2cac880660"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049576833304408065",
+        "url": "https://twitter.com/ReutersJamie/status/1049576833304408065",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ReutersJamie/status/1049576833304408065"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-09",
+    "contentid": "5bbc4631e4b0fc2a3accca69"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049322283607752709",
+        "url": "https://twitter.com/fxmacro/status/1049322283607752709",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/fxmacro/status/1049322283607752709"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-09",
+    "contentid": "5bbc4631e4b0fc2a3accca69"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049586016632229889",
+        "url": "https://twitter.com/hancocktom/status/1049586016632229889",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/hancocktom/status/1049586016632229889"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-09",
+    "contentid": "5bbc4631e4b0fc2a3accca69"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049536260782604288",
+        "url": "https://twitter.com/kitjuckes/status/1049536260782604288",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/kitjuckes/status/1049536260782604288"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-09",
+    "contentid": "5bbc4631e4b0fc2a3accca69"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049561720916766720",
+        "url": "https://twitter.com/HowardArcherUK/status/1049561720916766720",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/HowardArcherUK/status/1049561720916766720"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-09",
+    "contentid": "5bbc4631e4b0fc2a3accca69"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049576833304408065",
+        "url": "https://twitter.com/ReutersJamie/status/1049576833304408065",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ReutersJamie/status/1049576833304408065"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-09",
+    "contentid": "5bbc4631e4b0fc2a3accca69"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DpCy_eRWsAA6txx.jpg",
+          "fields": {
+            "width": "1537",
+            "height": "1010",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DpCy_eRWsAA6txx.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1049535524044754944",
+        "url": "https://twitter.com/jsblokland/status/1049535524044754944",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jsblokland/status/1049535524044754944"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-09",
+    "contentid": "5bbc4631e4b0fc2a3accca69"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DiT_iGiXUAAvAai.jpg",
+          "fields": {
+            "width": "985",
+            "height": "651",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DiT_iGiXUAAvAai.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1019220533559382017",
+        "url": "https://twitter.com/flyethiopian/status/1019220533559382017",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/flyethiopian/status/1019220533559382017"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-07-18",
+    "contentid": "5b4efe1fe4b0aaa7a4737b99"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1019549895202689024",
+        "url": "https://twitter.com/hawelti/status/1019549895202689024",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/hawelti/status/1019549895202689024"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-07-18",
+    "contentid": "5b4efe1fe4b0aaa7a4737b99"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1069326825728303104",
+        "url": "https://twitter.com/nflthrowback/status/1069326825728303104",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/nflthrowback/status/1069326825728303104"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-04",
+    "contentid": "5c06d770e4b0de80e89727ff"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1012368971272728577",
+        "url": "https://twitter.com/dannyctkemp/status/1012368971272728577",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/dannyctkemp/status/1012368971272728577"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-28",
+    "contentid": "5b349207e4b0bef28bb9b840"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1012365442424459265",
+        "url": "https://twitter.com/tconnellyRTE/status/1012365442424459265",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tconnellyRTE/status/1012365442424459265"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-28",
+    "contentid": "5b349207e4b0bef28bb9b840"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1012274927779475456",
+        "url": "https://twitter.com/NaomiOhReally/status/1012274927779475456",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/NaomiOhReally/status/1012274927779475456"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-28",
+    "contentid": "5b349207e4b0bef28bb9b840"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1012226140855992321",
+        "url": "https://twitter.com/jonlansman/status/1012226140855992321",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jonlansman/status/1012226140855992321"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-28",
+    "contentid": "5b349207e4b0bef28bb9b840"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1012226338776866820",
+        "url": "https://twitter.com/jonlansman/status/1012226338776866820",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jonlansman/status/1012226338776866820"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-28",
+    "contentid": "5b349207e4b0bef28bb9b840"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1012226720634679296",
+        "url": "https://twitter.com/jonlansman/status/1012226720634679296",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jonlansman/status/1012226720634679296"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-28",
+    "contentid": "5b349207e4b0bef28bb9b840"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1012226841829093376",
+        "url": "https://twitter.com/jonlansman/status/1012226841829093376",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jonlansman/status/1012226841829093376"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-28",
+    "contentid": "5b349207e4b0bef28bb9b840"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1012227006761709568",
+        "url": "https://twitter.com/jonlansman/status/1012227006761709568",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jonlansman/status/1012227006761709568"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-28",
+    "contentid": "5b349207e4b0bef28bb9b840"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1012344632695574532",
+        "url": "https://twitter.com/michaelgove/status/1012344632695574532",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/michaelgove/status/1012344632695574532"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-28",
+    "contentid": "5b349207e4b0bef28bb9b840"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1012344729172959232",
+        "url": "https://twitter.com/SamCoatesTimes/status/1012344729172959232",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SamCoatesTimes/status/1012344729172959232"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-28",
+    "contentid": "5b349207e4b0bef28bb9b840"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1012323848933593090",
+        "url": "https://twitter.com/CharlesMichel/status/1012323848933593090",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/CharlesMichel/status/1012323848933593090"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-28",
+    "contentid": "5b349207e4b0bef28bb9b840"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1012319466737238017",
+        "url": "https://twitter.com/lisaocarroll/status/1012319466737238017",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/lisaocarroll/status/1012319466737238017"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-28",
+    "contentid": "5b349207e4b0bef28bb9b840"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1012285236045144065",
+        "url": "https://twitter.com/RuthDavidsonMSP/status/1012285236045144065",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/RuthDavidsonMSP/status/1012285236045144065"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-28",
+    "contentid": "5b349207e4b0bef28bb9b840"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1012286291390664704",
+        "url": "https://twitter.com/BBCPhilipSim/status/1012286291390664704",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BBCPhilipSim/status/1012286291390664704"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-28",
+    "contentid": "5b349207e4b0bef28bb9b840"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1012269120610586624",
+        "url": "https://twitter.com/alisonthewliss/status/1012269120610586624",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/alisonthewliss/status/1012269120610586624"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-28",
+    "contentid": "5b349207e4b0bef28bb9b840"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1012284953487380480",
+        "url": "https://twitter.com/danbloom1/status/1012284953487380480",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/danbloom1/status/1012284953487380480"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-28",
+    "contentid": "5b349207e4b0bef28bb9b840"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1012274397560950789",
+        "url": "https://twitter.com/lisaocarroll/status/1012274397560950789",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/lisaocarroll/status/1012274397560950789"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-28",
+    "contentid": "5b349207e4b0bef28bb9b840"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1083178169044213761",
+        "url": "https://twitter.com/AOC/status/1083178169044213761",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AOC/status/1083178169044213761"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-01-10",
+    "contentid": "5c36b5ffe4b072dc52e6bcad"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1083179277795971073",
+        "url": "https://twitter.com/AOC/status/1083179277795971073",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AOC/status/1083179277795971073"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-01-10",
+    "contentid": "5c36b5ffe4b072dc52e6bcad"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1083094190307897345",
+        "url": "https://twitter.com/AOC/status/1083094190307897345",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AOC/status/1083094190307897345"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-01-10",
+    "contentid": "5c36b5ffe4b072dc52e6bcad"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1006885048044478465",
+        "url": "https://twitter.com/Anna_Soubry/status/1006885048044478465",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Anna_Soubry/status/1006885048044478465"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-13",
+    "contentid": "5b211546e4b06f2cac87b71c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/826660232948490242/pu/img/uFcpfDd_i6jikSFg.jpg",
+          "fields": {
+            "width": "480",
+            "height": "480",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/826660232948490242/pu/img/uFcpfDd_i6jikSFg.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "826660267341783044",
+        "url": "https://twitter.com/Phil_Lewis_/status/826660267341783044",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Phil_Lewis_/status/826660267341783044?ref_src=twsrc%5Etfw"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-07",
+    "contentid": "5899f8b6e4b09739e65f51c1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "978965098038550528",
+        "url": "https://twitter.com/BBCNewsPR/status/978965098038550528",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BBCNewsPR/status/978965098038550528"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-03-27",
+    "contentid": "5aba4236e4b0ea82609d0f0d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1201305004990193664",
+        "url": "https://twitter.com/nzherald/status/1201305004990193664",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/nzherald/status/1201305004990193664"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-12-02",
+    "contentid": "5de488048f087410d9876755"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1141022266832150530",
+        "url": "https://twitter.com/tom_watson/status/1141022266832150530",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tom_watson/status/1141022266832150530"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-06-18",
+    "contentid": "5d08ec038f08263b930f1df7"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/D3zTSmEW4AE-8aV.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1536",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/D3zTSmEW4AE-8aV.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1115999137835646976",
+        "url": "https://twitter.com/sarahrainsford/status/1115999137835646976",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/sarahrainsford/status/1115999137835646976"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-04-09",
+    "contentid": "5cac95c48f0852bbb93b4abb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1188475257780342786",
+        "url": "https://twitter.com/MeetThePress/status/1188475257780342786",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MeetThePress/status/1188475257780342786"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-10-27",
+    "contentid": "5db5614f8f08142786c51509"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1188470666712043520",
+        "url": "https://twitter.com/azarijahromi/status/1188470666712043520",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/azarijahromi/status/1188470666712043520"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-10-27",
+    "contentid": "5db5614f8f08142786c51509"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1188463044524957696",
+        "url": "https://twitter.com/florence_parly/status/1188463044524957696",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/florence_parly/status/1188463044524957696"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-10-27",
+    "contentid": "5db5614f8f08142786c51509"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1188463046060072960",
+        "url": "https://twitter.com/florence_parly/status/1188463046060072960",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/florence_parly/status/1188463046060072960"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-10-27",
+    "contentid": "5db5614f8f08142786c51509"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1188452404133584897",
+        "url": "https://twitter.com/DominicRaab/status/1188452404133584897",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/DominicRaab/status/1188452404133584897"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-10-27",
+    "contentid": "5db5614f8f08142786c51509"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1188463827324682242",
+        "url": "https://twitter.com/BorisJohnson/status/1188463827324682242",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/borisjohnson/status/1188463827324682242?s=12"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-10-27",
+    "contentid": "5db5614f8f08142786c51509"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/EH5AjYpX4AArYeX.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "683",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/EH5AjYpX4AArYeX.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1188458334086684673",
+        "url": "https://twitter.com/WhiteHouse/status/1188458334086684673",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/WhiteHouse/status/1188458334086684673"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-10-27",
+    "contentid": "5db5614f8f08142786c51509"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1188459940593197056",
+        "url": "https://twitter.com/WhiteHouse/status/1188459940593197056",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/WhiteHouse/status/1188459940593197056"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-10-27",
+    "contentid": "5db5614f8f08142786c51509"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1188461598182121472",
+        "url": "https://twitter.com/WhiteHouse/status/1188461598182121472",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/WhiteHouse/status/1188461598182121472"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-10-27",
+    "contentid": "5db5614f8f08142786c51509"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1188366280908333057",
+        "url": "https://twitter.com/MazloumAbdi/status/1188366280908333057",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MazloumAbdi/status/1188366280908333057?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E1188366280908333057&ref_url=https%3A%2F%2Fwww.cnn.com%2Fpolitics%2Flive-news%2Fabu-bakr-al-baghdadi-isis-intl-hnk%2Findex.html"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-10-27",
+    "contentid": "5db5614f8f08142786c51509"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1188372866007519232",
+        "url": "https://twitter.com/mustefabali/status/1188372866007519232",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/mustefabali/status/1188372866007519232?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E1188372866007519232&ref_url=https%3A%2F%2Fwww.cnn.com%2Fpolitics%2Flive-news%2Fabu-bakr-al-baghdadi-isis-intl-hnk%2Findex.html"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-10-27",
+    "contentid": "5db5614f8f08142786c51509"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1188384346840936448",
+        "url": "https://twitter.com/tcsavunma/status/1188384346840936448",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tcsavunma/status/1188384346840936448"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-10-27",
+    "contentid": "5db5614f8f08142786c51509"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1188264965930700801",
+        "url": "https://twitter.com/realDonaldTrump/status/1188264965930700801",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/realDonaldTrump/status/1188264965930700801"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-10-27",
+    "contentid": "5db5614f8f08142786c51509"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/EHWMV_4U4AA2Gx6.jpg",
+          "fields": {
+            "width": "872",
+            "height": "872",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/EHWMV_4U4AA2Gx6.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1186008390926917632",
+        "url": "https://twitter.com/HillaryClinton/status/1186008390926917632",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/HillaryClinton/status/1186008390926917632"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-10-20",
+    "contentid": "5dacbf7a8f0804be7279a208"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/996218345631318016/pu/img/V1Pz7BSiHRTl9UDS.jpg",
+          "fields": {
+            "width": "270",
+            "height": "480",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/996218345631318016/pu/img/V1Pz7BSiHRTl9UDS.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "996218489831473152",
+        "url": "https://twitter.com/CloeCouture/status/996218489831473152",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/CloeCouture/status/996218489831473152"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-05-16",
+    "contentid": "5afb7c7de4b03387f9ceeee1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "996462632998711297",
+        "url": "https://twitter.com/xxv/status/996462632998711297",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/xxv/status/996462632998711297"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-05-16",
+    "contentid": "5afb7c7de4b03387f9ceeee1"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/996390771367563272/pu/img/L1SuYaJvOkjwZrFe.jpg",
+          "fields": {
+            "width": "720",
+            "height": "1280",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/996390771367563272/pu/img/L1SuYaJvOkjwZrFe.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "996390813939748864",
+        "url": "https://twitter.com/earthvessquotes/status/996390813939748864",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/earthvessquotes/status/996390813939748864"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-05-16",
+    "contentid": "5afb7c7de4b03387f9ceeee1"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/996509521764810752/pu/img/jg2W3VL6zvGkfQkZ.jpg",
+          "fields": {
+            "width": "720",
+            "height": "1280",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/996509521764810752/pu/img/jg2W3VL6zvGkfQkZ.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "996509937458085893",
+        "url": "https://twitter.com/XeSaad/status/996509937458085893",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/xesaad/status/996509937458085893"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-05-16",
+    "contentid": "5afb7c7de4b03387f9ceeee1"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DdQ5YGIU0AAoAt_.jpg",
+          "fields": {
+            "width": "440",
+            "height": "293",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DdQ5YGIU0AAoAt_.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "996484539013828609",
+        "url": "https://twitter.com/azalben/status/996484539013828609",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/azalben/status/996484539013828609"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-05-16",
+    "contentid": "5afb7c7de4b03387f9ceeee1"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/1000738993963765760/pu/img/HAV9FNJVSAThB7b_.jpg",
+          "fields": {
+            "width": "720",
+            "height": "1280",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/1000738993963765760/pu/img/HAV9FNJVSAThB7b_.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1000739132501626881",
+        "url": "https://twitter.com/Adil__Brown/status/1000739132501626881",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Adil__Brown/status/1000739132501626881"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-05-28",
+    "contentid": "5b0b4ca1e4b0dec4ad85f644"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1000792585760313344",
+        "url": "https://twitter.com/Anne_Hidalgo/status/1000792585760313344",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Anne_Hidalgo/status/1000792585760313344"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-05-28",
+    "contentid": "5b0b4ca1e4b0dec4ad85f644"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1099882204098891776",
+        "url": "https://twitter.com/ITYLTSmusic/status/1099882204098891776",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ITYLTSmusic/status/1099882204098891776"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-02-22",
+    "contentid": "5c7037e6e4b00307e95a8984"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1099882258280972288",
+        "url": "https://twitter.com/petridishes/status/1099882258280972288",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/petridishes/status/1099882258280972288"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-02-22",
+    "contentid": "5c7037e6e4b00307e95a8984"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1099868463898611713",
+        "url": "https://twitter.com/TheView/status/1099868463898611713",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TheView/status/1099868463898611713"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-02-22",
+    "contentid": "5c7037e6e4b00307e95a8984"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1099859558292471808",
+        "url": "https://twitter.com/Loelof/status/1099859558292471808",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Loelof/status/1099859558292471808"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-02-22",
+    "contentid": "5c7037e6e4b00307e95a8984"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1099859999868833792",
+        "url": "https://twitter.com/Robbie323i/status/1099859999868833792",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Robbie323i/status/1099859999868833792"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-02-22",
+    "contentid": "5c7037e6e4b00307e95a8984"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/1099857726144999425/pu/img/fDLYr-VWasyCs9VR.jpg",
+          "fields": {
+            "width": "640",
+            "height": "360",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/1099857726144999425/pu/img/fDLYr-VWasyCs9VR.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1099858014381719552",
+        "url": "https://twitter.com/LightsCameraPod/status/1099858014381719552",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/LightsCameraPod/status/1099858014381719552"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-02-22",
+    "contentid": "5c7037e6e4b00307e95a8984"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/D0NyDzCVYAA0qze.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/D0NyDzCVYAA0qze.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1099848151517675521",
+        "url": "https://twitter.com/THR/status/1099848151517675521",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/THR/status/1099848151517675521"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-02-22",
+    "contentid": "5c7037e6e4b00307e95a8984"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/D0NuujwVYAci9gy.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/D0NuujwVYAci9gy.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1099844488191602688",
+        "url": "https://twitter.com/THR/status/1099844488191602688",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/THR/status/1099844488191602688"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-02-22",
+    "contentid": "5c7037e6e4b00307e95a8984"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/1099831485580890113/pu/img/1AoL8iNXMFf9dD1g.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/1099831485580890113/pu/img/1AoL8iNXMFf9dD1g.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1099832094153494530",
+        "url": "https://twitter.com/Bethanyminelle/status/1099832094153494530",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Bethanyminelle/status/1099832094153494530"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-02-22",
+    "contentid": "5c7037e6e4b00307e95a8984"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1017764397752750080",
+        "url": "https://twitter.com/alexburnsNYT/status/1017764397752750080",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/alexburnsNYT/status/1017764397752750080"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-07-13",
+    "contentid": "5b4908ede4b04dbcfcbe093f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1017073022581248000",
+        "url": "https://twitter.com/davidlitt/status/1017073022581248000",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/davidlitt/status/1017073022581248000"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-07-13",
+    "contentid": "5b4908ede4b04dbcfcbe093f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1016528765323800576",
+        "url": "https://twitter.com/ggreeneva/status/1016528765323800576",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ggreeneva/status/1016528765323800576"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-07-13",
+    "contentid": "5b4908ede4b04dbcfcbe093f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1016064902371217408",
+        "url": "https://twitter.com/SaraJBenincasa/status/1016064902371217408",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SaraJBenincasa/status/1016064902371217408"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-07-13",
+    "contentid": "5b4908ede4b04dbcfcbe093f"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/1062926430885953536/pu/img/b1FLX_kcLdoQpRG4.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/1062926430885953536/pu/img/b1FLX_kcLdoQpRG4.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1062927079350558721",
+        "url": "https://twitter.com/wills_account/status/1062927079350558721",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/wills_account/status/1062927079350558721"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-18",
+    "contentid": "5c188453e4b04062cd7913f6"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/1073734738139992064/pu/img/-091gl4wRt0qsyUP.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/1073734738139992064/pu/img/-091gl4wRt0qsyUP.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1073734854993272832",
+        "url": "https://twitter.com/marrowing/status/1073734854993272832",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/marrowing/status/1073734854993272832"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-18",
+    "contentid": "5c188453e4b04062cd7913f6"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/1073381473065947136/pu/img/ZS7qEhQyTUxOJ8C7.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/1073381473065947136/pu/img/ZS7qEhQyTUxOJ8C7.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1073386626875703296",
+        "url": "https://twitter.com/naamanzhou/status/1073386626875703296",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/naamanzhou/status/1073386626875703296"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-18",
+    "contentid": "5c188453e4b04062cd7913f6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1073795630902824960",
+        "url": "https://twitter.com/ShitpostRodeo/status/1073795630902824960",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ShitpostRodeo/status/1073795630902824960"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-18",
+    "contentid": "5c188453e4b04062cd7913f6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1076183338795368453",
+        "url": "https://twitter.com/LordAshcroft/status/1076183338795368453",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/LordAshcroft/status/1076183338795368453"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1076187833524805634",
+        "url": "https://twitter.com/GatwickExpress/status/1076187833524805634",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GatwickExpress/status/1076187833524805634"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1076185478498529280",
+        "url": "https://twitter.com/James_Chadders/status/1076185478498529280",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/James_Chadders/status/1076185478498529280"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1076184070139404289",
+        "url": "https://twitter.com/easyJet/status/1076184070139404289",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/easyJet/status/1076184070139404289"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1076183426091368449",
+        "url": "https://twitter.com/Gatwick_Airport/status/1076183426091368449",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Gatwick_Airport/status/1076183426091368449"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1076176405187182592",
+        "url": "https://twitter.com/SouthernRailUK/status/1076176405187182592",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SouthernRailUK/status/1076176405187182592"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1076176438703939584",
+        "url": "https://twitter.com/TLRailUK/status/1076176438703939584",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TLRailUK/status/1076176438703939584"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1076172218550374401",
+        "url": "https://twitter.com/Gatwick_Airport/status/1076172218550374401",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Gatwick_Airport/status/1076172218550374401"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/Du8bCtvWsAAAbXz.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1536",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/Du8bCtvWsAAAbXz.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1076108582133907459",
+        "url": "https://twitter.com/brightonsnapper/status/1076108582133907459",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/brightonsnapper/status/1076108582133907459"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/Du8Vo3IWsAYADgY.jpg",
+          "fields": {
+            "width": "1536",
+            "height": "2048",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/Du8Vo3IWsAYADgY.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1076102635730685952",
+        "url": "https://twitter.com/fperraudin/status/1076102635730685952",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/fperraudin/status/1076102635730685952"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1076067655096901632",
+        "url": "https://twitter.com/BALPApilots/status/1076067655096901632",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BALPApilots/status/1076067655096901632"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1076048049103867905",
+        "url": "https://twitter.com/danieljcarey/status/1076048049103867905",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/danieljcarey/status/1076048049103867905"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1076061748095012865",
+        "url": "https://twitter.com/mitchefi/status/1076061748095012865",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/mitchefi/status/1076061748095012865"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/Du7MSKCW0AAbblg.jpg",
+          "fields": {
+            "width": "753",
+            "height": "530",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/Du7MSKCW0AAbblg.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1076021999120596992",
+        "url": "https://twitter.com/BenQuinn75/status/1076021999120596992",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BenQuinn75/status/1076021999120596992"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1076012684879904768",
+        "url": "https://twitter.com/MsKateLyons/status/1076012684879904768",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MsKateLyons/status/1076012684879904768"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1076009460047306752",
+        "url": "https://twitter.com/MsKateLyons/status/1076009460047306752",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MsKateLyons/status/1076009460047306752"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/Du5LUSsWsAAG5PQ.jpg",
+          "fields": {
+            "width": "724",
+            "height": "975",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/Du5LUSsWsAAG5PQ.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1075880175437578241",
+        "url": "https://twitter.com/DailyMailUK/status/1075880175437578241",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/DailyMailUK/status/1075880175437578241"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/Du5IReFXQAAxJH5.jpg",
+          "fields": {
+            "width": "1622",
+            "height": "2048",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/Du5IReFXQAAxJH5.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1075876831474135040",
+        "url": "https://twitter.com/hendopolis/status/1075876831474135040",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/hendopolis/status/1075876831474135040"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1075879466298195968",
+        "url": "https://twitter.com/TheSun/status/1075879466298195968",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TheSun/status/1075879466298195968"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1075872403706798086",
+        "url": "https://twitter.com/Telegraph/status/1075872403706798086",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Telegraph/status/1075872403706798086"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/Du43dUiXcAAlck0.jpg",
+          "fields": {
+            "width": "1608",
+            "height": "2048",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/Du43dUiXcAAlck0.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1075873479012999170",
+        "url": "https://twitter.com/guardian/status/1075873479012999170",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/guardian/status/1075873479012999170"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/Du5L_osWkAUJi0Y.jpg",
+          "fields": {
+            "width": "1608",
+            "height": "2048",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/Du5L_osWkAUJi0Y.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1075880925018370053",
+        "url": "https://twitter.com/hendopolis/status/1075880925018370053",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/hendopolis/status/1075880925018370053"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1075998451538821120",
+        "url": "https://twitter.com/dawnpunter/status/1075998451538821120",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideMedia": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/dawnpunter/status/1075998451538821120"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1075995399322828801",
+        "url": "https://twitter.com/Gatwick_Airport/status/1075995399322828801",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Gatwick_Airport/status/1075995399322828801"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1075805061597589505",
+        "url": "https://twitter.com/easyJet_press/status/1075805061597589505",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/easyJet_press/status/1075805061597589505"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1075993479346417664",
+        "url": "https://twitter.com/MsKateLyons/status/1075993479346417664",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MsKateLyons/status/1075993479346417664"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1075991408622764032",
+        "url": "https://twitter.com/MsKateLyons/status/1075991408622764032",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MsKateLyons/status/1075991408622764032"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1075990091707760642",
+        "url": "https://twitter.com/MsKateLyons/status/1075990091707760642",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MsKateLyons/status/1075990091707760642"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1075912709202477056",
+        "url": "https://twitter.com/easyJet/status/1075912709202477056",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/easyJet/status/1075912709202477056"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1075982637423054848",
+        "url": "https://twitter.com/British_Airways/status/1075982637423054848",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/British_Airways/status/1075982637423054848"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1075977172546936833",
+        "url": "https://twitter.com/British_Airways/status/1075977172546936833",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/British_Airways/status/1075977172546936833"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-12-21",
+    "contentid": "5c1c6c98e4b0cebe76178f59"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1089928303543283712",
+        "url": "https://twitter.com/JamieJackson___/status/1089928303543283712",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/JamieJackson___/status/1089928303543283712"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-01-28",
+    "contentid": "5c4ed465e4b024f0efeafefe"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1089924342715170816",
+        "url": "https://twitter.com/ed_aarons/status/1089924342715170816",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ed_aarons/status/1089924342715170816"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-01-28",
+    "contentid": "5c4ed465e4b024f0efeafefe"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DyAh5NBX0AAGhT-.jpg",
+          "fields": {
+            "width": "1600",
+            "height": "800",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DyAh5NBX0AAGhT-.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1089908474874654727",
+        "url": "https://twitter.com/officialpompey/status/1089908474874654727",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/officialpompey/status/1089908474874654727"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-01-28",
+    "contentid": "5c4ed465e4b024f0efeafefe"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1089908909597487105",
+        "url": "https://twitter.com/atletienglish/status/1089908909597487105",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/atletienglish/status/1089908909597487105"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-01-28",
+    "contentid": "5c4ed465e4b024f0efeafefe"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1089852929190825984",
+        "url": "https://twitter.com/AlfredoPedulla/status/1089852929190825984",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AlfredoPedulla/status/1089852929190825984"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-01-28",
+    "contentid": "5c4ed465e4b024f0efeafefe"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1089880567867416578",
+        "url": "https://twitter.com/Ataqoz/status/1089880567867416578",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Ataqoz/status/1089880567867416578"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-01-28",
+    "contentid": "5c4ed465e4b024f0efeafefe"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1089883654740951040",
+        "url": "https://twitter.com/ed_aarons/status/1089883654740951040",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ed_aarons/status/1089883654740951040"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-01-28",
+    "contentid": "5c4ed465e4b024f0efeafefe"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1089863061282934784",
+        "url": "https://twitter.com/officialcufc/status/1089863061282934784",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/officialcufc/status/1089863061282934784"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-01-28",
+    "contentid": "5c4ed465e4b024f0efeafefe"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1089875172717404161",
+        "url": "https://twitter.com/GFFN/status/1089875172717404161",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GFFN/status/1089875172717404161"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-01-28",
+    "contentid": "5c4ed465e4b024f0efeafefe"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1089870708568743936",
+        "url": "https://twitter.com/NFFC/status/1089870708568743936",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/NFFC/status/1089870708568743936"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-01-28",
+    "contentid": "5c4ed465e4b024f0efeafefe"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1089810539495243776",
+        "url": "https://twitter.com/RCDEspanyol/status/1089810539495243776",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/RCDEspanyol/status/1089810539495243776"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-01-28",
+    "contentid": "5c4ed465e4b024f0efeafefe"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1089817598206926849",
+        "url": "https://twitter.com/JPercyTelegraph/status/1089817598206926849",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/JPercyTelegraph/status/1089817598206926849"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-01-28",
+    "contentid": "5c4ed465e4b024f0efeafefe"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/Dx_a7tMX4AAk0-A.jpg",
+          "fields": {
+            "width": "615",
+            "height": "409",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/Dx_a7tMX4AAk0-A.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1089830358827368448",
+        "url": "https://twitter.com/HLNinEngeland/status/1089830358827368448",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/HLNinEngeland/status/1089830358827368448"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-01-28",
+    "contentid": "5c4ed465e4b024f0efeafefe"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1089831124828864512",
+        "url": "https://twitter.com/AdamLeventhal/status/1089831124828864512",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AdamLeventhal/status/1089831124828864512"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-01-28",
+    "contentid": "5c4ed465e4b024f0efeafefe"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "624331829957513216",
+        "url": "https://twitter.com/DanHannanMEP/statuses/624331829957513216",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/DanHannanMEP/status/624331829957513216"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-07-24",
+    "contentid": "55b1f6f8e4b0659cb8ce4b6d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1151115215842488320",
+        "url": "https://twitter.com/TheDailyShow/status/1151115215842488320",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TheDailyShow/status/1151115215842488320"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-07-16",
+    "contentid": "5d2dd4568f08d0b6ca531a9e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "936496417694154752",
+        "url": "https://twitter.com/KRLS/status/936496417694154752",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/KRLS/status/936496417694154752"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a212a2cd658b206982cde89"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DQCVHffVwAEpFRW.jpg",
+          "fields": {
+            "width": "800",
+            "height": "450",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DQCVHffVwAEpFRW.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "936912714424664064",
+        "url": "https://twitter.com/RLWC2017/status/936912714424664064",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/RLWC2017/status/936912714424664064"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a20edcaae3bcb05d202304c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "936913271822565376",
+        "url": "https://twitter.com/steveburgess23/status/936913271822565376",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/steveburgess23/status/936913271822565376"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a20edcaae3bcb05d202304c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DQCBoaZVAAI4q4W.jpg",
+          "fields": {
+            "width": "640",
+            "height": "360",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DQCBoaZVAAI4q4W.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "936891301571604480",
+        "url": "https://twitter.com/RLWC2017/status/936891301571604480",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/RLWC2017/status/936891301571604480"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a20edcaae3bcb05d202304c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/amplify_video_thumb/936884029919342592/img/9rr-j4TJlEAkcfmU.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/amplify_video_thumb/936884029919342592/img/9rr-j4TJlEAkcfmU.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "936884325244485632",
+        "url": "https://twitter.com/RLWC2017/status/936884325244485632",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/RLWC2017/status/936884325244485632"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a20edcaae3bcb05d202304c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "936882988838559744",
+        "url": "https://twitter.com/Rewster7/status/936882988838559744",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Rewster7/status/936882988838559744"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a20edcaae3bcb05d202304c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "936656149473935360",
+        "url": "https://twitter.com/England_RL/status/936656149473935360",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/England_RL/status/936656149473935360"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a20edcaae3bcb05d202304c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "936707463205851141",
+        "url": "https://twitter.com/JonnyWilkinson/status/936707463205851141",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/JonnyWilkinson/status/936707463205851141"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a20edcaae3bcb05d202304c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DQBtQg4U8AA03WO.jpg",
+          "fields": {
+            "width": "1500",
+            "height": "1500",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DQBtQg4U8AA03WO.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "936868936271904768",
+        "url": "https://twitter.com/RLWC2017/status/936868936271904768",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/RLWC2017/status/936868936271904768"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a20edcaae3bcb05d202304c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/936872683463000066/pu/img/v0dl1R2dk8-oSiqo.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/936872683463000066/pu/img/v0dl1R2dk8-oSiqo.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "936872904133713921",
+        "url": "https://twitter.com/RLWC2017/status/936872904133713921",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/RLWC2017/status/936872904133713921"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a20edcaae3bcb05d202304c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DQBlc0wV4AAAFa-.jpg",
+          "fields": {
+            "width": "1200",
+            "height": "1200",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DQBlc0wV4AAAFa-.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "936860304377442310",
+        "url": "https://twitter.com/AusJillaroos/status/936860304377442310",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AusJillaroos/status/936860304377442310"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a20edcaae3bcb05d202304c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DQBPcU1VoAAqVFu.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DQBPcU1VoAAqVFu.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "936836079763701760",
+        "url": "https://twitter.com/AusJillaroos/status/936836079763701760",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AusJillaroos/status/936836079763701760"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a20edcaae3bcb05d202304c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DP5xh9BW4AIYKOb.jpg",
+          "fields": {
+            "width": "1920",
+            "height": "1080",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DP5xh9BW4AIYKOb.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "936308877422759936",
+        "url": "https://twitter.com/England_RL/status/936308877422759936",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/England_RL/status/936308877422759936"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a20edcaae3bcb05d202304c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "974642820987449344",
+        "url": "https://twitter.com/guardian/status/974642820987449344",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/guardian/status/974642820987449344"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-03-16",
+    "contentid": "5aabbc13e4b0f83efb46809c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "990292886083264518",
+        "url": "https://twitter.com/itsallzara/status/990292886083264518",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/itsallzara/status/990292886083264518"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-04-30",
+    "contentid": "5ae6d088e4b0ed4091d28930"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "990330619870707718",
+        "url": "https://twitter.com/7AnthonyDagher7/status/990330619870707718",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/7AnthonyDagher7/status/990330619870707718"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-04-30",
+    "contentid": "5ae6d088e4b0ed4091d28930"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "990493637715906560",
+        "url": "https://twitter.com/itsallzara/status/990493637715906560",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/itsallzara/status/990493637715906560"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-04-30",
+    "contentid": "5ae6d088e4b0ed4091d28930"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/969061228000591872/pu/img/J5D7LWOFMKw1vwh_.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/969061228000591872/pu/img/J5D7LWOFMKw1vwh_.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "969061722005884928",
+        "url": "https://twitter.com/HoustonRockets/status/969061722005884928",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/HoustonRockets/status/969061722005884928"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-03-01",
+    "contentid": "5a97f583e4b092021077ae60"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DXLQIKwUQAAGx8s.jpg",
+          "fields": {
+            "width": "1378",
+            "height": "696",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DXLQIKwUQAAGx8s.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "969065717327839233",
+        "url": "https://twitter.com/gebguddaye/status/969065717327839233",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/gebguddaye/status/969065717327839233/photo/1"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-03-01",
+    "contentid": "5a97f583e4b092021077ae60"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DXLTF9_UQAAH0t0.jpg",
+          "fields": {
+            "width": "750",
+            "height": "1334",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DXLTF9_UQAAH0t0.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "969068981960302592",
+        "url": "https://twitter.com/luke_fillmore32/status/969068981960302592",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/luke_fillmore32/status/969068981960302592"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-03-01",
+    "contentid": "5a97f583e4b092021077ae60"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451456346979061762",
+        "url": "https://twitter.com/guardian_clark/statuses/451456346979061762",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/guardian_clark/status/451456346979061762"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451456797430542336",
+        "url": "https://twitter.com/guardian_clark/statuses/451456797430542336",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/guardian_clark/status/451456797430542336"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451437336627519489",
+        "url": "https://twitter.com/JeremyCliffe/statuses/451437336627519489",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/JeremyCliffe/status/451437336627519489"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451437398086672386",
+        "url": "https://twitter.com/gideonrachman/statuses/451437398086672386",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/gideonrachman/status/451437398086672386"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451438722266193920",
+        "url": "https://twitter.com/paulwaugh/statuses/451438722266193920",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/paulwaugh/status/451438722266193920"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451438767493373952",
+        "url": "https://twitter.com/rafaelbehr/statuses/451438767493373952",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/rafaelbehr/status/451438767493373952"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451438916860907520",
+        "url": "https://twitter.com/jameskirkup/statuses/451438916860907520",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/jameskirkup/status/451438916860907520"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451440040057786368",
+        "url": "https://twitter.com/sunny_hundal/statuses/451440040057786368",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/sunny_hundal/status/451440040057786368"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451440715781115905",
+        "url": "https://twitter.com/tnewtondunn/statuses/451440715781115905",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/tnewtondunn/status/451440715781115905"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451440988880650240",
+        "url": "https://twitter.com/esmesky/statuses/451440988880650240",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/esmesky/status/451440988880650240"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451442788220284929",
+        "url": "https://twitter.com/nicholaswatt/statuses/451442788220284929",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/nicholaswatt/status/451442788220284929"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451443206816034817",
+        "url": "https://twitter.com/nicholaswatt/statuses/451443206816034817",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/nicholaswatt/status/451443206816034817"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451446401034371072",
+        "url": "https://twitter.com/JGForsyth/statuses/451446401034371072",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/JGForsyth/status/451446401034371072"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451438869805035520",
+        "url": "https://twitter.com/jameschappers/statuses/451438869805035520",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/jameschappers/status/451438869805035520"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451441674624188416",
+        "url": "https://twitter.com/christopherhope/statuses/451441674624188416",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/christopherhope/status/451441674624188416"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451434781788872704",
+        "url": "https://twitter.com/hugorifkind/statuses/451434781788872704",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/hugorifkind/status/451434781788872704"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451433474738880512",
+        "url": "https://twitter.com/toryboypierce/statuses/451433474738880512",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/toryboypierce/status/451433474738880512"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451433456137142272",
+        "url": "https://twitter.com/rafaelbehr/statuses/451433456137142272",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/rafaelbehr/status/451433456137142272"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451433930936553473",
+        "url": "https://twitter.com/sunny_hundal/statuses/451433930936553473",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/sunny_hundal/status/451433930936553473"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451433990667632640",
+        "url": "https://twitter.com/mehdirhasan/statuses/451433990667632640",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/mehdirhasan/status/451433990667632640"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451436443689566208",
+        "url": "https://twitter.com/georgeeaton/statuses/451436443689566208",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/georgeeaton/status/451436443689566208"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451436505366806528",
+        "url": "https://twitter.com/tombradby/statuses/451436505366806528",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/tombradby/status/451436505366806528"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451438935143899136",
+        "url": "https://twitter.com/jennirsl/statuses/451438935143899136",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/jennirsl/status/451438935143899136"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451437954179674112",
+        "url": "https://twitter.com/Sun_Politics/statuses/451437954179674112",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/Sun_Politics/status/451437954179674112"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451423863902334976",
+        "url": "https://twitter.com/Demos/statuses/451423863902334976",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/Demos/status/451423863902334976"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451434364501762048",
+        "url": "https://twitter.com/Sun_Politics/statuses/451434364501762048",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/Sun_Politics/status/451434364501762048"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451418409801351169",
+        "url": "https://twitter.com/adamboultonSKY/statuses/451418409801351169",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/adamboultonSKY/status/451418409801351169"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451415205726388224",
+        "url": "https://twitter.com/jameschappers/statuses/451415205726388224",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/jameschappers/status/451415205726388224"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451416413782417408",
+        "url": "https://twitter.com/maitlis/statuses/451416413782417408",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/maitlis/status/451416413782417408"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451415693557514240",
+        "url": "https://twitter.com/SophyRidgeSky/statuses/451415693557514240",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/SophyRidgeSky/status/451415693557514240"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451413635676794880",
+        "url": "https://twitter.com/rowenamason/statuses/451413635676794880",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/rowenamason/status/451413635676794880"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451400163358416896",
+        "url": "https://twitter.com/LordAshcroft/statuses/451400163358416896",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/LordAshcroft/status/451400163358416896"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451401629007638528",
+        "url": "https://twitter.com/oflynndirector/statuses/451401629007638528",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/oflynndirector/status/451401629007638528"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "451292065377161217",
+        "url": "https://twitter.com/LibDemPress/statuses/451292065377161217",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/LibDemPress/status/451292065377161217"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-04-02",
+    "contentid": "533c1a2de4b040af4c4db49e"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/EWf0C4JWkAI5N57.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/EWf0C4JWkAI5N57.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1254252640399249408",
+        "url": "https://twitter.com/nbcsnl/status/1254252640399249408",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/nbcsnl/status/1254252640399249408?ref_src=twsrc%5Etfw"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-04-26",
+    "contentid": "5ea5729a8f08e05690dc4c9a"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009475595892350978",
+        "url": "https://twitter.com/BethRigby/status/1009475595892350978",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BethRigby/status/1009475595892350978"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009476751108567040",
+        "url": "https://twitter.com/Keir_Starmer/status/1009476751108567040",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Keir_Starmer/status/1009476751108567040"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/1008662467835256832/pu/img/P8DSMfDS9uALX8Y5.jpg",
+          "fields": {
+            "width": "1440",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/1008662467835256832/pu/img/P8DSMfDS9uALX8Y5.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1009467509878263808",
+        "url": "https://twitter.com/UKHouseofLords/status/1009467509878263808",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/UKHouseofLords/status/1009467509878263808"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009449749173407745",
+        "url": "https://twitter.com/KirstyStricklan/status/1009449749173407745",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/KirstyStricklan/status/1009449749173407745"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009429491263967233",
+        "url": "https://twitter.com/PickardJE/status/1009429491263967233",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/PickardJE/status/1009429491263967233"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009455379393273857",
+        "url": "https://twitter.com/bbclaurak/status/1009455379393273857",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bbclaurak/status/1009455379393273857"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009458050749681664",
+        "url": "https://twitter.com/LibbyWienerITV/status/1009458050749681664",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/LibbyWienerITV/status/1009458050749681664"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009449102181093379",
+        "url": "https://twitter.com/SamCoatesTimes/status/1009449102181093379",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SamCoatesTimes/status/1009449102181093379"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009444425641144320",
+        "url": "https://twitter.com/Peston/status/1009444425641144320",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Peston/status/1009444425641144320"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009437040893661184",
+        "url": "https://twitter.com/CarolineFlintMP/status/1009437040893661184",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/CarolineFlintMP/status/1009437040893661184"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009437897509007361",
+        "url": "https://twitter.com/JGForsyth/status/1009437897509007361",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/JGForsyth/status/1009437897509007361"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009418585880612864",
+        "url": "https://twitter.com/bbclaurak/status/1009418585880612864",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideMedia": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bbclaurak/status/1009418585880612864"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009437723982225409",
+        "url": "https://twitter.com/tnewtondunn/status/1009437723982225409",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tnewtondunn/status/1009437723982225409"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009437471803953157",
+        "url": "https://twitter.com/gordonrayner/status/1009437471803953157",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/gordonrayner/status/1009437471803953157"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009437573633183744",
+        "url": "https://twitter.com/angelaeagle/status/1009437573633183744",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/angelaeagle/status/1009437573633183744"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009417887898132481",
+        "url": "https://twitter.com/bbclaurak/status/1009417887898132481",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bbclaurak/status/1009417887898132481"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DgIr3YOXUAEdsLM.jpg",
+          "fields": {
+            "width": "1536",
+            "height": "2048",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DgIr3YOXUAEdsLM.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1009417498486243328",
+        "url": "https://twitter.com/bbclaurak/status/1009417498486243328",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bbclaurak/status/1009417498486243328"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009413014595014656",
+        "url": "https://twitter.com/johnprescott/status/1009413014595014656",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/johnprescott/status/1009413014595014656"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009395951478493185",
+        "url": "https://twitter.com/nicholaswatt/status/1009395951478493185",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/nicholaswatt/status/1009395951478493185"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009410146785726465",
+        "url": "https://twitter.com/lewis_goodall/status/1009410146785726465",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/lewis_goodall/status/1009410146785726465"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009411920020037632",
+        "url": "https://twitter.com/lewis_goodall/status/1009411920020037632",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/lewis_goodall/status/1009411920020037632"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009413396125704193",
+        "url": "https://twitter.com/lewis_goodall/status/1009413396125704193",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/lewis_goodall/status/1009413396125704193"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DgIlOfSWsAEcipi.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1536",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DgIlOfSWsAEcipi.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1009410198904147969",
+        "url": "https://twitter.com/bbclaurak/status/1009410198904147969",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bbclaurak/status/1009410198904147969"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009409271153463296",
+        "url": "https://twitter.com/GuardianHeather/status/1009409271153463296",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GuardianHeather/status/1009409271153463296"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009409140282847232",
+        "url": "https://twitter.com/GuardianHeather/status/1009409140282847232",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GuardianHeather/status/1009409140282847232"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009406479470821378",
+        "url": "https://twitter.com/faisalislam/status/1009406479470821378",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/faisalislam/status/1009406479470821378"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009400700185595904",
+        "url": "https://twitter.com/bbclaurak/status/1009400700185595904",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bbclaurak/status/1009400700185595904"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009401234493722624",
+        "url": "https://twitter.com/bbclaurak/status/1009401234493722624",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bbclaurak/status/1009401234493722624"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009400496208179200",
+        "url": "https://twitter.com/timsculthorpe/status/1009400496208179200",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/timsculthorpe/status/1009400496208179200"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009400185208926208",
+        "url": "https://twitter.com/SamCoatesTimes/status/1009400185208926208",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SamCoatesTimes/status/1009400185208926208"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009399963443519489",
+        "url": "https://twitter.com/lisanandy/status/1009399963443519489",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/lisanandy/status/1009399963443519489"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009398291052691457",
+        "url": "https://twitter.com/BBCPolitics/status/1009398291052691457",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BBCPolitics/status/1009398291052691457"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009390395002966017",
+        "url": "https://twitter.com/patrick_kidd/status/1009390395002966017",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/patrick_kidd/status/1009390395002966017"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009389975471837189",
+        "url": "https://twitter.com/GeorgeWParker/status/1009389975471837189",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GeorgeWParker/status/1009389975471837189"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009101940310110208",
+        "url": "https://twitter.com/daily_politics/status/1009101940310110208",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/daily_politics/status/1009101940310110208"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009374237776281602",
+        "url": "https://twitter.com/RobDotHutton/status/1009374237776281602",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/RobDotHutton/status/1009374237776281602"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009381625891868673",
+        "url": "https://twitter.com/George_Osborne/status/1009381625891868673",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/George_Osborne/status/1009381625891868673"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009216150146863105",
+        "url": "https://twitter.com/SamGyimah/status/1009216150146863105",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SamGyimah/status/1009216150146863105"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009369518953680896",
+        "url": "https://twitter.com/labourwhips/status/1009369518953680896",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/labourwhips/status/1009369518953680896"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009371595410952192",
+        "url": "https://twitter.com/CommonsLeader/status/1009371595410952192",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/CommonsLeader/status/1009371595410952192"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009362891932422146",
+        "url": "https://twitter.com/jessicaelgot/status/1009362891932422146",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jessicaelgot/status/1009362891932422146"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009363131024465920",
+        "url": "https://twitter.com/PippaCrerar/status/1009363131024465920",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/PippaCrerar/status/1009363131024465920"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009345680966549504",
+        "url": "https://twitter.com/tnewtondunn/status/1009345680966549504",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tnewtondunn/status/1009345680966549504"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009326801187950592",
+        "url": "https://twitter.com/labourwhips/status/1009326801187950592",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/labourwhips/status/1009326801187950592"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1009097843464785920",
+        "url": "https://twitter.com/Anna_Soubry/status/1009097843464785920",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Anna_Soubry/status/1009097843464785920"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-06-20",
+    "contentid": "5b2a0e23e4b06f2cac87fb2c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/CRBkUn3WwAAA69B.jpg",
+          "fields": {
+            "width": "638",
+            "height": "558",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/CRBkUn3WwAAA69B.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "653132274528055296",
+        "url": "https://twitter.com/jimwaterson/statuses/653132274528055296",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideMedia": "true",
+        "originalUrl": "https://twitter.com/jimwaterson/status/653132274528055296"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-10-12",
+    "contentid": "561ba2e3e4b027b549471d15"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "653519783288246272",
+        "url": "https://twitter.com/carldinnen/statuses/653519783288246272",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideMedia": "false",
+        "originalUrl": "https://twitter.com/carldinnen/status/653519783288246272"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-10-12",
+    "contentid": "561ba2e3e4b027b549471d15"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "976924813234237443",
+        "url": "https://twitter.com/RandPaul/status/976924813234237443",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/RandPaul/status/976924813234237443"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-03-22",
+    "contentid": "5ab3dc19e4b044506eec167b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "980175772206993409",
+        "url": "https://twitter.com/Deadspin/status/980175772206993409",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Deadspin/status/980175772206993409"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-04-02",
+    "contentid": "5ac249d1e4b06ca6b916416b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "975575855366680576",
+        "url": "https://twitter.com/ChronicleBooks/status/975575855366680576",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ChronicleBooks/status/975575855366680576"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-03-22",
+    "contentid": "5ab31b68e4b01a4d38ba8f21"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1160904040907235329",
+        "url": "https://twitter.com/ReutersJamie/status/1160904040907235329",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ReutersJamie/status/1160904040907235329"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-08-12",
+    "contentid": "5d5101eb8f084f687f354e04"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1160893442324668416",
+        "url": "https://twitter.com/Birdyword/status/1160893442324668416",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Birdyword/status/1160893442324668416"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-08-12",
+    "contentid": "5d5101eb8f084f687f354e04"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1160887093306056706",
+        "url": "https://twitter.com/ABC/status/1160887093306056706",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ABC/status/1160887093306056706"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-08-12",
+    "contentid": "5d5101eb8f084f687f354e04"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1160485176478187522",
+        "url": "https://twitter.com/Versace/status/1160485176478187522",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Versace/status/1160485176478187522"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-08-12",
+    "contentid": "5d5101eb8f084f687f354e04"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/EBw6SgfVAAEFgRZ.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "768",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/EBw6SgfVAAEFgRZ.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1160866906473000960",
+        "url": "https://twitter.com/Birdyword/status/1160866906473000960",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Birdyword/status/1160866906473000960"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-08-12",
+    "contentid": "5d5101eb8f084f687f354e04"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/EBw69bcXUAED6n7.png",
+          "fields": {
+            "width": "1521",
+            "height": "856",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/EBw69bcXUAED6n7.png"
+          },
+          "mimeType": "image/png",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1160867636315643904",
+        "url": "https://twitter.com/CityIndex/status/1160867636315643904",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/CityIndex/status/1160867636315643904"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-08-12",
+    "contentid": "5d5101eb8f084f687f354e04"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/EBw1L_0X4AASZb5.jpg",
+          "fields": {
+            "width": "775",
+            "height": "344",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/EBw1L_0X4AASZb5.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1160861286332338176",
+        "url": "https://twitter.com/TheStalwart/status/1160861286332338176",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TheStalwart/status/1160861286332338176"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-08-12",
+    "contentid": "5d5101eb8f084f687f354e04"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "517717315660832768",
+        "url": "https://twitter.com/cinematicsoul/statuses/517717315660832768",
+        "html": "REDACTED",
+        "role": "supporting",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/cinematicsoul/status/517717315660832768"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-10-02",
+    "contentid": "542d63fbe4b0cd82a095e890"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049615940646780928",
+        "url": "https://twitter.com/BBCArchive/status/1049615940646780928",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BBCArchive/status/1049615940646780928"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-19",
+    "contentid": "5bf2d544e4b07e5fcd49dc3f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1064126048718282753",
+        "url": "https://twitter.com/BBC3CR/status/1064126048718282753",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BBC3CR/status/1064126048718282753"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-19",
+    "contentid": "5bf2d544e4b07e5fcd49dc3f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1233130604436369409",
+        "url": "https://twitter.com/tedcruz/status/1233130604436369409",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tedcruz/status/1233130604436369409"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-02-28",
+    "contentid": "5e5946968f0811db2fb009b7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1233409167085449216",
+        "url": "https://twitter.com/AOC/status/1233409167085449216",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AOC/status/1233409167085449216"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-02-28",
+    "contentid": "5e5946968f0811db2fb009b7"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/EH21bGkWkAU2PzK.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/EH21bGkWkAU2PzK.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1188305944662417408",
+        "url": "https://twitter.com/nbcsnl/status/1188305944662417408",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/nbcsnl/status/1188305944662417408"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-10-27",
+    "contentid": "5db578d08f08993584c8bbbc"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/EH24g5uXUAAgSM6.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/EH24g5uXUAAgSM6.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1188309315158970368",
+        "url": "https://twitter.com/nbcsnl/status/1188309315158970368",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/nbcsnl/status/1188309315158970368"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-10-27",
+    "contentid": "5db578d08f08993584c8bbbc"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1133117290273107969",
+        "url": "https://twitter.com/antsharwood/status/1133117290273107969",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/antsharwood/status/1133117290273107969"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-27",
+    "contentid": "5cec6aaa8f08cb6183377167"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/D7m5eIoU0AArJpZ.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "497",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/D7m5eIoU0AArJpZ.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1133140717100867585",
+        "url": "https://twitter.com/_hotham/status/1133140717100867585",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/_hotham/status/1133140717100867585?s=20"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-27",
+    "contentid": "5cec6aaa8f08cb6183377167"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/1132901297655435264/pu/img/4r9p2IPA9R5p9czh.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "1280",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/1132901297655435264/pu/img/4r9p2IPA9R5p9czh.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1132901393377910784",
+        "url": "https://twitter.com/ThredboResort/status/1132901393377910784",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ThredboResort/status/1132901393377910784"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-27",
+    "contentid": "5cec6aaa8f08cb6183377167"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/D7igolpVUAA-JwM.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1365",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/D7igolpVUAA-JwM.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1132831935800139776",
+        "url": "https://twitter.com/PerisherResort/status/1132831935800139776",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/PerisherResort/status/1132831935800139776?s=20"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-27",
+    "contentid": "5cec6aaa8f08cb6183377167"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/D7jc1gnUEAA5g5d.jpg",
+          "fields": {
+            "width": "768",
+            "height": "1024",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/D7jc1gnUEAA5g5d.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1132898139281616896",
+        "url": "https://twitter.com/TonyDoran09/status/1132898139281616896",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TonyDoran09/status/1132898139281616896?s=20"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-27",
+    "contentid": "5cec6aaa8f08cb6183377167"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/D7iCOIbU8AAvl_m.jpg",
+          "fields": {
+            "width": "750",
+            "height": "750",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/D7iCOIbU8AAvl_m.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1132798491669884928",
+        "url": "https://twitter.com/lyndal_conroy/status/1132798491669884928",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/lyndal_conroy/status/1132798491669884928?s=20"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-27",
+    "contentid": "5cec6aaa8f08cb6183377167"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/Dg_N9zkU8AATRQC.jpg",
+          "fields": {
+            "width": "2039",
+            "height": "1149",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/Dg_N9zkU8AATRQC.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1013254910597402626",
+        "url": "https://twitter.com/sleemol/status/1013254910597402626",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/sleemol/status/1013254910597402626?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E1013254910597402626&ref_url=https%3A%2F%2Fwww.pedestrian.tv%2Fnews%2Fsky-news-apologises-appalling-comments%2F"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-07-01",
+    "contentid": "5b3888f9e4b05bcf5a6955c3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1013293086493949952",
+        "url": "https://twitter.com/SkyNewsAust/status/1013293086493949952",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SkyNewsAust/status/1013293086493949952"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-07-01",
+    "contentid": "5b3888f9e4b05bcf5a6955c3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "964953250691731457",
+        "url": "https://twitter.com/britneyspears/status/964953250691731457",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/britneyspears/status/964953250691731457"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-18",
+    "contentid": "5a893542e4b066a6256bc81c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "990612207586217989",
+        "url": "https://twitter.com/lfc_belaraby/status/990612207586217989",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/lfc_belaraby/status/990612207586217989"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-05-05",
+    "contentid": "5aee2217e4b0abe4e3cedf69"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "990631505008480257",
+        "url": "https://twitter.com/SC_ESPN/status/990631505008480257",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SC_ESPN/status/990631505008480257"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-05-05",
+    "contentid": "5aee2217e4b0abe4e3cedf69"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "978553257143386112",
+        "url": "https://twitter.com/Tony_Burke/status/978553257143386112",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Tony_Burke/status/978553257143386112"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-03-27",
+    "contentid": "5ab9cba8e4b0ce013f86c7bc"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4UP1GdXAAEBo15.jpg",
+          "fields": {
+            "width": "682",
+            "height": "512",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4UP1GdXAAEBo15.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830087969306472448",
+        "url": "https://twitter.com/GaurivanGulik/status/830087969306472448",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://mobile.twitter.com/GaurivanGulik/status/830087969306472448/photo/1"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-08",
+    "contentid": "589b54cfe4b08bb4fbbea00c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829365962755420161",
+        "url": "https://twitter.com/fqdayib/status/829365962755420161",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/fqdayib/status/829365962755420161"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-08",
+    "contentid": "589b4e71e4b08bb4fbbe9fec"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "828687260396695553",
+        "url": "https://twitter.com/cwardell/status/828687260396695553",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/cwardell/status/828687260396695553"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c4f6ae4b01b5caf3ce535"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "828691563555454976",
+        "url": "https://twitter.com/justinhendrix/status/828691563555454976",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/justinhendrix/status/828691563555454976"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c4f6ae4b01b5caf3ce535"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "828711889458847746",
+        "url": "https://twitter.com/justinhendrix/status/828711889458847746",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/justinhendrix/status/828711889458847746"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c4f6ae4b01b5caf3ce535"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829114287696277504",
+        "url": "https://twitter.com/weprogressives/status/829114287696277504",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/weprogressives/status/829114287696277504?ref_src=twsrc%5Etfw"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c4f6ae4b01b5caf3ce535"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829689845240954882",
+        "url": "https://twitter.com/Note2PresBannon/status/829689845240954882",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Note2PresBannon/status/829689845240954882"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c4f6ae4b01b5caf3ce535"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4B-OLmVUAAPB1U.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1536",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4B-OLmVUAAPB1U.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "828801533898809344",
+        "url": "https://twitter.com/Note2PresBannon/status/828801533898809344",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Note2PresBannon/status/828801533898809344"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c4f6ae4b01b5caf3ce535"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/827133234131656704/pu/img/0Vwwlxdp8HfnZGk-.jpg",
+          "fields": {
+            "width": "540",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/827133234131656704/pu/img/0Vwwlxdp8HfnZGk-.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "827133266708803584",
+        "url": "https://twitter.com/TIME/status/827133266708803584",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TIME/status/827133266708803584"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c4f6ae4b01b5caf3ce535"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "828575949268606977",
+        "url": "https://twitter.com/realDonaldTrump/status/828575949268606977",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/realDonaldTrump/status/828575949268606977"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c4f6ae4b01b5caf3ce535"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "828445886925508608",
+        "url": "https://twitter.com/micahflee/status/828445886925508608",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/micahflee/status/828445886925508608"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c4f6ae4b01b5caf3ce535"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4OD1QMWMAAK9TQ.jpg",
+          "fields": {
+            "width": "1512",
+            "height": "2016",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4OD1QMWMAAK9TQ.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829651749745094656",
+        "url": "https://twitter.com/CZSecStateEU/status/829651749745094656",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/CZSecStateEU/status/829651749745094656"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c2ab4e4b01b5caf3ce487"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829691923212431360",
+        "url": "https://twitter.com/faisalislam/status/829691923212431360",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/faisalislam/status/829691923212431360"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c2ab4e4b01b5caf3ce487"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829653810129883138",
+        "url": "https://twitter.com/labourlewis/status/829653810129883138",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/labourlewis/status/829653810129883138"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c2ab4e4b01b5caf3ce487"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/829673253081866241/pu/img/U10Ai5GZGdcSOUvD.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "576",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/829673253081866241/pu/img/U10Ai5GZGdcSOUvD.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829673572142546944",
+        "url": "https://twitter.com/singharj/status/829673572142546944",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/singharj/status/829673572142546944"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c2ab4e4b01b5caf3ce487"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829645268228399105",
+        "url": "https://twitter.com/willquince/status/829645268228399105",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/willquince/status/829645268228399105"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c2ab4e4b01b5caf3ce487"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829631898649522176",
+        "url": "https://twitter.com/LabourLordsUK/status/829631898649522176",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/LabourLordsUK/status/829631898649522176"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c2ab4e4b01b5caf3ce487"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829606870251929601",
+        "url": "https://twitter.com/JamieMcConkey/status/829606870251929601",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/JamieMcConkey/status/829606870251929601"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c2ab4e4b01b5caf3ce487"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829436790763315207",
+        "url": "https://twitter.com/jeremycorbyn/status/829436790763315207",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jeremycorbyn/status/829436790763315207"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c2ab4e4b01b5caf3ce487"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829719738636972032",
+        "url": "https://twitter.com/Livesquawk/status/829719738636972032",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Livesquawk/status/829719738636972032"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c1289e4b08bb4fbbea2e8"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4O-jo1UEAM3rhx.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4O-jo1UEAM3rhx.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829716283595780097",
+        "url": "https://twitter.com/IMFSpokesperson/status/829716283595780097",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/IMFSpokesperson/status/829716283595780097"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c1289e4b08bb4fbbea2e8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829714246720065536",
+        "url": "https://twitter.com/KaterinaSokou/status/829714246720065536",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/KaterinaSokou/status/829714246720065536"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c1289e4b08bb4fbbea2e8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829718429930311680",
+        "url": "https://twitter.com/nasoskook/status/829718429930311680",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/nasoskook/status/829718429930311680"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c1289e4b08bb4fbbea2e8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829702207821971457",
+        "url": "https://twitter.com/Elbarbie/status/829702207821971457",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Elbarbie/status/829702207821971457"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c1289e4b08bb4fbbea2e8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829585879895257089",
+        "url": "https://twitter.com/unilincoln/status/829585879895257089",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/unilincoln/status/829585879895257089"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c1289e4b08bb4fbbea2e8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829692000576401409",
+        "url": "https://twitter.com/PHammondMP/status/829692000576401409",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/PHammondMP/status/829692000576401409"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c1289e4b08bb4fbbea2e8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829666061368836096",
+        "url": "https://twitter.com/ByRobDavies/status/829666061368836096",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ByRobDavies/status/829666061368836096"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c1289e4b08bb4fbbea2e8"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829665060159180801",
+        "url": "https://twitter.com/ByRobDavies/status/829665060159180801",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ByRobDavies/status/829665060159180801"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c1289e4b08bb4fbbea2e8"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4NsmMPUkAAVjK8.jpg",
+          "fields": {
+            "width": "958",
+            "height": "598",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4NsmMPUkAAVjK8.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829626162020179968",
+        "url": "https://twitter.com/ekathimerini/status/829626162020179968",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ekathimerini/status/829626162020179968"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c1289e4b08bb4fbbea2e8"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4L_XJyW8AE3JD0.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1156",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4L_XJyW8AE3JD0.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829510151522525188",
+        "url": "https://twitter.com/TheDailyShow/status/829510151522525188",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TheDailyShow/status/829510151522525188"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c785ee4b01b5caf3ce602"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C3SOsiYWEAACK2k.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1365",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C3SOsiYWEAACK2k.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "825441704442486784",
+        "url": "https://twitter.com/JustinTrudeau/status/825441704442486784",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/JustinTrudeau/status/825441704442486784"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-08",
+    "contentid": "589b8f65e4b08bb4fbbea11c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829943246071570432",
+        "url": "https://twitter.com/lost_auryn/status/829943246071570432",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/lost_auryn/status/829943246071570432"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829941161108262912",
+        "url": "https://twitter.com/Ausgrid/status/829941161108262912",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Ausgrid/status/829941161108262912"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829932076719693825",
+        "url": "https://twitter.com/Ausgrid/status/829932076719693825",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Ausgrid/status/829932076719693825"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829935621380542464",
+        "url": "https://twitter.com/Ausgrid/status/829935621380542464",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Ausgrid/status/829935621380542464"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829885425653211136",
+        "url": "https://twitter.com/Ausgrid/status/829885425653211136",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Ausgrid/status/829885425653211136"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829931078089527298",
+        "url": "https://twitter.com/BOM_NSW/status/829931078089527298",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BOM_NSW/status/829931078089527298"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829929903113924608",
+        "url": "https://twitter.com/BOM_NSW/status/829929903113924608",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BOM_NSW/status/829929903113924608"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4SARNoUoAMopBo.jpg",
+          "fields": {
+            "width": "1080",
+            "height": "1920",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4SARNoUoAMopBo.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829929303013941251",
+        "url": "https://twitter.com/NicSommer/status/829929303013941251",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/NicSommer/status/829929303013941251"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4R-PoPVMAEkAU-.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1536",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4R-PoPVMAEkAU-.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829927067026288640",
+        "url": "https://twitter.com/Perksy_73/status/829927067026288640",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Perksy_73/status/829927067026288640"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4R2WgUUkAAHi-Y.jpg",
+          "fields": {
+            "width": "713",
+            "height": "439",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4R2WgUUkAAHi-Y.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829918364063657984",
+        "url": "https://twitter.com/BOM_NSW/status/829918364063657984",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BOM_NSW/status/829918364063657984"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829908102120038400",
+        "url": "https://twitter.com/NSWRFS/status/829908102120038400",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/NSWRFS/status/829908102120038400"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829910390196760576",
+        "url": "https://twitter.com/lizfarquhar/status/829910390196760576",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/lizfarquhar/status/829910390196760576"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829888847051763712",
+        "url": "https://twitter.com/GiselleWak/status/829888847051763712",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GiselleWak/status/829888847051763712"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829895623079976960",
+        "url": "https://twitter.com/GiselleWak/status/829895623079976960",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GiselleWak/status/829895623079976960"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4RvwvVVcAAfWuQ.jpg",
+          "fields": {
+            "width": "750",
+            "height": "211",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4RvwvVVcAAfWuQ.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829911122337599488",
+        "url": "https://twitter.com/mmcgowan569/status/829911122337599488",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/mmcgowan569/status/829911122337599488"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829907038234750976",
+        "url": "https://twitter.com/TristanJMeyers/status/829907038234750976",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TristanJMeyers/status/829907038234750976"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4RiyZOUYAAwhsY.jpg",
+          "fields": {
+            "width": "815",
+            "height": "1211",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4RiyZOUYAAwhsY.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829896991974961153",
+        "url": "https://twitter.com/mlle_elle/status/829896991974961153",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/mlle_elle/status/829896991974961153"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829893352585719808",
+        "url": "https://twitter.com/NSWRFS/status/829893352585719808",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/NSWRFS/status/829893352585719808"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829883910330871809",
+        "url": "https://twitter.com/AdamBandt/status/829883910330871809",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/adambandt/status/829883910330871809"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4RG3tJVMAE6ASe.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1536",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4RG3tJVMAE6ASe.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829866189690068992",
+        "url": "https://twitter.com/TessaHardy9/status/829866189690068992",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TessaHardy9/status/829866189690068992"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4RWRZpUoAArQYk.jpg",
+          "fields": {
+            "width": "1180",
+            "height": "626",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4RWRZpUoAArQYk.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829883107616579584",
+        "url": "https://twitter.com/lukasmarshall/status/829883107616579584",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/lukasmarshall/status/829883107616579584"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4RUbBTUcAA_XGW.jpg",
+          "fields": {
+            "width": "1632",
+            "height": "1224",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4RUbBTUcAA_XGW.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829881107533307904",
+        "url": "https://twitter.com/NSWRFS/status/829881107533307904",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/NSWRFS/status/829881107533307904"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829876397262983168",
+        "url": "https://twitter.com/LiveTrafficNSW/status/829876397262983168",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/LiveTrafficNSW/status/829876397262983168"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829878440731955200",
+        "url": "https://twitter.com/NSWRFS/status/829878440731955200",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/NSWRFS/status/829878440731955200"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829871183017291777",
+        "url": "https://twitter.com/NSWRFS/status/829871183017291777",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/NSWRFS/status/829871183017291777"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829868656578359296",
+        "url": "https://twitter.com/NSWRFS/status/829868656578359296",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/NSWRFS/status/829868656578359296"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829841742698467332",
+        "url": "https://twitter.com/PSCouncil/status/829841742698467332",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/PSCouncil/status/829841742698467332"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829861276650131456",
+        "url": "https://twitter.com/DaisyHuntly/status/829861276650131456",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/DaisyHuntly/status/829861276650131456"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829864791636205568",
+        "url": "https://twitter.com/Tony_Burke/status/829864791636205568",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Tony_Burke/status/829864791636205568"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829863328948305920",
+        "url": "https://twitter.com/AdrienneFranci1/status/829863328948305920",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AdrienneFranci1/status/829863328948305920"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4QJuP_VUAA3e-q.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1365",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4QJuP_VUAA3e-q.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829799076354879489",
+        "url": "https://twitter.com/triplejHack/status/829799076354879489",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/triplejHack/status/829799076354879489"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829833943314673666",
+        "url": "https://twitter.com/WIRES_NSW/status/829833943314673666",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/WIRES_NSW/status/829833943314673666"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4Q5gbeVMAEFyuQ.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "576",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4Q5gbeVMAEFyuQ.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829851470962925568",
+        "url": "https://twitter.com/jlmcarthur4/status/829851470962925568",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jlmcarthur4/status/829851470962925568"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/C4Qrr1DUYAA853X.jpg",
+          "fields": {
+            "width": "320",
+            "height": "240",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/C4Qrr1DUYAA853X.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829836274580090881",
+        "url": "https://twitter.com/Kylie_Lovers23/status/829836274580090881",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Kylie_Lovers23/status/829836274580090881"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/C4QwkvvVYAEprwj.jpg",
+          "fields": {
+            "width": "320",
+            "height": "240",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/C4QwkvvVYAEprwj.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829841647286439936",
+        "url": "https://twitter.com/mariac/status/829841647286439936",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/mariac/status/829841647286439936"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/C4QqBYFUcAEdnCr.jpg",
+          "fields": {
+            "width": "222",
+            "height": "126",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/C4QqBYFUcAEdnCr.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829834579125022720",
+        "url": "https://twitter.com/ShesOnTheMoney/status/829834579125022720",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ShesOnTheMoney/status/829834579125022720"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/C4QsKDDVMAEYl5E.jpg",
+          "fields": {
+            "width": "480",
+            "height": "356",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/C4QsKDDVMAEYl5E.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829836801367957504",
+        "url": "https://twitter.com/wesmantooth4774/status/829836801367957504",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/wesmantooth4774/status/829836801367957504"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4QvwRmUkAAjVAV.jpg",
+          "fields": {
+            "width": "442",
+            "height": "333",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4QvwRmUkAAjVAV.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829840746723151872",
+        "url": "https://twitter.com/brooke_power/status/829840746723151872",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/brooke_power/status/829840746723151872"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/C4QwMv6VMAAkWC2.jpg",
+          "fields": {
+            "width": "400",
+            "height": "274",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/C4QwMv6VMAAkWC2.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829841246449328129",
+        "url": "https://twitter.com/ScottCragg/status/829841246449328129",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ScottCragg/status/829841246449328129"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/C4QpeIfUYAAhi1F.jpg",
+          "fields": {
+            "width": "498",
+            "height": "372",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/C4QpeIfUYAAhi1F.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829833837207105537",
+        "url": "https://twitter.com/sensachanel_/status/829833837207105537",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/sensachanel_/status/829833837207105537"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829851801817985024",
+        "url": "https://twitter.com/P_B_Wee/status/829851801817985024",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/P_B_Wee/status/829851801817985024"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4QfN9VUYAAACx6.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "2048",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4QfN9VUYAAACx6.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829822591808311296",
+        "url": "https://twitter.com/mlle_elle/status/829822591808311296",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/mlle_elle/status/829822591808311296"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4Q1sm9UkAArTrT.jpg",
+          "fields": {
+            "width": "657",
+            "height": "481",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4Q1sm9UkAArTrT.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829847376147869696",
+        "url": "https://twitter.com/mlle_elle/status/829847376147869696",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/mlle_elle/status/829847376147869696"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4QwGsnVMAAYvkn.jpg",
+          "fields": {
+            "width": "940",
+            "height": "627",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4QwGsnVMAAYvkn.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829841216179023872",
+        "url": "https://twitter.com/abcnews/status/829841216179023872",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/abcnews/status/829841216179023872"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4QOEV1VMAE_kv4.jpg",
+          "fields": {
+            "width": "480",
+            "height": "673",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4QOEV1VMAE_kv4.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829803719566897152",
+        "url": "https://twitter.com/GregBarila/status/829803719566897152",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GregBarila/status/829803719566897152"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4QeK4OVYAQO6uP.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "768",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4QeK4OVYAQO6uP.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829821405659222016",
+        "url": "https://twitter.com/cunninghamscott/status/829821405659222016",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/cunninghamscott/status/829821405659222016"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cf18ee4b08bb4fbbea6b2"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829516437454663680",
+        "url": "https://twitter.com/Rachel__Nichols/status/829516437454663680",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Rachel__Nichols/status/829516437454663680?ref_src=twsrc%5Etfw"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589c668ae4b0e78a1131d932"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4KLuE4XUAIsy_N.jpg",
+          "fields": {
+            "width": "1200",
+            "height": "1200",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4KLuE4XUAIsy_N.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829379045729169410",
+        "url": "https://twitter.com/KamalaHarris/status/829379045729169410",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/KamalaHarris/status/829379045729169410"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-08",
+    "contentid": "589b9123e4b01b5caf3ce275"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829384587482656768",
+        "url": "https://twitter.com/realDonaldTrump/status/829384587482656768",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/realDonaldTrump/status/829384587482656768"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-08",
+    "contentid": "589b9123e4b01b5caf3ce275"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829389966740447232",
+        "url": "https://twitter.com/AmandaMarcotte/status/829389966740447232",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AmandaMarcotte/status/829389966740447232"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-08",
+    "contentid": "589b9123e4b01b5caf3ce275"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829356871848951809",
+        "url": "https://twitter.com/realDonaldTrump/status/829356871848951809",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/realDonaldTrump/status/829356871848951809"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-08",
+    "contentid": "589b9123e4b01b5caf3ce275"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829041688186335232",
+        "url": "https://twitter.com/daylinleach/status/829041688186335232",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/daylinleach/status/829041688186335232"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-08",
+    "contentid": "589b9123e4b01b5caf3ce275"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4L-WmKW8AM4NVE.jpg",
+          "fields": {
+            "width": "1334",
+            "height": "750",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4L-WmKW8AM4NVE.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829504954884882432",
+        "url": "https://twitter.com/ZekeJMiller/status/829504954884882432",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ZekeJMiller/status/829504954884882432"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589bef01e4b0e78a1131d754"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829436790763315207",
+        "url": "https://twitter.com/jeremycorbyn/status/829436790763315207",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jeremycorbyn/status/829436790763315207"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589bbbd0e4b0e78a1131d6b1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829442621340803083",
+        "url": "https://twitter.com/NicolaSturgeon/status/829442621340803083",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/NicolaSturgeon/status/829442621340803083"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589bbbd0e4b0e78a1131d6b1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829455314198069248",
+        "url": "https://twitter.com/StewartWood/status/829455314198069248",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/StewartWood/status/829455314198069248"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589bbbd0e4b0e78a1131d6b1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829453590829805568",
+        "url": "https://twitter.com/carlmaxim/status/829453590829805568",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/carlmaxim/status/829453590829805568"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589bbbd0e4b0e78a1131d6b1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829454419574022148",
+        "url": "https://twitter.com/heawood/status/829454419574022148",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/heawood/status/829454419574022148"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589bbbd0e4b0e78a1131d6b1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829457080776028160",
+        "url": "https://twitter.com/kenningtonkitty/status/829457080776028160",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/kenningtonkitty/status/829457080776028160"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589bbbd0e4b0e78a1131d6b1"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/C4LV71UWYAAMzMd.jpg",
+          "fields": {
+            "width": "300",
+            "height": "400",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/C4LV71UWYAAMzMd.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829460523204894721",
+        "url": "https://twitter.com/dubdubble/status/829460523204894721",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/dubdubble/status/829460523204894721"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589bbbd0e4b0e78a1131d6b1"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/C4LUgsYWYAAgzIw.jpg",
+          "fields": {
+            "width": "424",
+            "height": "226",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/C4LUgsYWYAAgzIw.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829459028107485185",
+        "url": "https://twitter.com/VanHellsong/status/829459028107485185",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/VanHellsong/status/829459028107485185"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589bbbd0e4b0e78a1131d6b1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829448010815922186",
+        "url": "https://twitter.com/SocialHistoryOx/status/829448010815922186",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SocialHistoryOx/status/829448010815922186"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589bbbd0e4b0e78a1131d6b1"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/C4LQcRPWYAQQM4F.jpg",
+          "fields": {
+            "width": "392",
+            "height": "372",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/C4LQcRPWYAQQM4F.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829454477300228106",
+        "url": "https://twitter.com/LettersOfNote/status/829454477300228106",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/LettersOfNote/status/829454477300228106"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589bbbd0e4b0e78a1131d6b1"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4LL-fhWYAMZHcE.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4LL-fhWYAMZHcE.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829449584455868420",
+        "url": "https://twitter.com/BDStanley/status/829449584455868420",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BDStanley/status/829449584455868420https://twitter.com/bashthebox/status/829461401265651717https://twitter.com/dubdubble/status/829460523204894721https://twitter.com/madeofwasps/status/829449956893265920https://twitter.com/VanHellsong/status/829459028107485185https://twitter.com/kenningtonkitty/status/829457080776028160https://twitter.com/MarkyLott/status/829460159202209793https://twitter.com/MrKenShabby/status/829454840799506432"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589bbbd0e4b0e78a1131d6b1"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/C4LvnPaWcAIj4ra.jpg",
+          "fields": {
+            "width": "220",
+            "height": "124",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/C4LvnPaWcAIj4ra.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829488766825947136",
+        "url": "https://twitter.com/Pannypannypan/status/829488766825947136",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Pannypannypan/status/829488766825947136"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589bbbd0e4b0e78a1131d6b1"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/C4LQwJRWYAEa87R.jpg",
+          "fields": {
+            "width": "400",
+            "height": "300",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/C4LQwJRWYAEa87R.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829454840799506432",
+        "url": "https://twitter.com/MrKenShabby/status/829454840799506432",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MrKenShabby/status/829454840799506432"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589bbbd0e4b0e78a1131d6b1"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4MAwz_XUAEl16I.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4MAwz_XUAEl16I.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829507597241839616",
+        "url": "https://twitter.com/SocialNOklaCity/status/829507597241839616",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SocialNOklaCity/status/829507597241839616"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589bccf4e4b0e78a1131d6e0"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "524177164561022977",
+        "url": "https://twitter.com/steve_hawkes/statuses/524177164561022977",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/steve_hawkes/status/524177164561022977"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-10-20",
+    "contentid": "5444b122e4b0cd82a095fd0b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "524217749120114689",
+        "url": "https://twitter.com/DavidLammy/statuses/524217749120114689",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/DavidLammy/status/524217749120114689"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-10-20",
+    "contentid": "5444b122e4b0cd82a095fd0b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "524186467472801794",
+        "url": "https://twitter.com/MSmithsonPB/statuses/524186467472801794",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/MSmithsonPB/status/524186467472801794"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-10-20",
+    "contentid": "5444b122e4b0cd82a095fd0b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "523429668582858752",
+        "url": "https://twitter.com/George_Osborne/statuses/523429668582858752",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/George_Osborne/status/523429668582858752"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-10-20",
+    "contentid": "5444b122e4b0cd82a095fd0b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "524200073195180033",
+        "url": "https://twitter.com/faisalislam/statuses/524200073195180033",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/faisalislam/status/524200073195180033"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-10-20",
+    "contentid": "5444b122e4b0cd82a095fd0b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "524175093346213888",
+        "url": "https://twitter.com/suttonnick/statuses/524175093346213888",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/suttonnick/status/524175093346213888"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-10-20",
+    "contentid": "5444b122e4b0cd82a095fd0b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "524178356582219776",
+        "url": "https://twitter.com/chrisshipitv/statuses/524178356582219776",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/chrisshipitv/status/524178356582219776"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-10-20",
+    "contentid": "5444b122e4b0cd82a095fd0b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "524150586426789890",
+        "url": "https://twitter.com/AGH_UM_/statuses/524150586426789890",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/AGH_UM_/status/524150586426789890"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-10-20",
+    "contentid": "5444b122e4b0cd82a095fd0b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "524151562323914752",
+        "url": "https://twitter.com/MayorofLondon/statuses/524151562323914752",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/MayorofLondon/status/524151562323914752"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-10-20",
+    "contentid": "5444b122e4b0cd82a095fd0b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "524113963051937793",
+        "url": "https://twitter.com/lionelbarber/statuses/524113963051937793",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/lionelbarber/status/524113963051937793"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-10-20",
+    "contentid": "5444b122e4b0cd82a095fd0b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "524115668409790464",
+        "url": "https://twitter.com/Hugodixon/statuses/524115668409790464",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/Hugodixon/status/524115668409790464"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-10-20",
+    "contentid": "5444b122e4b0cd82a095fd0b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "524089796558594048",
+        "url": "https://twitter.com/RogerHelmerMEP/statuses/524089796558594048",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/RogerHelmerMEP/status/524089796558594048"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-10-20",
+    "contentid": "5444b122e4b0cd82a095fd0b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "524079632333938688",
+        "url": "https://twitter.com/ShneurOdzeUKIP/statuses/524079632333938688",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/ShneurOdzeUKIP/status/524079632333938688"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-10-20",
+    "contentid": "5444b122e4b0cd82a095fd0b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "524111039248760833",
+        "url": "https://twitter.com/PaulBrandITV/statuses/524111039248760833",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/PaulBrandITV/status/524111039248760833"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-10-20",
+    "contentid": "5444b122e4b0cd82a095fd0b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "524112618500657152",
+        "url": "https://twitter.com/PaulBrandITV/statuses/524112618500657152",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/PaulBrandITV/status/524112618500657152"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-10-20",
+    "contentid": "5444b122e4b0cd82a095fd0b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "398062613906468864",
+        "url": "https://twitter.com/adamvaughan_uk/statuses/398062613906468864",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/adamvaughan_uk/status/398062613906468864"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2013-11-05",
+    "contentid": "52790ec5e4b05943043c3937"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830072207854432256",
+        "url": "https://twitter.com/FitchRatings/status/830072207854432256",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/FitchRatings/status/830072207854432256"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dceb5e4b09b65848ea388"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DrLiXBBUUAAn7vl.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DrLiXBBUUAAn7vl.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1059157756731518976",
+        "url": "https://twitter.com/NFL/status/1059157756731518976",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/NFL/status/1059157756731518976"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-05",
+    "contentid": "5bdfa8ade4b02dafd12f1115"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DrMC1iaU0AEk4GA.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DrMC1iaU0AEk4GA.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1059193463093157888",
+        "url": "https://twitter.com/Seahawks/status/1059193463093157888",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Seahawks/status/1059193463093157888"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-05",
+    "contentid": "5bdfa8ade4b02dafd12f1115"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1110716942439071744",
+        "url": "https://twitter.com/MiamiOpen/status/1110716942439071744",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MiamiOpen/status/1110716942439071744"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-26",
+    "contentid": "5c9aac68e4b0a8f431e31df1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1110711447405948928",
+        "url": "https://twitter.com/MiamiOpen/status/1110711447405948928",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MiamiOpen/status/1110711447405948928"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-26",
+    "contentid": "5c9aac68e4b0a8f431e31df1"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/D2mtSnqXQAEWk2b.jpg",
+          "fields": {
+            "width": "1920",
+            "height": "1080",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/D2mtSnqXQAEWk2b.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1110609389197684736",
+        "url": "https://twitter.com/TennisTV/status/1110609389197684736",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TennisTV/status/1110609389197684736"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-26",
+    "contentid": "5c9aac68e4b0a8f431e31df1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829518497914945536",
+        "url": "https://twitter.com/soledadobrien/status/829518497914945536",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/soledadobrien/status/829518497914945536"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589deaa3e4b0fcbf4e7d47eb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829392295711485952",
+        "url": "https://twitter.com/annfriedman/status/829392295711485952",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/annfriedman/status/829392295711485952"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589deaa3e4b0fcbf4e7d47eb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829111170061783041",
+        "url": "https://twitter.com/jiatolentino/status/829111170061783041",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jiatolentino/status/829111170061783041"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589deaa3e4b0fcbf4e7d47eb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829199432793149442",
+        "url": "https://twitter.com/tressiemcphd/status/829199432793149442",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tressiemcphd/status/829199432793149442"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589deaa3e4b0fcbf4e7d47eb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829836231802515457",
+        "url": "https://twitter.com/realDonaldTrump/status/829836231802515457",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/realDonaldTrump/status/829836231802515457"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cebf5e4b01b5caf3ce807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829880050694627328",
+        "url": "https://twitter.com/GOP/status/829880050694627328",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GOP/status/829880050694627328"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cebf5e4b01b5caf3ce807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "828792995591888896",
+        "url": "https://twitter.com/Rosie/status/828792995591888896",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Rosie/status/828792995591888896"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cebf5e4b01b5caf3ce807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "828817401718439939",
+        "url": "https://twitter.com/Rosie/status/828817401718439939",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Rosie/status/828817401718439939?ref_src=twsrc%5Etfw"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cebf5e4b01b5caf3ce807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829836231802515457",
+        "url": "https://twitter.com/realDonaldTrump/status/829836231802515457",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/realDonaldTrump/status/829836231802515457"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cebf5e4b01b5caf3ce807"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/829855559549542400/pu/img/5alLnvIxGeP7T57g.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "576",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/829855559549542400/pu/img/5alLnvIxGeP7T57g.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829856043438075905",
+        "url": "https://twitter.com/Acosta/status/829856043438075905",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Acosta/status/829856043438075905"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cebf5e4b01b5caf3ce807"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4Q2BCLWQAAwB01.jpg",
+          "fields": {
+            "width": "671",
+            "height": "638",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4Q2BCLWQAAwB01.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829847634802204672",
+        "url": "https://twitter.com/EricHolder/status/829847634802204672",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/EricHolder/status/829847634802204672"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cebf5e4b01b5caf3ce807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829846842150096896",
+        "url": "https://twitter.com/HillaryClinton/status/829846842150096896",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/HillaryClinton/status/829846842150096896"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cebf5e4b01b5caf3ce807"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/829846377450577921/pu/img/qqdCuskokccY07Eb.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "576",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/829846377450577921/pu/img/qqdCuskokccY07Eb.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829846605864005632",
+        "url": "https://twitter.com/BraddJaffy/status/829846605864005632",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BraddJaffy/status/829846605864005632"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cebf5e4b01b5caf3ce807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829840901656735745",
+        "url": "https://twitter.com/HallieJackson/status/829840901656735745",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/HallieJackson/status/829840901656735745"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cebf5e4b01b5caf3ce807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829830558049918976",
+        "url": "https://twitter.com/AGOWA/status/829830558049918976",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AGOWA/status/829830558049918976"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cebf5e4b01b5caf3ce807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829836231802515457",
+        "url": "https://twitter.com/realDonaldTrump/status/829836231802515457",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/realDonaldTrump/status/829836231802515457"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cebf5e4b01b5caf3ce807"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4QmUNdW8AA912f.jpg",
+          "fields": {
+            "width": "579",
+            "height": "114",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4QmUNdW8AA912f.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829830362515832832",
+        "url": "https://twitter.com/jamiedupree/status/829830362515832832",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jamiedupree/status/829830362515832832"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-09",
+    "contentid": "589cebf5e4b01b5caf3ce807"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831972381463891968",
+        "url": "https://twitter.com/IanWright0/status/831972381463891968",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/IanWright0/status/831972381463891968"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a1d05ae4b012eeb30c9796"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DxJ9UK8WsAAhNMW.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DxJ9UK8WsAAhNMW.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1086068365096075264",
+        "url": "https://twitter.com/TheDailyShow/status/1086068365096075264",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TheDailyShow/status/1086068365096075264"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-01-18",
+    "contentid": "5c4202aae4b0197a614f5bf4"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/1324285476539375618/pu/img/RjMBgEC3ES6NtLTH.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/1324285476539375618/pu/img/RjMBgEC3ES6NtLTH.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1324286193106898944",
+        "url": "https://twitter.com/Soapmoine/status/1324286193106898944",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/soapmoine/status/1324286193106898944?s=21"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-11-05",
+    "contentid": "5fa417b38f08f536f6a5fa9b"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/EmCdMxYVcAIXjNO.jpg",
+          "fields": {
+            "width": "989",
+            "height": "724",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/EmCdMxYVcAIXjNO.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1324231136415940610",
+        "url": "https://twitter.com/Fothousands/status/1324231136415940610",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Fothousands/status/1324231136415940610"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-11-05",
+    "contentid": "5fa417b38f08f536f6a5fa9b"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/1315450945774538753/pu/img/zCgXr7vjDRGDTwb8.jpg",
+          "fields": {
+            "width": "640",
+            "height": "480",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/1315450945774538753/pu/img/zCgXr7vjDRGDTwb8.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1324218622751830019",
+        "url": "https://twitter.com/ej11lizzie/status/1324218622751830019",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ej11lizzie/status/1324218622751830019"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-11-05",
+    "contentid": "5fa417b38f08f536f6a5fa9b"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/EmBMBX5XUAEZ_4B.jpg",
+          "fields": {
+            "width": "1020",
+            "height": "574",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/EmBMBX5XUAEZ_4B.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1324141882931318784",
+        "url": "https://twitter.com/nahtiqueee_/status/1324141882931318784",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/nahtiqueee_/status/1324141882931318784"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-11-05",
+    "contentid": "5fa417b38f08f536f6a5fa9b"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/1324200375394717696/pu/img/yxaab1FXegw64-Eh.jpg",
+          "fields": {
+            "width": "720",
+            "height": "784",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/1324200375394717696/pu/img/yxaab1FXegw64-Eh.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1324200420865122304",
+        "url": "https://twitter.com/alyssalavacca/status/1324200420865122304",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/alyssalavacca/status/1324200420865122304"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-11-05",
+    "contentid": "5fa417b38f08f536f6a5fa9b"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/1324121375523655683/pu/img/Rd0UBN-u2913cIm6.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/1324121375523655683/pu/img/Rd0UBN-u2913cIm6.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1324121416485273600",
+        "url": "https://twitter.com/hollyherndon/status/1324121416485273600",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/hollyherndon/status/1324121416485273600"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-11-05",
+    "contentid": "5fa417b38f08f536f6a5fa9b"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/1324131224508661763/pu/img/3XLIzwzDxkKiY8oR.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/1324131224508661763/pu/img/3XLIzwzDxkKiY8oR.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1324280879561232385",
+        "url": "https://twitter.com/Freedland/status/1324280879561232385",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/freedland/status/1324280879561232385?s=21"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-11-05",
+    "contentid": "5fa417b38f08f536f6a5fa9b"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/1324002570663329797/pu/img/3VuCAbBlEZnHXh-k.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/1324002570663329797/pu/img/3VuCAbBlEZnHXh-k.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1324295586795827200",
+        "url": "https://twitter.com/AynRandPaulRyan/status/1324295586795827200",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AynRandPaulRyan/status/1324295586795827200"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-11-05",
+    "contentid": "5fa417b38f08f536f6a5fa9b"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/EmABwJEW0AQDl5A.jpg",
+          "fields": {
+            "width": "750",
+            "height": "313",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/EmABwJEW0AQDl5A.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1324060221350793216",
+        "url": "https://twitter.com/ForeverWithJoeJ/status/1324060221350793216",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ForeverWithJoeJ/status/1324060221350793216"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-11-05",
+    "contentid": "5fa417b38f08f536f6a5fa9b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1052205659259695104",
+        "url": "https://twitter.com/SPromotionsUK/status/1052205659259695104",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SPromotionsUK/status/1052205659259695104"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-03-13",
+    "contentid": "5e6b82898f088d7575592c16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "935876240761917440",
+        "url": "https://twitter.com/nytopinion/status/935876240761917440",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/nytopinion/status/935876240761917440"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a218552ae3bcb05d2023663"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "936037588372283392",
+        "url": "https://twitter.com/realDonaldTrump/status/936037588372283392",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/realDonaldTrump/status/936037588372283392"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a214f360470380699b52d13"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "936013001240600576",
+        "url": "https://twitter.com/AlistairBurtUK/status/936013001240600576",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AlistairBurtUK/status/936013001240600576"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a214f360470380699b52d13"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "936126445868462080",
+        "url": "https://twitter.com/tariqahmadbt/status/936126445868462080",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tariqahmadbt/status/936126445868462080"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a214f360470380699b52d13"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049128129523081216",
+        "url": "https://twitter.com/tomphillipsin/status/1049128129523081216",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tomphillipsin/status/1049128129523081216"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-05",
+    "contentid": "5bb6b48ee4b0494d8052a746"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049103957266763782",
+        "url": "https://twitter.com/DLBiller/status/1049103957266763782",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/DLBiller/status/1049103957266763782"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-05",
+    "contentid": "5bb6b48ee4b0494d8052a746"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049103706438995968",
+        "url": "https://twitter.com/Riogringa/status/1049103706438995968",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Riogringa/status/1049103706438995968"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-05",
+    "contentid": "5bb6b48ee4b0494d8052a746"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049093212386648064",
+        "url": "https://twitter.com/domphillips/status/1049093212386648064",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/domphillips/status/1049093212386648064"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-05",
+    "contentid": "5bb6b48ee4b0494d8052a746"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049083251300679680",
+        "url": "https://twitter.com/TSEjusbr/status/1049083251300679680",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TSEjusbr/status/1049083251300679680"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-05",
+    "contentid": "5bb6b48ee4b0494d8052a746"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/Do8UsaCX4AA8CaN.jpg",
+          "fields": {
+            "width": "720",
+            "height": "706",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/Do8UsaCX4AA8CaN.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1049079998861246471",
+        "url": "https://twitter.com/pirescarol/status/1049079998861246471",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/pirescarol/status/1049079998861246471"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-05",
+    "contentid": "5bb6b48ee4b0494d8052a746"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049078659750014977",
+        "url": "https://twitter.com/TSEjusbr/status/1049078659750014977",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TSEjusbr/status/1049078659750014977"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-05",
+    "contentid": "5bb6b48ee4b0494d8052a746"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049074780983443456",
+        "url": "https://twitter.com/TSEjusbr/status/1049074780983443456",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TSEjusbr/status/1049074780983443456"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-05",
+    "contentid": "5bb6b48ee4b0494d8052a746"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049073521605918725",
+        "url": "https://twitter.com/tomphillipsin/status/1049073521605918725",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tomphillipsin/status/1049073521605918725"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-05",
+    "contentid": "5bb6b48ee4b0494d8052a746"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049072683680456705",
+        "url": "https://twitter.com/BrazilBrian/status/1049072683680456705",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BrazilBrian/status/1049072683680456705"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-05",
+    "contentid": "5bb6b48ee4b0494d8052a746"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049067627354763264",
+        "url": "https://twitter.com/BlogdoNoblat/status/1049067627354763264",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BlogdoNoblat/status/1049067627354763264"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-05",
+    "contentid": "5bb6b48ee4b0494d8052a746"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049064887098466305",
+        "url": "https://twitter.com/adowniebrazil/status/1049064887098466305",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/adowniebrazil/status/1049064887098466305"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-05",
+    "contentid": "5bb6b48ee4b0494d8052a746"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049061244894945281",
+        "url": "https://twitter.com/tomphillipsin/status/1049061244894945281",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tomphillipsin/status/1049061244894945281"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-05",
+    "contentid": "5bb6b48ee4b0494d8052a746"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049057334033633281",
+        "url": "https://twitter.com/tomphillipsin/status/1049057334033633281",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tomphillipsin/status/1049057334033633281"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-05",
+    "contentid": "5bb6b48ee4b0494d8052a746"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049050958871912449",
+        "url": "https://twitter.com/cculbertosborn/status/1049050958871912449",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/cculbertosborn/status/1049050958871912449"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-05",
+    "contentid": "5bb6b48ee4b0494d8052a746"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049006918960918528",
+        "url": "https://twitter.com/tomphillipsin/status/1049006918960918528",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tomphillipsin/status/1049006918960918528"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-05",
+    "contentid": "5bb6b48ee4b0494d8052a746"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1048968237222957056",
+        "url": "https://twitter.com/MidiaNINJA/status/1048968237222957056",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MidiaNINJA/status/1048968237222957056"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-05",
+    "contentid": "5bb6b48ee4b0494d8052a746"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1049025100375384065",
+        "url": "https://twitter.com/domphillips/status/1049025100375384065",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/domphillips/status/1049025100375384065"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-05",
+    "contentid": "5bb6b48ee4b0494d8052a746"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/1049038867813322754/pu/img/MqW-jPWKHHuU9rCN.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/1049038867813322754/pu/img/MqW-jPWKHHuU9rCN.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1049038932036530177",
+        "url": "https://twitter.com/domphillips/status/1049038932036530177",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/domphillips/status/1049038932036530177"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-05",
+    "contentid": "5bb6b48ee4b0494d8052a746"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/Do7t7qSX4AEf2tX.jpg",
+          "fields": {
+            "width": "1343",
+            "height": "950",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/Do7t7qSX4AEf2tX.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1049037432803545088",
+        "url": "https://twitter.com/BlogdoNoblat/status/1049037432803545088",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BlogdoNoblat/status/1049037432803545088"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-05",
+    "contentid": "5bb6b48ee4b0494d8052a746"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1039766846876995584",
+        "url": "https://twitter.com/QldPolice/status/1039766846876995584",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/QldPolice/status/1039766846876995584"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-09-12",
+    "contentid": "5b98be63e4b0bd389edeb58b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1039770852991033344",
+        "url": "https://twitter.com/QldPolice/status/1039770852991033344",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/QldPolice/status/1039770852991033344"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-09-12",
+    "contentid": "5b98be63e4b0bd389edeb58b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1092255028566523904",
+        "url": "https://twitter.com/washingtonpost/status/1092255028566523904",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/washingtonpost/status/1092255028566523904"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-02-04",
+    "contentid": "5c57b6b8e4b0c3e1fbdbd972"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1363828826783027200",
+        "url": "https://twitter.com/lizgoingon/status/1363828826783027200",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/lizgoingon/status/1363828826783027200"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2021-02-22",
+    "contentid": "6033c5058f08614ccf103321"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/965177449356001280/pu/img/BoZw13kTlTGepy9g.jpg",
+          "fields": {
+            "width": "720",
+            "height": "1280",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/965177449356001280/pu/img/BoZw13kTlTGepy9g.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "965177553920012288",
+        "url": "https://twitter.com/Elise_Christie/status/965177553920012288",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Elise_Christie/status/965177553920012288"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-18",
+    "contentid": "5a893d7ae4b0767e2673d748"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1151872170458357761",
+        "url": "https://twitter.com/trustednerd/status/1151872170458357761",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/trustednerd/status/1151872170458357761"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-07-26",
+    "contentid": "5d3b5dae8f08d0b6ca53898e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1043511932131713025",
+        "url": "https://twitter.com/VolunteerReport/status/1043511932131713025",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/VolunteerReport/status/1043511932131713025"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-09-23",
+    "contentid": "5ba75dcde4b0a71b5946af9e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "980183251410067456",
+        "url": "https://twitter.com/MLS/status/980183251410067456",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MLS/status/980183251410067456"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-04-01",
+    "contentid": "5ac10964e4b06ca6b9163b60"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1061028221267828736",
+        "url": "https://twitter.com/GrahamManou/status/1061028221267828736",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GrahamManou/status/1061028221267828736"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be4f7a5e4b0b8cf943c87b7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1061015292724367365",
+        "url": "https://twitter.com/_hypocaust/status/1061015292724367365",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/_hypocaust/status/1061015292724367365"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be4f7a5e4b0b8cf943c87b7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1060991962621403136",
+        "url": "https://twitter.com/benjonescricket/status/1060991962621403136",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/benjonescricket/status/1060991962621403136"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be4f7a5e4b0b8cf943c87b7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1061001772624297984",
+        "url": "https://twitter.com/Gampa_cricket/status/1061001772624297984",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Gampa_cricket/status/1061001772624297984"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be4f7a5e4b0b8cf943c87b7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1061000359458603008",
+        "url": "https://twitter.com/_hypocaust/status/1061000359458603008",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/_hypocaust/status/1061000359458603008"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be4f7a5e4b0b8cf943c87b7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1060999049124339712",
+        "url": "https://twitter.com/LiebCricket/status/1060999049124339712",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/LiebCricket/status/1060999049124339712"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be4f7a5e4b0b8cf943c87b7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1060990901605031936",
+        "url": "https://twitter.com/_hypocaust/status/1060990901605031936",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/_hypocaust/status/1060990901605031936"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be4f7a5e4b0b8cf943c87b7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1060988577440514048",
+        "url": "https://twitter.com/benjonescricket/status/1060988577440514048",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/benjonescricket/status/1060988577440514048"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be4f7a5e4b0b8cf943c87b7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1060962881108353024",
+        "url": "https://twitter.com/MazherArshad/status/1060962881108353024",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MazherArshad/status/1060962881108353024"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be4f7a5e4b0b8cf943c87b7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1060957469629997056",
+        "url": "https://twitter.com/WorldT20/status/1060957469629997056",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/WorldT20/status/1060957469629997056"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be4f7a5e4b0b8cf943c87b7"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DrlXDG8UUAAbQxG.jpg",
+          "fields": {
+            "width": "900",
+            "height": "1600",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DrlXDG8UUAAbQxG.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1060975065339031552",
+        "url": "https://twitter.com/SouthernStars/status/1060975065339031552",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SouthernStars/status/1060975065339031552"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be4f7a5e4b0b8cf943c87b7"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DrlbVq9UUAEU4nl.jpg",
+          "fields": {
+            "width": "1200",
+            "height": "1200",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DrlbVq9UUAEU4nl.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1060980081936424961",
+        "url": "https://twitter.com/SouthernStars/status/1060980081936424961",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SouthernStars/status/1060980081936424961"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be4f7a5e4b0b8cf943c87b7"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DrlYEZVU0AA1QdX.jpg",
+          "fields": {
+            "width": "1600",
+            "height": "1066",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DrlYEZVU0AA1QdX.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1060976285755666433",
+        "url": "https://twitter.com/SouthernStars/status/1060976285755666433",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SouthernStars/status/1060976285755666433"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be4f7a5e4b0b8cf943c87b7"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/ELRn9dqXkAAzfRz.jpg",
+          "fields": {
+            "width": "1920",
+            "height": "1080",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/ELRn9dqXkAAzfRz.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1203701355409551360",
+        "url": "https://twitter.com/btsportfootball/status/1203701355409551360",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/btsportfootball/status/1203701355409551360"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-12-08",
+    "contentid": "5decd9e48f08e7796de8ed0f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830074762663718913",
+        "url": "https://twitter.com/TheDailyShow/status/830074762663718913",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TheDailyShow/status/830074762663718913"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dd7f4e4b0fcbf4e7d4787"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "962367259489587200",
+        "url": "https://twitter.com/ThaneAtCawdor/status/962367259489587200",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ThaneAtCawdor/status/962367259489587200"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-09",
+    "contentid": "5a7d80ede4b05abd28aac39f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "962366165388578816",
+        "url": "https://twitter.com/jonawils/status/962366165388578816",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jonawils/status/962366165388578816"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-09",
+    "contentid": "5a7d80ede4b05abd28aac39f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "962362944607551488",
+        "url": "https://twitter.com/OptaJoe/status/962362944607551488",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/OptaJoe/status/962362944607551488"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-09",
+    "contentid": "5a7d80ede4b05abd28aac39f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "962361556293050368",
+        "url": "https://twitter.com/SalfordCityFC/status/962361556293050368",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SalfordCityFC/status/962361556293050368"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-09",
+    "contentid": "5a7d80ede4b05abd28aac39f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "962360550423388160",
+        "url": "https://twitter.com/tony_rutt/status/962360550423388160",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tony_rutt/status/962360550423388160"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-09",
+    "contentid": "5a7d80ede4b05abd28aac39f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "962359333974691840",
+        "url": "https://twitter.com/BurnleyOfficial/status/962359333974691840",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BurnleyOfficial/status/962359333974691840"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-09",
+    "contentid": "5a7d80ede4b05abd28aac39f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "962357881642409985",
+        "url": "https://twitter.com/OfficialFPL/status/962357881642409985",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/OfficialFPL/status/962357881642409985"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-09",
+    "contentid": "5a7d80ede4b05abd28aac39f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "962356992470867968",
+        "url": "https://twitter.com/JamieJackson___/status/962356992470867968",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/JamieJackson___/status/962356992470867968"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-09",
+    "contentid": "5a7d80ede4b05abd28aac39f"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/DVr0A7WXUAALXGi.jpg",
+          "fields": {
+            "width": "384",
+            "height": "216",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/DVr0A7WXUAALXGi.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "962349785650024448",
+        "url": "https://twitter.com/BVB/status/962349785650024448",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BVB/status/962349785650024448"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-09",
+    "contentid": "5a7d80ede4b05abd28aac39f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "962351915634917377",
+        "url": "https://twitter.com/Everton/status/962351915634917377",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Everton/status/962351915634917377"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-09",
+    "contentid": "5a7d80ede4b05abd28aac39f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "962350814101737472",
+        "url": "https://twitter.com/SunderlandAFC/status/962350814101737472",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SunderlandAFC/status/962350814101737472"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-09",
+    "contentid": "5a7d80ede4b05abd28aac39f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "962348234541813760",
+        "url": "https://twitter.com/DarrenMWinter/status/962348234541813760",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/DarrenMWinter/status/962348234541813760"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-09",
+    "contentid": "5a7d80ede4b05abd28aac39f"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DVrwAxzXkAAo117.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1249",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DVrwAxzXkAAo117.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "962345568919015424",
+        "url": "https://twitter.com/stokecity/status/962345568919015424",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/stokecity/status/962345568919015424"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-09",
+    "contentid": "5a7d80ede4b05abd28aac39f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "962342370376331264",
+        "url": "https://twitter.com/WestHamUtd/status/962342370376331264",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/WestHamUtd/status/962342370376331264"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-09",
+    "contentid": "5a7d80ede4b05abd28aac39f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "962280133154533377",
+        "url": "https://twitter.com/chris_kammy/status/962280133154533377",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/chris_kammy/status/962280133154533377"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-09",
+    "contentid": "5a7d80ede4b05abd28aac39f"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DVra3uXU8AEgBAt.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1536",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DVra3uXU8AEgBAt.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "962322134360932352",
+        "url": "https://twitter.com/tariqpanja/status/962322134360932352",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tariqpanja/status/962322134360932352"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-09",
+    "contentid": "5a7d80ede4b05abd28aac39f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "962336081516654592",
+        "url": "https://twitter.com/shinytoyrobots/status/962336081516654592",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/shinytoyrobots/status/962336081516654592"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-09",
+    "contentid": "5a7d80ede4b05abd28aac39f"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DVrmNcRX0AA8Ijo.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1366",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DVrmNcRX0AA8Ijo.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "962334639800094720",
+        "url": "https://twitter.com/EITC/status/962334639800094720",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/EITC/status/962334639800094720"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-09",
+    "contentid": "5a7d80ede4b05abd28aac39f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "962334123280011264",
+        "url": "https://twitter.com/JacobSteinberg/status/962334123280011264",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/JacobSteinberg/status/962334123280011264"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-09",
+    "contentid": "5a7d80ede4b05abd28aac39f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "962326355731013632",
+        "url": "https://twitter.com/stokecity/status/962326355731013632",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/stokecity/status/962326355731013632"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-02-09",
+    "contentid": "5a7d80ede4b05abd28aac39f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829155952414842880",
+        "url": "https://twitter.com/SteveFranconeri/status/829155952414842880",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideMedia": "false",
+        "hideThread": "false",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SteveFranconeri/status/829155952414842880"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a1841ee4b09b65848eb189"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105910675862421505",
+        "url": "https://twitter.com/bbclaurak/status/1105910675862421505",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bbclaurak/status/1105910675862421505"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105911492522754048",
+        "url": "https://twitter.com/jessicaelgot/status/1105911492522754048",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jessicaelgot/status/1105911492522754048"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105913888665669633",
+        "url": "https://twitter.com/faisalislam/status/1105913888665669633",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/faisalislam/status/1105913888665669633"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105875155878887424",
+        "url": "https://twitter.com/TUCeconomics/status/1105875155878887424",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TUCeconomics/status/1105875155878887424"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105846788538486784",
+        "url": "https://twitter.com/WomensBudgetGrp/status/1105846788538486784",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/WomensBudgetGrp/status/1105846788538486784"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105834410153312256",
+        "url": "https://twitter.com/TrussellTrust/status/1105834410153312256",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TrussellTrust/status/1105834410153312256"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105820839289614336",
+        "url": "https://twitter.com/BBCPolitics/status/1105820839289614336",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BBCPolitics/status/1105820839289614336"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105818692846272513",
+        "url": "https://twitter.com/gordonrayner/status/1105818692846272513",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/gordonrayner/status/1105818692846272513"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105819585276727296",
+        "url": "https://twitter.com/JSHeappey/status/1105819585276727296",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/JSHeappey/status/1105819585276727296"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105832645756416000",
+        "url": "https://twitter.com/GregHands/status/1105832645756416000",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GregHands/status/1105832645756416000"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105835598852616193",
+        "url": "https://twitter.com/GregHands/status/1105835598852616193",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GregHands/status/1105835598852616193"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105834159640117248",
+        "url": "https://twitter.com/Anna_Soubry/status/1105834159640117248",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Anna_Soubry/status/1105834159640117248"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105823783091347456",
+        "url": "https://twitter.com/heidiallen75/status/1105823783091347456",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/heidiallen75/status/1105823783091347456"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105829569754525696",
+        "url": "https://twitter.com/steve_hawkes/status/1105829569754525696",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/steve_hawkes/status/1105829569754525696"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105820416998891526",
+        "url": "https://twitter.com/GuardianHeather/status/1105820416998891526",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GuardianHeather/status/1105820416998891526"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105829013472378880",
+        "url": "https://twitter.com/GuardianHeather/status/1105829013472378880",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GuardianHeather/status/1105829013472378880"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105830604598325248",
+        "url": "https://twitter.com/yaelselfin/status/1105830604598325248",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/yaelselfin/status/1105830604598325248"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105829688314920961",
+        "url": "https://twitter.com/OBR_UK/status/1105829688314920961",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/OBR_UK/status/1105829688314920961"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105823591499739136",
+        "url": "https://twitter.com/ZacGoldsmith/status/1105823591499739136",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ZacGoldsmith/status/1105823591499739136"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105820917362552832",
+        "url": "https://twitter.com/CSkidmoreUK/status/1105820917362552832",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/CSkidmoreUK/status/1105820917362552832"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105815682934018048",
+        "url": "https://twitter.com/annaturley/status/1105815682934018048",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/annaturley/status/1105815682934018048"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105822831470960640",
+        "url": "https://twitter.com/LouHaigh/status/1105822831470960640",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/LouHaigh/status/1105822831470960640"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105821140163940358",
+        "url": "https://twitter.com/Alison_McGovern/status/1105821140163940358",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Alison_McGovern/status/1105821140163940358"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105821062372175872",
+        "url": "https://twitter.com/CarolineLucas/status/1105821062372175872",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/CarolineLucas/status/1105821062372175872"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105823879593902082",
+        "url": "https://twitter.com/SkyNews/status/1105823879593902082",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SkyNews/status/1105823879593902082"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105819828491816960",
+        "url": "https://twitter.com/BethRigby/status/1105819828491816960",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BethRigby/status/1105819828491816960"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105818084097576961",
+        "url": "https://twitter.com/hmtreasury/status/1105818084097576961",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/hmtreasury/status/1105818084097576961"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105817848105000960",
+        "url": "https://twitter.com/DamianCollins/status/1105817848105000960",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/DamianCollins/status/1105817848105000960"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/D1iQ4yiW0AYOcuz.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1448",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/D1iQ4yiW0AYOcuz.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1105816822505488385",
+        "url": "https://twitter.com/hmtreasury/status/1105816822505488385",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/hmtreasury/status/1105816822505488385"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105816636915888161",
+        "url": "https://twitter.com/PJTheEconomist/status/1105816636915888161",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/PJTheEconomist/status/1105816636915888161"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105816450990788609",
+        "url": "https://twitter.com/paullewismoney/status/1105816450990788609",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/paullewismoney/status/1105816450990788609"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105813533319663616",
+        "url": "https://twitter.com/MattWhittakerRF/status/1105813533319663616",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MattWhittakerRF/status/1105813533319663616"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105815713510494208",
+        "url": "https://twitter.com/DavidMundellDCT/status/1105815713510494208",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/DavidMundellDCT/status/1105815713510494208"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/D1iQ2QoWsAAKVjg.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1448",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/D1iQ2QoWsAAKVjg.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1105813097841872901",
+        "url": "https://twitter.com/hmtreasury/status/1105813097841872901",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/hmtreasury/status/1105813097841872901"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105812556436914176",
+        "url": "https://twitter.com/hmtreasury/status/1105812556436914176",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/hmtreasury/status/1105812556436914176"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105812843306332160",
+        "url": "https://twitter.com/hmtreasury/status/1105812843306332160",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/hmtreasury/status/1105812843306332160"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105801606547812357",
+        "url": "https://twitter.com/PhilipHammondUK/status/1105801606547812357",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/PhilipHammondUK/status/1105801606547812357"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105805990811918336",
+        "url": "https://twitter.com/BBCDouglasF/status/1105805990811918336",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BBCDouglasF/status/1105805990811918336"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105805775098793984",
+        "url": "https://twitter.com/redmaynebentley/status/1105805775098793984",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/redmaynebentley/status/1105805775098793984"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105214054682058752",
+        "url": "https://twitter.com/sturdyAlex/status/1105214054682058752",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/sturdyAlex/status/1105214054682058752"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105745329838870528",
+        "url": "https://twitter.com/Jess_Shankleman/status/1105745329838870528",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Jess_Shankleman/status/1105745329838870528"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105791817352704000",
+        "url": "https://twitter.com/HouseofCommons/status/1105791817352704000",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/HouseofCommons/status/1105791817352704000"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105787751587291136",
+        "url": "https://twitter.com/JohnJCrace/status/1105787751587291136",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/JohnJCrace/status/1105787751587291136"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105731763131895809",
+        "url": "https://twitter.com/Alison_McGovern/status/1105731763131895809",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Alison_McGovern/status/1105731763131895809"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105772308839481345",
+        "url": "https://twitter.com/MarshadeCordova/status/1105772308839481345",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MarshadeCordova/status/1105772308839481345"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105734829897891845",
+        "url": "https://twitter.com/LaylaMoran/status/1105734829897891845",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/LaylaMoran/status/1105734829897891845"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105726091300405248",
+        "url": "https://twitter.com/GuyOpperman/status/1105726091300405248",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GuyOpperman/status/1105726091300405248"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105754782965395456",
+        "url": "https://twitter.com/tom_watson/status/1105754782965395456",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tom_watson/status/1105754782965395456"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105751416650563584",
+        "url": "https://twitter.com/CrimeLineLaw/status/1105751416650563584",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/CrimeLineLaw/status/1105751416650563584"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105751417707524096",
+        "url": "https://twitter.com/CrimeLineLaw/status/1105751417707524096",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/CrimeLineLaw/status/1105751417707524096"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105536889929564160",
+        "url": "https://twitter.com/johnmcdonnellMP/status/1105536889929564160",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/johnmcdonnellMP/status/1105536889929564160"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105729669024894977",
+        "url": "https://twitter.com/BethRigby/status/1105729669024894977",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BethRigby/status/1105729669024894977"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1105530787498213376",
+        "url": "https://twitter.com/GeorgeWParker/status/1105530787498213376",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GeorgeWParker/status/1105530787498213376"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-03-13",
+    "contentid": "5c88ae61e4b016d23425ac16"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1060828527115804672",
+        "url": "https://twitter.com/ONS/status/1060828527115804672",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ONS/status/1060828527115804672"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be5334ae4b0b627bf3ccbb6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1060842204674080768",
+        "url": "https://twitter.com/ReutersJamie/status/1060842204674080768",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ReutersJamie/status/1060842204674080768"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be5334ae4b0b627bf3ccbb6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1060841027462926336",
+        "url": "https://twitter.com/DharshiniDavid/status/1060841027462926336",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/DharshiniDavid/status/1060841027462926336"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be5334ae4b0b627bf3ccbb6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1060834694739177473",
+        "url": "https://twitter.com/Danske_Research/status/1060834694739177473",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Danske_Research/status/1060834694739177473"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be5334ae4b0b627bf3ccbb6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1060834212700454913",
+        "url": "https://twitter.com/ITVJoel/status/1060834212700454913",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ITVJoel/status/1060834212700454913"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be5334ae4b0b627bf3ccbb6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1060831822567878656",
+        "url": "https://twitter.com/EdConwaySky/status/1060831822567878656",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/EdConwaySky/status/1060831822567878656"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be5334ae4b0b627bf3ccbb6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1060829445697794048",
+        "url": "https://twitter.com/mikejakeman/status/1060829445697794048",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/mikejakeman/status/1060829445697794048"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be5334ae4b0b627bf3ccbb6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1060829477280849920",
+        "url": "https://twitter.com/notayesmansecon/status/1060829477280849920",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/notayesmansecon/status/1060829477280849920"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be5334ae4b0b627bf3ccbb6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1060829351514660864",
+        "url": "https://twitter.com/NobleFrancis/status/1060829351514660864",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/NobleFrancis/status/1060829351514660864"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be5334ae4b0b627bf3ccbb6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1060832504389734400",
+        "url": "https://twitter.com/siobhankennedy4/status/1060832504389734400",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/siobhankennedy4/status/1060832504389734400"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be5334ae4b0b627bf3ccbb6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1060828007424761856",
+        "url": "https://twitter.com/Annaisaac/status/1060828007424761856",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Annaisaac/status/1060828007424761856"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be5334ae4b0b627bf3ccbb6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1060825715376046080",
+        "url": "https://twitter.com/alaidi/status/1060825715376046080",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/alaidi/status/1060825715376046080"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be5334ae4b0b627bf3ccbb6"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DrjMiOKWwAAIbbq.jpg",
+          "fields": {
+            "width": "950",
+            "height": "278",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DrjMiOKWwAAIbbq.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1060822624450813953",
+        "url": "https://twitter.com/RANsquawk/status/1060822624450813953",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/RANsquawk/status/1060822624450813953"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be5334ae4b0b627bf3ccbb6"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/amplify_video_thumb/989538852707667969/img/xjmdDvylUKjXruZX.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/amplify_video_thumb/989538852707667969/img/xjmdDvylUKjXruZX.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1060796631996604416",
+        "url": "https://twitter.com/hmtreasury/status/1060796631996604416",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/hmtreasury/status/1060796631996604416"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-09",
+    "contentid": "5be5334ae4b0b627bf3ccbb6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831170812690456576",
+        "url": "https://twitter.com/neilwilson_etx/status/831170812690456576",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/neilwilson_etx/status/831170812690456576"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a15870e4b012eeb30c9571"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831159038641573890",
+        "url": "https://twitter.com/ReutersJamie/status/831159038641573890",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ReutersJamie/status/831159038641573890"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a15870e4b012eeb30c9571"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831151474654769152",
+        "url": "https://twitter.com/CNBC/status/831151474654769152",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/CNBC/status/831151474654769152"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a15870e4b012eeb30c9571"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831119944523841538",
+        "url": "https://twitter.com/LaMonicaBuzz/status/831119944523841538",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/LaMonicaBuzz/status/831119944523841538"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a15870e4b012eeb30c9571"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831095933807030276",
+        "url": "https://twitter.com/dannyctkemp/status/831095933807030276",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/dannyctkemp/status/831095933807030276"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a15870e4b012eeb30c9571"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831094876448161792",
+        "url": "https://twitter.com/MxSba/status/831094876448161792",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MxSba/status/831094876448161792"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a15870e4b012eeb30c9571"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831085189845680128",
+        "url": "https://twitter.com/pierremoscovici/status/831085189845680128",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/pierremoscovici/status/831085189845680128"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a15870e4b012eeb30c9571"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831087914792710144",
+        "url": "https://twitter.com/pierremoscovici/status/831087914792710144",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/pierremoscovici/status/831087914792710144"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a15870e4b012eeb30c9571"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4iZwLcWQAEvhMt.jpg",
+          "fields": {
+            "width": "953",
+            "height": "329",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4iZwLcWQAEvhMt.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831083237913026561",
+        "url": "https://twitter.com/JeanComte/status/831083237913026561",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/JeanComte/status/831083237913026561"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a15870e4b012eeb30c9571"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4iZFWlXAAE_tSq.jpg",
+          "fields": {
+            "width": "1200",
+            "height": "600",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4iZFWlXAAE_tSq.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831082450545700864",
+        "url": "https://twitter.com/Brexit/status/831082450545700864",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Brexit/status/831082450545700864"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a15870e4b012eeb30c9571"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831080629873815553",
+        "url": "https://twitter.com/dannyctkemp/status/831080629873815553",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/dannyctkemp/status/831080629873815553"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a15870e4b012eeb30c9571"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4iSccvWEAAh9DZ.jpg",
+          "fields": {
+            "width": "638",
+            "height": "360",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4iSccvWEAAh9DZ.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831082259771957248",
+        "url": "https://twitter.com/EU_Commission/status/831082259771957248",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/EU_Commission/status/831082259771957248"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a15870e4b012eeb30c9571"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831070725834424321",
+        "url": "https://twitter.com/ReutersJamie/status/831070725834424321",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ReutersJamie/status/831070725834424321"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a15870e4b012eeb30c9571"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831061651545747456",
+        "url": "https://twitter.com/spignal/status/831061651545747456",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/spignal/status/831061651545747456"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a15870e4b012eeb30c9571"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831052162478272512",
+        "url": "https://twitter.com/RANsquawk/status/831052162478272512",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/RANsquawk/status/831052162478272512"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a15870e4b012eeb30c9571"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831051583517515776",
+        "url": "https://twitter.com/jamesbevan_ccla/status/831051583517515776",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jamesbevan_ccla/status/831051583517515776"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a15870e4b012eeb30c9571"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/830105647521918976/pu/img/RFVrLUQtGF3A-UMH.jpg",
+          "fields": {
+            "width": "640",
+            "height": "360",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/830105647521918976/pu/img/RFVrLUQtGF3A-UMH.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830105679801225216",
+        "url": "https://twitter.com/CBSNews/status/830105679801225216",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/CBSNews/status/830105679801225216"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a15870e4b012eeb30c9571"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4hu9_dWQAATlzP.jpg",
+          "fields": {
+            "width": "288",
+            "height": "300",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4hu9_dWQAATlzP.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831036182138085376",
+        "url": "https://twitter.com/destatis_news/status/831036182138085376",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/destatis_news/status/831036182138085376"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a15870e4b012eeb30c9571"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4SZ-BFUoAAOflH.jpg",
+          "fields": {
+            "width": "750",
+            "height": "1016",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4SZ-BFUoAAOflH.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829957531459997698",
+        "url": "https://twitter.com/easton_wood/status/829957531459997698",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/easton_wood/status/829957531459997698"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0e2d6e4b0fcbf4e7d5277"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830842501506412545",
+        "url": "https://twitter.com/JasonTaylor/status/830842501506412545",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/JasonTaylor/status/830842501506412545?ref_src=twsrc%5Etfw"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0bb1ce4b09b65848eae99"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "974433363061719040",
+        "url": "https://twitter.com/E_Reid35/status/974433363061719040",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/E_Reid35/status/974433363061719040"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-03-16",
+    "contentid": "5aabc0a3e4b0f83efb4680d6"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "815769247104135170",
+        "url": "https://twitter.com/china_chas/status/815769247104135170",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/china_chas/status/815769247104135170"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4iaxCBUkAAZ6wI.jpg",
+          "fields": {
+            "width": "1920",
+            "height": "1280",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4iaxCBUkAAZ6wI.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831084314347532289",
+        "url": "https://twitter.com/safimichael/status/831084314347532289",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/safimichael/status/831084314347532289"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831097164336078851",
+        "url": "https://twitter.com/HadassahEgbedi/status/831097164336078851",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/HadassahEgbedi/status/831097164336078851"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831187741094260736",
+        "url": "https://twitter.com/nate_berg/status/831187741094260736",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/nate_berg/status/831187741094260736/photo/1"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4jux6QVYAAD5ny.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1536",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4jux6QVYAAD5ny.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831176690256654337",
+        "url": "https://twitter.com/nate_berg/status/831176690256654337",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/nate_berg/status/831176690256654337"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831184779370340353",
+        "url": "https://twitter.com/nate_berg/status/831184779370340353",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/nate_berg/status/831184779370340353"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829873930701639680",
+        "url": "https://twitter.com/nate_berg/status/829873930701639680",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/nate_berg/status/829873930701639680"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830087060086099968",
+        "url": "https://twitter.com/nate_berg/status/830087060086099968",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/nate_berg/status/830087060086099968"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831187741094260736",
+        "url": "https://twitter.com/nate_berg/status/831187741094260736",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/nate_berg/status/831187741094260736"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4j-VwtVcAAmMiD.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1536",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4j-VwtVcAAmMiD.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831193800240361472",
+        "url": "https://twitter.com/nate_berg/status/831193800240361472",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/nate_berg/status/831193800240361472"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4jddKkVYAARths.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1536",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4jddKkVYAARths.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831157639799148544",
+        "url": "https://twitter.com/nate_berg/status/831157639799148544",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/nate_berg/status/831157639799148544"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4jn-79UYAME79A.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1536",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4jn-79UYAME79A.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831169215394570240",
+        "url": "https://twitter.com/nate_berg/status/831169215394570240",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/nate_berg/status/831169215394570240"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831153303354540032",
+        "url": "https://twitter.com/sortegarango/status/831153303354540032",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/sortegarango/status/831153303354540032"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831125113651212288",
+        "url": "https://twitter.com/ClimateLabs_UK/status/831125113651212288",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/climatelabs_uk/status/831125113651212288"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4impqYUYAITUH1.jpg",
+          "fields": {
+            "width": "540",
+            "height": "960",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4impqYUYAITUH1.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831097518377218048",
+        "url": "https://twitter.com/shibayanraha/status/831097518377218048",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/shibayanraha/status/831097518377218048"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831151610583674880",
+        "url": "https://twitter.com/ninalakhani/status/831151610583674880",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ninalakhani/status/831151610583674880"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831155911196495872",
+        "url": "https://twitter.com/ninalakhani/status/831155911196495872",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ninalakhani/status/831155911196495872"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831146352998391812",
+        "url": "https://twitter.com/ninalakhani/status/831146352998391812",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ninalakhani/status/831146352998391812"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831160235385499649",
+        "url": "https://twitter.com/ninalakhani/status/831160235385499649",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ninalakhani/status/831160235385499649"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831130985165094912",
+        "url": "https://twitter.com/ninalakhani/status/831130985165094912",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ninalakhani/status/831130985165094912"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831134791340802048",
+        "url": "https://twitter.com/ninalakhani/status/831134791340802048",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ninalakhani/status/831134791340802048"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/831176571088052224/pu/img/X6EhXrxnY-E5gqA4.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "576",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/831176571088052224/pu/img/X6EhXrxnY-E5gqA4.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831176677791264769",
+        "url": "https://twitter.com/ptrmsk/status/831176677791264769",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ptrmsk/status/831176677791264769"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4jRNomVUAAQPtz.jpg",
+          "fields": {
+            "width": "1536",
+            "height": "2048",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4jRNomVUAAQPtz.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831144171348041729",
+        "url": "https://twitter.com/ptrmsk/status/831144171348041729",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ptrmsk/status/831144171348041729"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/831147515302940674/pu/img/sKFqMg7Ghhx3U84E.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "576",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/831147515302940674/pu/img/sKFqMg7Ghhx3U84E.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831147625164349440",
+        "url": "https://twitter.com/ptrmsk/status/831147625164349440",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ptrmsk/status/831147625164349440"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/B_1JVzoW8AA92n9.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "576",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/B_1JVzoW8AA92n9.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "575696966438490112",
+        "url": "https://twitter.com/grist/status/575696966438490112",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/grist/status/575696966438490112/photo/1"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831168943360442368",
+        "url": "https://twitter.com/jonathanwatts/status/831168943360442368",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jonathanwatts/status/831168943360442368"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831170256655757313",
+        "url": "https://twitter.com/jonathanwatts/status/831170256655757313",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jonathanwatts/status/831170256655757313"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831170699964403712",
+        "url": "https://twitter.com/jonathanwatts/status/831170699964403712",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jonathanwatts/status/831170699964403712"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831171183571828736",
+        "url": "https://twitter.com/jonathanwatts/status/831171183571828736",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jonathanwatts/status/831171183571828736"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831168749575217152",
+        "url": "https://twitter.com/jonathanwatts/status/831168749575217152",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jonathanwatts/status/831168749575217152"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831169420680687616",
+        "url": "https://twitter.com/jonathanwatts/status/831169420680687616",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jonathanwatts/status/831169420680687616"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831151183968481280",
+        "url": "https://twitter.com/tess_riley/status/831151183968481280",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tess_riley/status/831151183968481280"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831152819176484864",
+        "url": "https://twitter.com/tess_riley/status/831152819176484864",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tess_riley/status/831152819176484864"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4jasgkWIAAVTj_.jpg",
+          "fields": {
+            "width": "768",
+            "height": "1024",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4jasgkWIAAVTj_.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831154591886622725",
+        "url": "https://twitter.com/tess_riley/status/831154591886622725",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tess_riley/status/831154591886622725"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4jcqfFWMAAEev5.jpg",
+          "fields": {
+            "width": "768",
+            "height": "1024",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4jcqfFWMAAEev5.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831156756118114304",
+        "url": "https://twitter.com/tess_riley/status/831156756118114304",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tess_riley/status/831156756118114304"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4jblymWYAEQI3b.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "768",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4jblymWYAEQI3b.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831155575492841472",
+        "url": "https://twitter.com/tess_riley/status/831155575492841472",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tess_riley/status/831155575492841472"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4jDE9LXUAEu4K4.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1155",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4jDE9LXUAEu4K4.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831129031265361921",
+        "url": "https://twitter.com/HadassahEgbedi/status/831129031265361921",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/HadassahEgbedi/status/831129031265361921"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831131266292527105",
+        "url": "https://twitter.com/HadassahEgbedi/status/831131266292527105",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/HadassahEgbedi/status/831131266292527105"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831134370249469953",
+        "url": "https://twitter.com/HadassahEgbedi/status/831134370249469953",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/HadassahEgbedi/status/831134370249469953"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831121582177280002",
+        "url": "https://twitter.com/HadassahEgbedi/status/831121582177280002",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/HadassahEgbedi/status/831121582177280002"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4i-SpbWIAAL2hR.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1365",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4i-SpbWIAAL2hR.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831124038172942336",
+        "url": "https://twitter.com/HadassahEgbedi/status/831124038172942336",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/HadassahEgbedi/status/831124038172942336"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831097164336078851",
+        "url": "https://twitter.com/HadassahEgbedi/status/831097164336078851",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/HadassahEgbedi/status/831097164336078851"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831059063261667328",
+        "url": "https://twitter.com/DrAnnPower/status/831059063261667328",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/DrAnnPower/status/831059063261667328"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831080669556199424",
+        "url": "https://twitter.com/mwt2008/status/831080669556199424",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/mwt2008/status/831080669556199424"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831098180695621633",
+        "url": "https://twitter.com/bristolgreen/status/831098180695621633",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bristolgreen/status/831098180695621633"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831097981029982209",
+        "url": "https://twitter.com/ClimateLabs_UK/status/831097981029982209",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ClimateLabs_UK/status/831097981029982209"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4iGpvWWMAAjehF.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1536",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4iGpvWWMAAjehF.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831062214564073476",
+        "url": "https://twitter.com/helenpidd/status/831062214564073476",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/helenpidd/status/831062214564073476"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4itiK1UcAEHEsg.jpg",
+          "fields": {
+            "width": "1920",
+            "height": "1280",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4itiK1UcAEHEsg.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831104950126010368",
+        "url": "https://twitter.com/safimichael/status/831104950126010368",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/safimichael/status/831104950126010368"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4itiK-VcAALB6M.jpg",
+          "fields": {
+            "width": "1920",
+            "height": "1280",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4itiK-VcAALB6M.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831104950130216960",
+        "url": "https://twitter.com/safimichael/status/831104950130216960",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/safimichael/status/831104950130216960"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831079162307702785",
+        "url": "https://twitter.com/DilliSeb/status/831079162307702785",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/DilliSeb/status/831079162307702785"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4impqYUYAITUH1.jpg",
+          "fields": {
+            "width": "540",
+            "height": "960",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4impqYUYAITUH1.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831097518377218048",
+        "url": "https://twitter.com/shibayanraha/status/831097518377218048",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/shibayanraha/status/831097518377218048"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4ik110WAAAdRbB.jpg",
+          "fields": {
+            "width": "1536",
+            "height": "2048",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4ik110WAAAdRbB.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831095715782914049",
+        "url": "https://twitter.com/adiraj_dhar/status/831095715782914049",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/adiraj_dhar/status/831095715782914049"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831080910376280064",
+        "url": "https://twitter.com/erin_klassen/status/831080910376280064",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/erin_klassen/status/831080910376280064"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831089735401476097",
+        "url": "https://twitter.com/safimichael/status/831089735401476097",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/safimichael/status/831089735401476097"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4ikZIIVcAE8aZ4.jpg",
+          "fields": {
+            "width": "1920",
+            "height": "1280",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4ikZIIVcAE8aZ4.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831094911789207552",
+        "url": "https://twitter.com/safimichael/status/831094911789207552",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/safimichael/status/831094911789207552"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831095272734289920",
+        "url": "https://twitter.com/safimichael/status/831095272734289920",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/safimichael/status/831095272734289920"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831090415998636032",
+        "url": "https://twitter.com/safimichael/status/831090415998636032",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/safimichael/status/831090415998636032"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4iaxCBUkAAZ6wI.jpg",
+          "fields": {
+            "width": "1920",
+            "height": "1280",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4iaxCBUkAAZ6wI.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831084314347532289",
+        "url": "https://twitter.com/safimichael/status/831084314347532289",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/safimichael/status/831084314347532289"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831044071829368832",
+        "url": "https://twitter.com/ShanghaiEye/status/831044071829368832",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ShanghaiEye/status/831044071829368832"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831023327476998144",
+        "url": "https://twitter.com/chinaorgcn/status/831023327476998144",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/chinaorgcn/status/831023327476998144"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4iCoUzUYAEJpUH.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1536",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4iCoUzUYAEJpUH.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831057789870972928",
+        "url": "https://twitter.com/naamanzhou/status/831057789870972928",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/naamanzhou/status/831057789870972928"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831060299637678083",
+        "url": "https://twitter.com/naamanzhou/status/831060299637678083",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/naamanzhou/status/831060299637678083"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831052694492098560",
+        "url": "https://twitter.com/naamanzhou/status/831052694492098560",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/naamanzhou/status/831052694492098560"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "815769247104135170",
+        "url": "https://twitter.com/china_chas/status/815769247104135170",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/china_chas/status/815769247104135170"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830912969525465088",
+        "url": "https://twitter.com/tomphillipsin/status/830912969525465088",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tomphillipsin/status/830912969525465088"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589dfe18e4b0fcbf4e7d4843"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1058932703209213953",
+        "url": "https://twitter.com/ScottMorrisonMP/status/1058932703209213953",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ScottMorrisonMP/status/1058932703209213953"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-11-04",
+    "contentid": "5bdf5e18e4b066dcae08a980"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830508027409231873",
+        "url": "https://twitter.com/NSWRFS/status/830508027409231873",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/NSWRFS/status/830508027409231873"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-11",
+    "contentid": "589f82ade4b0fcbf4e7d4d9e"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4ZP8lMWAAEtpP3.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "768",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4ZP8lMWAAEtpP3.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830439086548729856",
+        "url": "https://twitter.com/colvinj/status/830439086548729856",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/colvinj/status/830439086548729856"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-11",
+    "contentid": "589f70e6e4b0fcbf4e7d4d70"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "977035961405198338",
+        "url": "https://twitter.com/OCHAAsiaPac/status/977035961405198338",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/OCHAAsiaPac/status/977035961405198338"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-03-23",
+    "contentid": "5ab48041e4b044506eec1ad9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830793164499931138",
+        "url": "https://twitter.com/IanStaffs/status/830793164499931138",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/IanStaffs/status/830793164499931138"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a03e73e4b0fcbf4e7d4fae"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4YrFpNWQAEJQRL.jpg",
+          "fields": {
+            "width": "1152",
+            "height": "2048",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4YrFpNWQAEJQRL.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830398576920559616",
+        "url": "https://twitter.com/MakeAmericaWait/status/830398576920559616",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MakeAmericaWait/status/830398576920559616"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-11",
+    "contentid": "589f305ae4b0fcbf4e7d4c3c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4YpZyEWYAAgSbN.jpg",
+          "fields": {
+            "width": "1152",
+            "height": "2048",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4YpZyEWYAAgSbN.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830396719389093889",
+        "url": "https://twitter.com/M_Ali_Salik/status/830396719389093889",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/M_Ali_Salik/status/830396719389093889"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-11",
+    "contentid": "589f305ae4b0fcbf4e7d4c3c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4Yv50LXAAAHT-7.jpg",
+          "fields": {
+            "width": "1152",
+            "height": "2048",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4Yv50LXAAAHT-7.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830403869758853121",
+        "url": "https://twitter.com/MakeAmericaWait/status/830403869758853121",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MakeAmericaWait/status/830403869758853121"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-11",
+    "contentid": "589f305ae4b0fcbf4e7d4c3c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4Y02HqXUAE3POm.jpg",
+          "fields": {
+            "width": "1152",
+            "height": "2048",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4Y02HqXUAE3POm.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830409300929605634",
+        "url": "https://twitter.com/MakeAmericaWait/status/830409300929605634",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MakeAmericaWait/status/830409300929605634"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-11",
+    "contentid": "589f305ae4b0fcbf4e7d4c3c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/830618299125862400/pu/img/rtgg1YxS_Nw2VbBR.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "576",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/830618299125862400/pu/img/rtgg1YxS_Nw2VbBR.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830640776786935808",
+        "url": "https://twitter.com/NBAInside_Stuff/status/830640776786935808",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/NBAInside_Stuff/status/830640776786935808"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0795ee4b0fcbf4e7d5098"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829649907229270016",
+        "url": "https://twitter.com/GaryLineker/status/829649907229270016",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GaryLineker/status/829649907229270016"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a071f4e4b012eeb30c91d5"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829836231802515457",
+        "url": "https://twitter.com/realDonaldTrump/status/829836231802515457",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/realDonaldTrump/status/829836231802515457"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d8372e4b01b5caf3cea00"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829842972506255360",
+        "url": "https://twitter.com/caseyjohnston/status/829842972506255360",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/caseyjohnston/status/829842972506255360"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d8372e4b01b5caf3cea00"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4QvFZGUYAAwO8d.jpg",
+          "fields": {
+            "width": "800",
+            "height": "450",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4QvFZGUYAAwO8d.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829840079132647424",
+        "url": "https://twitter.com/ArmsControlWonk/status/829840079132647424",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ArmsControlWonk/status/829840079132647424?ref_src=twsrc%5Etfw"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d8372e4b01b5caf3cea00"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4Quv_ZWAAQxrF8.jpg",
+          "fields": {
+            "width": "750",
+            "height": "350",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4Quv_ZWAAQxrF8.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829839637975822336",
+        "url": "https://twitter.com/markberman/status/829839637975822336",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/markberman/status/829839637975822336?ref_src=twsrc%5Etfw"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d8372e4b01b5caf3cea00"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4Q7asvXUAIwbLK.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "960",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4Q7asvXUAIwbLK.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829853569440440321",
+        "url": "https://twitter.com/GrossmanMax/status/829853569440440321",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GrossmanMax/status/829853569440440321"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d8372e4b01b5caf3cea00"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4Q1q8YVcAIDpUw.jpg",
+          "fields": {
+            "width": "1110",
+            "height": "740",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4Q1q8YVcAIDpUw.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829847303775096832",
+        "url": "https://twitter.com/0DanSmith/status/829847303775096832",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/0DanSmith/status/829847303775096832"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d8372e4b01b5caf3cea00"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829844161901842434",
+        "url": "https://twitter.com/SORRYNOTSOORRY/status/829844161901842434",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SORRYNOTSOORRY/status/829844161901842434?ref_src=twsrc%5Etfw"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d8372e4b01b5caf3cea00"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829839202019921920",
+        "url": "https://twitter.com/bobby/status/829839202019921920",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/bobby/status/829839202019921920"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d8372e4b01b5caf3cea00"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829839322186706947",
+        "url": "https://twitter.com/mileskahn/status/829839322186706947",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/mileskahn/status/829839322186706947"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d8372e4b01b5caf3cea00"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829846842150096896",
+        "url": "https://twitter.com/HillaryClinton/status/829846842150096896",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/HillaryClinton/status/829846842150096896?ref_src=twsrc%5Etfw"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d8372e4b01b5caf3cea00"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "828575949268606977",
+        "url": "https://twitter.com/realDonaldTrump/status/828575949268606977",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/realDonaldTrump/status/828575949268606977"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d8372e4b01b5caf3cea00"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/C3_cDNIWEAEAnHN.jpg",
+          "fields": {
+            "width": "350",
+            "height": "248",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/C3_cDNIWEAEAnHN.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "828622822427787266",
+        "url": "https://twitter.com/online_shawn/status/828622822427787266",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/online_shawn/status/828622822427787266"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d8372e4b01b5caf3cea00"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/C3-0J-LXAAAjiF2.jpg",
+          "fields": {
+            "width": "220",
+            "height": "192",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/C3-0J-LXAAAjiF2.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "828578948279889920",
+        "url": "https://twitter.com/mattleys/status/828578948279889920",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/mattleys/status/828578948279889920"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d8372e4b01b5caf3cea00"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/C3wUnD1VcAA71be.jpg",
+          "fields": {
+            "width": "746",
+            "height": "648",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/C3wUnD1VcAA71be.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "827568589607694336",
+        "url": "https://twitter.com/TrumpDraws/status/827568589607694336",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TrumpDraws/status/827568589607694336"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d8372e4b01b5caf3cea00"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/EJ59hjKWkAAhQCu.jpg",
+          "fields": {
+            "width": "1080",
+            "height": "1080",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/EJ59hjKWkAAhQCu.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1197533872310947846",
+        "url": "https://twitter.com/jeremycorbyn/status/1197533872310947846",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jeremycorbyn/status/1197533872310947846?s=20"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-11-25",
+    "contentid": "5ddbd4f38f087b800b620bef"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1204472894312583170",
+        "url": "https://twitter.com/QPR/status/1204472894312583170",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/QPR/status/1204472894312583170"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-12-10",
+    "contentid": "5defeb258f08eea0cdc2b5d1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1035779093000855552",
+        "url": "https://twitter.com/EamonRyan/status/1035779093000855552",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/EamonRyan/status/1035779093000855552"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-09-01",
+    "contentid": "5b8a97c7e4b0c18ca380b64e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829706439476211714",
+        "url": "https://twitter.com/britainelects/status/829706439476211714",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/britainelects/status/829706439476211714"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d63f6e4b01b5caf3ce98d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829824093193125888",
+        "url": "https://twitter.com/britainelects/status/829824093193125888",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/britainelects/status/829824093193125888"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d63f6e4b01b5caf3ce98d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829824435788062721",
+        "url": "https://twitter.com/britainelects/status/829824435788062721",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/britainelects/status/829824435788062721"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d63f6e4b01b5caf3ce98d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829830098211729408",
+        "url": "https://twitter.com/britainelects/status/829830098211729408",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/britainelects/status/829830098211729408"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d63f6e4b01b5caf3ce98d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829833963032166400",
+        "url": "https://twitter.com/britainelects/status/829833963032166400",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/britainelects/status/829833963032166400"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d63f6e4b01b5caf3ce98d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829830710567514112",
+        "url": "https://twitter.com/britainelects/status/829830710567514112",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/britainelects/status/829830710567514112"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d63f6e4b01b5caf3ce98d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829830856982269953",
+        "url": "https://twitter.com/britainelects/status/829830856982269953",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/britainelects/status/829830856982269953"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d63f6e4b01b5caf3ce98d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829835629605376000",
+        "url": "https://twitter.com/britainelects/status/829835629605376000",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/britainelects/status/829835629605376000"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d63f6e4b01b5caf3ce98d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829835869557252096",
+        "url": "https://twitter.com/britainelects/status/829835869557252096",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/britainelects/status/829835869557252096"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d63f6e4b01b5caf3ce98d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829836564196888576",
+        "url": "https://twitter.com/britainelects/status/829836564196888576",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/britainelects/status/829836564196888576"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d63f6e4b01b5caf3ce98d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829837060865417217",
+        "url": "https://twitter.com/britainelects/status/829837060865417217",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/britainelects/status/829837060865417217"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d63f6e4b01b5caf3ce98d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829843626196865024",
+        "url": "https://twitter.com/britainelects/status/829843626196865024",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/britainelects/status/829843626196865024"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d63f6e4b01b5caf3ce98d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831171616004513792",
+        "url": "https://twitter.com/TrumpModels/status/831171616004513792",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/TrumpModels/status/831171616004513792"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589e2b4ae4b0fcbf4e7d490c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830833729996201986",
+        "url": "https://twitter.com/OptaJoe/status/830833729996201986",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/OptaJoe/status/830833729996201986"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a03cd5e4b09b65848eac74"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830802931406364672",
+        "url": "https://twitter.com/tkesgar/status/830802931406364672",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tkesgar/status/830802931406364672"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a03cd5e4b09b65848eac74"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830801134159745024",
+        "url": "https://twitter.com/OptaJoe/status/830801134159745024",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/OptaJoe/status/830801134159745024"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a03cd5e4b09b65848eac74"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829516437454663680",
+        "url": "https://twitter.com/Rachel__Nichols/status/829516437454663680",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Rachel__Nichols/status/829516437454663680"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589e0fc0e4b0fcbf4e7d4893"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830739426426884096",
+        "url": "https://twitter.com/metoffice/status/830739426426884096",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/metoffice/status/830739426426884096"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a04879e4b0fcbf4e7d4fc9"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1174880425996509184",
+        "url": "https://twitter.com/SamCucchiara9/status/1174880425996509184",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SamCucchiara9/status/1174880425996509184?s=20"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-09-20",
+    "contentid": "5d843c048f08f9df5bdd7e8d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1174932770079928320",
+        "url": "https://twitter.com/DamonAM/status/1174932770079928320",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/DamonAM/status/1174932770079928320?s=20"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-09-20",
+    "contentid": "5d843c048f08f9df5bdd7e8d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1174869889422524417",
+        "url": "https://twitter.com/CMMortlock/status/1174869889422524417",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/CMMortlock/status/1174869889422524417?s=20"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-09-20",
+    "contentid": "5d843c048f08f9df5bdd7e8d"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1047050590797385730",
+        "url": "https://twitter.com/AlunCairns/status/1047050590797385730",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AlunCairns/status/1047050590797385730"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-10-02",
+    "contentid": "5bb34258e4b0b8830be678a1"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830474867602505728",
+        "url": "https://twitter.com/garynaylor999/status/830474867602505728",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/garynaylor999/status/830474867602505728"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-11",
+    "contentid": "589ef4bbe4b09b65848ea7d7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830468990518620161",
+        "url": "https://twitter.com/HughTaylor48/status/830468990518620161",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/HughTaylor48/status/830468990518620161"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-11",
+    "contentid": "589ef4bbe4b09b65848ea7d7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830468997439188992",
+        "url": "https://twitter.com/GuyHornsby/status/830468997439188992",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GuyHornsby/status/830468997439188992"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-11",
+    "contentid": "589ef4bbe4b09b65848ea7d7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830461533226348545",
+        "url": "https://twitter.com/brasil196333/status/830461533226348545",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/brasil196333/status/830461533226348545"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-11",
+    "contentid": "589ef4bbe4b09b65848ea7d7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830460549246906368",
+        "url": "https://twitter.com/JohnRogersShow/status/830460549246906368",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/JohnRogersShow/status/830460549246906368"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-11",
+    "contentid": "589ef4bbe4b09b65848ea7d7"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4ZdwIKW8AEUgHV.jpg",
+          "fields": {
+            "width": "1847",
+            "height": "2047",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4ZdwIKW8AEUgHV.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830454307661238272",
+        "url": "https://twitter.com/giteau_rugby/status/830454307661238272",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/giteau_rugby/status/830454307661238272"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-11",
+    "contentid": "589ef4bbe4b09b65848ea7d7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830443016871608333",
+        "url": "https://twitter.com/BBCWalesSport/status/830443016871608333",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BBCWalesSport/status/830443016871608333?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-11",
+    "contentid": "589ef4bbe4b09b65848ea7d7"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4GCQK7UoAAlvlx.jpg",
+          "fields": {
+            "width": "639",
+            "height": "287",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4GCQK7UoAAlvlx.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829090777896722434",
+        "url": "https://twitter.com/Paul1Singh/status/829090777896722434",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Paul1Singh/status/829090777896722434?ref_src=twsrc%5Etfw"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589d8658e4b0e78a1131dda8"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/C4ZN4B2W8AA-JJc.jpg",
+          "fields": {
+            "width": "640",
+            "height": "360",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/C4ZN4B2W8AA-JJc.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830436992437596161",
+        "url": "https://twitter.com/ForwardHamlet/status/830436992437596161",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ForwardHamlet/status/830436992437596161"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-10",
+    "contentid": "589e2ef1e4b012eeb30c8a32"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830617642771701760",
+        "url": "https://twitter.com/AustralisTerry/status/830617642771701760",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/AustralisTerry/status/830617642771701760"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0e92fe4b0fcbf4e7d5294"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830567820597481472",
+        "url": "https://twitter.com/CliveCHamilton/status/830567820597481472",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/CliveCHamilton/status/830567820597481472"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0e92fe4b0fcbf4e7d5294"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4WBOiSUkAILmcF.jpg",
+          "fields": {
+            "width": "1140",
+            "height": "472",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4WBOiSUkAILmcF.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830211810590482432",
+        "url": "https://twitter.com/GeorgeBludger/status/830211810590482432",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GeorgeBludger/status/830211810590482432"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0e92fe4b0fcbf4e7d5294"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4fpuXgVMAEQmOR.jpg",
+          "fields": {
+            "width": "763",
+            "height": "1105",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4fpuXgVMAEQmOR.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830889659047636992",
+        "url": "https://twitter.com/BrigadierSlog/status/830889659047636992",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BrigadierSlog/status/830889659047636992"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0e92fe4b0fcbf4e7d5294"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830508345094189056",
+        "url": "https://twitter.com/GEsfandiari/status/830508345094189056",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideMedia": "true",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GEsfandiari/status/830508345094189056"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a1bec7e4b0fcbf4e7d55bf"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/1217324496039792645/pu/img/2O_1_jFRM7a5ufGU.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/1217324496039792645/pu/img/2O_1_jFRM7a5ufGU.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "1217324535940149248",
+        "url": "https://twitter.com/Isk137/status/1217324535940149248",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Isk137/status/1217324535940149248"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-01-15",
+    "contentid": "5e1e97708f08d66fcfaa42ac"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1217373618335694853",
+        "url": "https://twitter.com/DanStrickAus/status/1217373618335694853",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/danstrickaus/status/1217373618335694853?s=21"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-01-15",
+    "contentid": "5e1e97708f08d66fcfaa42ac"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1217327195762368512",
+        "url": "https://twitter.com/BOM_Vic/status/1217327195762368512",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BOM_Vic/status/1217327195762368512"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-01-15",
+    "contentid": "5e1e97708f08d66fcfaa42ac"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1216501456108343296",
+        "url": "https://twitter.com/NSWRFS/status/1216501456108343296",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/NSWRFS/status/1216501456108343296"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-01-15",
+    "contentid": "5e1e97708f08d66fcfaa42ac"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1217324793956929536",
+        "url": "https://twitter.com/maartenijzerman/status/1217324793956929536",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/maartenijzerman/status/1217324793956929536"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-01-15",
+    "contentid": "5e1e97708f08d66fcfaa42ac"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1217282413522538496",
+        "url": "https://twitter.com/BOM_WA/status/1217282413522538496",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BOM_WA/status/1217282413522538496"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-01-15",
+    "contentid": "5e1e97708f08d66fcfaa42ac"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1217329664064204800",
+        "url": "https://twitter.com/BOM_Qld/status/1217329664064204800",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BOM_Qld/status/1217329664064204800"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-01-15",
+    "contentid": "5e1e97708f08d66fcfaa42ac"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4Q0ACmVMAAMRP_.jpg",
+          "fields": {
+            "width": "1400",
+            "height": "786",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4Q0ACmVMAAMRP_.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "829845414673125376",
+        "url": "https://twitter.com/mosesbread72/status/829845414673125376",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/mosesbread72/status/829845414673125376"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-11",
+    "contentid": "589f528fe4b09b65848ea986"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4jbnHeXAAEKOWN.jpg",
+          "fields": {
+            "width": "843",
+            "height": "474",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4jbnHeXAAEKOWN.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831156246929608704",
+        "url": "https://twitter.com/EU_Commission/status/831156246929608704",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/EU_Commission/status/831156246929608704"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a1d767e4b0fcbf4e7d563b"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831244402370678784",
+        "url": "https://twitter.com/garynaylor999/status/831244402370678784",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/garynaylor999/status/831244402370678784"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a1af4be4b09b65848eb258"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831237675759845377",
+        "url": "https://twitter.com/LeroyKeats/status/831237675759845377",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/LeroyKeats/status/831237675759845377"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a1af4be4b09b65848eb258"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831236963382546432",
+        "url": "https://twitter.com/NickMiller79/status/831236963382546432",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/NickMiller79/status/831236963382546432"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a1af4be4b09b65848eb258"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/830764469810765825/pu/img/6mrOblVCaWohYLdY.jpg",
+          "fields": {
+            "width": "384",
+            "height": "180",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/830764469810765825/pu/img/6mrOblVCaWohYLdY.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830764521996374016",
+        "url": "https://twitter.com/_AndyHa/status/830764521996374016",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/_AndyHa/status/830764521996374016"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "589fa614e4b012eeb30c8f53"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830761479813079040",
+        "url": "https://twitter.com/jimw1/status/830761479813079040",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/jimw1/status/830761479813079040"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "589fa614e4b012eeb30c8f53"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4UI215WcAAIfSI.jpg",
+          "fields": {
+            "width": "480",
+            "height": "480",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4UI215WcAAIfSI.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830522554636853248",
+        "url": "https://twitter.com/Channel4/status/830522554636853248",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Channel4/status/830522554636853248"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "589fa614e4b012eeb30c8f53"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4duc0GVUAAU3-7.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1365",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4duc0GVUAAU3-7.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830754100065292288",
+        "url": "https://twitter.com/premierleague/status/830754100065292288",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/premierleague/status/830754100065292288"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "589fa614e4b012eeb30c8f53"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "829442621340803083",
+        "url": "https://twitter.com/NicolaSturgeon/status/829442621340803083",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/NicolaSturgeon/status/829442621340803083?ref_src=twsrc%5Etfw"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a1870fe4b09b65848eb195"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1098302793046122496",
+        "url": "https://twitter.com/caro_milanesi/status/1098302793046122496",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/caro_milanesi/status/1098302793046122496"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-02-21",
+    "contentid": "5c6e882de4b00307e95a77f5"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4fPexlWQAA8fi7.jpg",
+          "fields": {
+            "width": "1148",
+            "height": "958",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4fPexlWQAA8fi7.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830860851108335619",
+        "url": "https://twitter.com/owenjbennett/status/830860851108335619",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/owenjbennett/status/830860851108335619"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a1ad53e4b09b65848eb24f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830894614332702722",
+        "url": "https://twitter.com/Arron_banks/status/830894614332702722",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Arron_banks/status/830894614332702722"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a1ad53e4b09b65848eb24f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831087970627227648",
+        "url": "https://twitter.com/DavidLammy/status/831087970627227648",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/DavidLammy/status/831087970627227648?ref_src=twsrc%5Etfw"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a1ad53e4b09b65848eb24f"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/C4g9o7DWcAAkztP.jpg",
+          "fields": {
+            "width": "390",
+            "height": "276",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/C4g9o7DWcAAkztP.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830982535681277956",
+        "url": "https://twitter.com/Musicnews_feed/status/830982535681277956",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Musicnews_feed/status/830982535681277956?ref_src=twsrc%5Etfw"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a1a721e4b012eeb30c96d2"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/830979361704513536/pu/img/sMK8Ypgg5KBWzsBy.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "576",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/830979361704513536/pu/img/sMK8Ypgg5KBWzsBy.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830979481095569408",
+        "url": "https://twitter.com/cjzero/status/830979481095569408",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/cjzero/status/830979481095569408"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a1a4ace4b0fcbf4e7d554c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831576508288401408",
+        "url": "https://twitter.com/LaurensJulien/status/831576508288401408",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/LaurensJulien/status/831576508288401408"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a1c194e4b012eeb30c975b"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4Vthe_XAAACwts.jpg",
+          "fields": {
+            "width": "400",
+            "height": "400",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4Vthe_XAAACwts.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830774712846348288",
+        "url": "https://twitter.com/usedgov/status/830774712846348288",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/usedgov/status/830774712846348288"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a111f4e4b09b65848eafeb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830862058719584256",
+        "url": "https://twitter.com/tariqnasheed/status/830862058719584256",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/tariqnasheed/status/830862058719584256"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a111f4e4b09b65848eafeb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830795035037859840",
+        "url": "https://twitter.com/soledadobrien/status/830795035037859840",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/soledadobrien/status/830795035037859840"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a111f4e4b09b65848eafeb"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831001593550163968",
+        "url": "https://twitter.com/NSWRFS/status/831001593550163968",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/NSWRFS/status/831001593550163968"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0e715e4b0fcbf4e7d528c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830915871514128385",
+        "url": "https://twitter.com/ABCemergency/status/830915871514128385",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ABCemergency/status/830915871514128385"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0e715e4b0fcbf4e7d528c"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830748334516080642",
+        "url": "https://twitter.com/ShooterWol/status/830748334516080642",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ShooterWol/status/830748334516080642"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0e715e4b0fcbf4e7d528c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4gP7uKVcAEbL1j.jpg",
+          "fields": {
+            "width": "460",
+            "height": "259",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4gP7uKVcAEbL1j.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830931681859153920",
+        "url": "https://twitter.com/abcnews/status/830931681859153920",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/abcnews/status/830931681859153920"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0e715e4b0fcbf4e7d528c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4ckZGoVcAAdGgp.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1366",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4ckZGoVcAAdGgp.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830672713601609728",
+        "url": "https://twitter.com/ellinghausen/status/830672713601609728",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ellinghausen/status/830672713601609728"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0e715e4b0fcbf4e7d528c"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/830990428514217987/pu/img/Z2XiME-8a4k_pbCB.jpg",
+          "fields": {
+            "width": "500",
+            "height": "460",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/830990428514217987/pu/img/Z2XiME-8a4k_pbCB.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830990475150639104",
+        "url": "https://twitter.com/RNavyBrazil/status/830990475150639104",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/RNavyBrazil/status/830990475150639104"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a17551e4b0fcbf4e7d547f"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/C4g9o7DWcAAkztP.jpg",
+          "fields": {
+            "width": "390",
+            "height": "276",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/C4g9o7DWcAAkztP.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830982535681277956",
+        "url": "https://twitter.com/Musicnews_feed/status/830982535681277956",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Musicnews_feed/status/830982535681277956"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a17551e4b0fcbf4e7d547f"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/830985307004755968/pu/img/7Mvndz11D_mxUjjL.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "576",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/830985307004755968/pu/img/7Mvndz11D_mxUjjL.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830985402467102720",
+        "url": "https://twitter.com/GxdCxmplex/status/830985402467102720",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GxdCxmplex/status/830985402467102720"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a17551e4b0fcbf4e7d547f"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4hEa24UkAADpwS.jpg",
+          "fields": {
+            "width": "1200",
+            "height": "579",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4hEa24UkAADpwS.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830989379925590017",
+        "url": "https://twitter.com/FIirtationship/status/830989379925590017",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/FIirtationship/status/830989379925590017"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a17551e4b0fcbf4e7d547f"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/830964100070985728/pu/img/ZMB4ZyyVvPVVxi61.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "576",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/830964100070985728/pu/img/ZMB4ZyyVvPVVxi61.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830964460386938883",
+        "url": "https://twitter.com/BeyLovesGaga/status/830964460386938883",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BeyLovesGaga/status/830964460386938883"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a17551e4b0fcbf4e7d547f"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/C4gynViUoAAs-BD.jpg",
+          "fields": {
+            "width": "640",
+            "height": "360",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/C4gynViUoAAs-BD.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830972188673052673",
+        "url": "https://twitter.com/BeyonceCapital/status/830972188673052673",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BeyonceCapital/status/830972188673052673"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a17551e4b0fcbf4e7d547f"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4gqSmSUcAA3wug.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1536",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4gqSmSUcAA3wug.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830960637060620288",
+        "url": "https://twitter.com/brownlashon/status/830960637060620288",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/brownlashon/status/830960637060620288"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a17551e4b0fcbf4e7d547f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830959573699694592",
+        "url": "https://twitter.com/chrissyteigen/status/830959573699694592",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/chrissyteigen/status/830959573699694592"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a17551e4b0fcbf4e7d547f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830979300266385408",
+        "url": "https://twitter.com/HereIsGina/status/830979300266385408",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/HereIsGina/status/830979300266385408"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a17551e4b0fcbf4e7d547f"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4gTFplXAAIgw2g.jpg",
+          "fields": {
+            "width": "1008",
+            "height": "670",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4gTFplXAAIgw2g.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830935134404747265",
+        "url": "https://twitter.com/nutellaANDpizza/status/830935134404747265",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/nutellaANDpizza/status/830935134404747265"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a17551e4b0fcbf4e7d547f"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4gUCPOUkAAPdVJ.jpg",
+          "fields": {
+            "width": "1365",
+            "height": "2048",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4gUCPOUkAAPdVJ.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830936187271409664",
+        "url": "https://twitter.com/kingsleyyy/status/830936187271409664",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/kingsleyyy/status/830936187271409664"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a17551e4b0fcbf4e7d547f"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4gZlSfVUAAZxQ6.jpg",
+          "fields": {
+            "width": "702",
+            "height": "493",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4gZlSfVUAAZxQ6.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830989885850939392",
+        "url": "https://twitter.com/KermitDarkMeme/status/830989885850939392",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/KermitDarkMeme/status/830989885850939392"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a17551e4b0fcbf4e7d547f"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4hdHuWWQAAq-XZ.jpg",
+          "fields": {
+            "width": "583",
+            "height": "489",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4hdHuWWQAAq-XZ.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831016523212976128",
+        "url": "https://twitter.com/yashar/status/831016523212976128",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/yashar/status/831016523212976128"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a17551e4b0fcbf4e7d547f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831023103819997186",
+        "url": "https://twitter.com/karlatheblonde/status/831023103819997186",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/karlatheblonde/status/831023103819997186"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-13",
+    "contentid": "58a17551e4b0fcbf4e7d547f"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1154465833113927680",
+        "url": "https://twitter.com/SteveBakerHW/status/1154465833113927680",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SteveBakerHW/status/1154465833113927680"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-07-25",
+    "contentid": "5d39e3978f0845f89e3145ca"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1154432825870966785",
+        "url": "https://twitter.com/S_Hammond/status/1154432825870966785",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "hideThread": "true",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/S_Hammond/status/1154432825870966785"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-07-25",
+    "contentid": "5d39e3978f0845f89e3145ca"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1154326928456916992",
+        "url": "https://twitter.com/ConorBurnsUK/status/1154326928456916992",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ConorBurnsUK/status/1154326928456916992"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-07-25",
+    "contentid": "5d39e3978f0845f89e3145ca"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1133322573696184320",
+        "url": "https://twitter.com/MPSWestminster/status/1133322573696184320",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MPSWestminster/status/1133322573696184320"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2019-05-28",
+    "contentid": "5ced3b508f0807b455f89c50"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937264344173121536",
+        "url": "https://twitter.com/CricketAus/status/937264344173121536",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/CricketAus/status/937264344173121536"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937246757771206656",
+        "url": "https://twitter.com/selvecricket/status/937246757771206656",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/selvecricket/status/937246757771206656"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937223469036576768",
+        "url": "https://twitter.com/KP24/status/937223469036576768",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/KP24/status/937223469036576768"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937208818718482432",
+        "url": "https://twitter.com/danbrettig/status/937208818718482432",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/danbrettig/status/937208818718482432"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937207512465657857",
+        "url": "https://twitter.com/garynaylor999/status/937207512465657857",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/garynaylor999/status/937207512465657857"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937204908620730370",
+        "url": "https://twitter.com/CricProf/status/937204908620730370",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/CricProf/status/937204908620730370"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937203676996820993",
+        "url": "https://twitter.com/sirswampthing/status/937203676996820993",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/sirswampthing/status/937203676996820993"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937195568656297984",
+        "url": "https://twitter.com/KP24/status/937195568656297984",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/KP24/status/937195568656297984"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937192412027543553",
+        "url": "https://twitter.com/sportzzzgirl/status/937192412027543553",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/sportzzzgirl/status/937192412027543553"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937191457307414528",
+        "url": "https://twitter.com/OptaJim/status/937191457307414528",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/OptaJim/status/937191457307414528"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937187922918412288",
+        "url": "https://twitter.com/Matt_Huxley/status/937187922918412288",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Matt_Huxley/status/937187922918412288"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937186877135716352",
+        "url": "https://twitter.com/Roscommon_Cat/status/937186877135716352",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Roscommon_Cat/status/937186877135716352"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937183426343419904",
+        "url": "https://twitter.com/KP24/status/937183426343419904",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/KP24/status/937183426343419904"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937183449248546817",
+        "url": "https://twitter.com/Roscommon_Cat/status/937183449248546817",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Roscommon_Cat/status/937183449248546817"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937181861352214528",
+        "url": "https://twitter.com/pfon73/status/937181861352214528",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/pfon73/status/937181861352214528"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937174232852717568",
+        "url": "https://twitter.com/collinsadam/status/937174232852717568",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/collinsadam/status/937174232852717568"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937169819048144896",
+        "url": "https://twitter.com/GeoffLemonSport/status/937169819048144896",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/GeoffLemonSport/status/937169819048144896"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937162688869871616",
+        "url": "https://twitter.com/11AMdeclaration/status/937162688869871616",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/11AMdeclaration/status/937162688869871616"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937159504835198977",
+        "url": "https://twitter.com/RicFinlay/status/937159504835198977",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/RicFinlay/status/937159504835198977"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/DQF1Bl8UQAAYu7T.jpg",
+          "fields": {
+            "width": "468",
+            "height": "264",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/DQF1Bl8UQAAYu7T.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "937158881247035393",
+        "url": "https://twitter.com/CricketAus/status/937158881247035393",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/CricketAus/status/937158881247035393"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937158154957209600",
+        "url": "https://twitter.com/willis_macp/status/937158154957209600",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/willis_macp/status/937158154957209600"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/937149892962615296/pu/img/yrV1NU49zAkyHCqR.jpg",
+          "fields": {
+            "width": "720",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/937149892962615296/pu/img/yrV1NU49zAkyHCqR.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "937149986952822784",
+        "url": "https://twitter.com/CricketAus/status/937149986952822784",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/CricketAus/status/937149986952822784"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DQFYIxVU8AEOi31.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DQFYIxVU8AEOi31.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "937127185327915009",
+        "url": "https://twitter.com/btsportcricket/status/937127185327915009",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/btsportcricket/status/937127185327915009"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "937146335064506368",
+        "url": "https://twitter.com/the_topspin/status/937146335064506368",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/the_topspin/status/937146335064506368"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DQFm6XXVoAE67zS.jpg",
+          "fields": {
+            "width": "2048",
+            "height": "1536",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DQFm6XXVoAE67zS.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "937143427610828800",
+        "url": "https://twitter.com/timwig/status/937143427610828800",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/timwig/status/937143427610828800"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a2134f20470380699b52bb3"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "847766558520856578",
+        "url": "https://twitter.com/realDonaldTrump/status/847766558520856578",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/realDonaldTrump/status/847766558520856578"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a21646aae3bcb05d2023434"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "936512587428188160",
+        "url": "https://twitter.com/SophieRunning/status/936512587428188160",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/SophieRunning/status/936512587428188160"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-12-01",
+    "contentid": "5a20ff400470380699b52a62"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1042042059404795904",
+        "url": "https://twitter.com/danielstorey85/status/1042042059404795904",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/danielstorey85/status/1042042059404795904"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-09-09",
+    "contentid": "5b94dbffe4b067ed00fdef48"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "517628299414364160",
+        "url": "https://twitter.com/ClimateOfGavin/statuses/517628299414364160",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/ClimateOfGavin/status/517628299414364160"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2014-10-01",
+    "contentid": "542be252e4b0c63dd7f56d5e"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1243065656687255553",
+        "url": "https://twitter.com/theMJA/status/1243065656687255553",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/theMJA/status/1243065656687255553"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-03-27",
+    "contentid": "5e7d508a8f0878a2a48ab169"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/ext_tw_video_thumb/831003500339425280/pu/img/Y27sLw72xx7LyJo8.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "576",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/ext_tw_video_thumb/831003500339425280/pu/img/Y27sLw72xx7LyJo8.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "831009967893278720",
+        "url": "https://twitter.com/sharonbell111/status/831009967893278720",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/sharonbell111/status/831009967893278720"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0b281e4b012eeb30c9308"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831001801168138240",
+        "url": "https://twitter.com/natalieweiner/status/831001801168138240",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/natalieweiner/status/831001801168138240"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0b281e4b012eeb30c9308"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831000348810674176",
+        "url": "https://twitter.com/rgay/status/831000348810674176",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/rgay/status/831000348810674176"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0b281e4b012eeb30c9308"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831002346998099969",
+        "url": "https://twitter.com/Samynemir/status/831002346998099969",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Samynemir/status/831002346998099969"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0b281e4b012eeb30c9308"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "831000572098650113",
+        "url": "https://twitter.com/djkhaled/status/831000572098650113",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/djkhaled/status/831000572098650113"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0b281e4b012eeb30c9308"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/tweet_video_thumb/C4g9o7DWcAAkztP.jpg",
+          "fields": {
+            "width": "390",
+            "height": "276",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/tweet_video_thumb/C4g9o7DWcAAkztP.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830985800154218497",
+        "url": "https://twitter.com/ImNyce908/status/830985800154218497",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ImNyce908/status/830985800154218497"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0b281e4b012eeb30c9308"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/amplify_video_thumb/830963435261227009/img/cPxpJM53uVECb7dQ.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "576",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/amplify_video_thumb/830963435261227009/img/cPxpJM53uVECb7dQ.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830965201184780288",
+        "url": "https://twitter.com/Kingwole/status/830965201184780288",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Kingwole/status/830965201184780288/video/1"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0b281e4b012eeb30c9308"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4gy0IAVMAEIoyb.jpg",
+          "fields": {
+            "width": "558",
+            "height": "309",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4gy0IAVMAEIoyb.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830970020364644352",
+        "url": "https://twitter.com/MatthewACherry/status/830970020364644352",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/MatthewACherry/status/830970020364644352"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0b281e4b012eeb30c9308"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4gj0irWcAI0syz.jpg",
+          "fields": {
+            "width": "531",
+            "height": "594",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4gj0irWcAI0syz.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830953687338143746",
+        "url": "https://twitter.com/BuzzFeed/status/830953687338143746",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/BuzzFeed/status/830953687338143746?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0b281e4b012eeb30c9308"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4gdS0sUYAAXZqw.jpg",
+          "fields": {
+            "width": "1280",
+            "height": "720",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4gdS0sUYAAXZqw.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830946348618903552",
+        "url": "https://twitter.com/THR/status/830946348618903552",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/THR/status/830946348618903552"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0b281e4b012eeb30c9308"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4gY0dWVYAAWhA6.jpg",
+          "fields": {
+            "width": "1072",
+            "height": "1072",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4gY0dWVYAAWhA6.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830941432437280768",
+        "url": "https://twitter.com/ladygagarazzi/status/830941432437280768",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/ladygagarazzi/status/830941432437280768"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0b281e4b012eeb30c9308"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4bePYUWQAAs11S.jpg",
+          "fields": {
+            "width": "750",
+            "height": "1334",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4bePYUWQAAs11S.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830595553931227136",
+        "url": "https://twitter.com/strange_mercyy/status/830595553931227136",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/strange_mercyy/status/830595553931227136"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0b281e4b012eeb30c9308"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4gVm-3WEAUAlun.jpg",
+          "fields": {
+            "width": "405",
+            "height": "361",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4gVm-3WEAUAlun.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830937896282628096",
+        "url": "https://twitter.com/HYPEBEAST/status/830937896282628096",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/HYPEBEAST/status/830937896282628096"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0b281e4b012eeb30c9308"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4gShyrXUAAC4CM.jpg",
+          "fields": {
+            "width": "988",
+            "height": "552",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4gShyrXUAAC4CM.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830934507649953792",
+        "url": "https://twitter.com/Musicnews_feed/status/830934507649953792",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/Musicnews_feed/status/830934507649953792"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0b281e4b012eeb30c9308"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/C4gP36LUoAAq8jh.jpg",
+          "fields": {
+            "width": "750",
+            "height": "1334",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/C4gP36LUoAAq8jh.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "830931592499585028",
+        "url": "https://twitter.com/itsthereal/status/830931592499585028",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/itsthereal/status/830931592499585028"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a0b281e4b012eeb30c9308"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607927038301859840",
+        "url": "https://twitter.com/tnewtondunn/statuses/607927038301859840",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/tnewtondunn/status/607927038301859840"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607910253326434304",
+        "url": "https://twitter.com/andybell5news/statuses/607910253326434304",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/andybell5news/status/607910253326434304"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607913419770085376",
+        "url": "https://twitter.com/JBeattieMirror/statuses/607913419770085376",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/JBeattieMirror/status/607913419770085376"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607912988184576001",
+        "url": "https://twitter.com/NigelpMorris/statuses/607912988184576001",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/NigelpMorris/status/607912988184576001"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607914240024920064",
+        "url": "https://twitter.com/faisalislam/statuses/607914240024920064",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/faisalislam/status/607914240024920064"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607910349023662082",
+        "url": "https://twitter.com/rafaelbehr/statuses/607910349023662082",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/rafaelbehr/status/607910349023662082"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607911186244452352",
+        "url": "https://twitter.com/ShippersUnbound/statuses/607911186244452352",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/ShippersUnbound/status/607911186244452352"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607912129673469953",
+        "url": "https://twitter.com/ShippersUnbound/statuses/607912129673469953",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/ShippersUnbound/status/607912129673469953"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607912311442046976",
+        "url": "https://twitter.com/ShippersUnbound/statuses/607912311442046976",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/ShippersUnbound/status/607912311442046976"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607912504451309569",
+        "url": "https://twitter.com/ShippersUnbound/statuses/607912504451309569",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/ShippersUnbound/status/607912504451309569"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607912750438883328",
+        "url": "https://twitter.com/ShippersUnbound/statuses/607912750438883328",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/ShippersUnbound/status/607912750438883328"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607912979569475584",
+        "url": "https://twitter.com/ShippersUnbound/statuses/607912979569475584",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/ShippersUnbound/status/607912979569475584"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607913345883238400",
+        "url": "https://twitter.com/ShippersUnbound/statuses/607913345883238400",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/ShippersUnbound/status/607913345883238400"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607913806027751425",
+        "url": "https://twitter.com/ShippersUnbound/statuses/607913806027751425",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/ShippersUnbound/status/607913806027751425"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607914355338936320",
+        "url": "https://twitter.com/ShippersUnbound/statuses/607914355338936320",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/ShippersUnbound/status/607914355338936320"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607914901181464576",
+        "url": "https://twitter.com/ShippersUnbound/statuses/607914901181464576",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/ShippersUnbound/status/607914901181464576"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/CG-7V2nWwAAkZFq.png",
+          "fields": {
+            "width": "696",
+            "height": "488",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/CG-7V2nWwAAkZFq.png"
+          },
+          "mimeType": "image/png",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "607910459761655808",
+        "url": "https://twitter.com/MattChorley/statuses/607910459761655808",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/MattChorley/status/607910459761655808"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/CG-83BLXAAAMGbH.png",
+          "fields": {
+            "width": "873",
+            "height": "543",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/CG-83BLXAAAMGbH.png"
+          },
+          "mimeType": "image/png",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "607912130776563712",
+        "url": "https://twitter.com/MattChorley/statuses/607912130776563712",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/MattChorley/status/607912130776563712"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607903128894054400",
+        "url": "https://twitter.com/RoadThruParis/statuses/607903128894054400",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/RoadThruParis/status/607903128894054400"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/CG-ziz0WoAA05X0.jpg",
+          "fields": {
+            "width": "596",
+            "height": "297",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/CG-ziz0WoAA05X0.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "607901886323257344",
+        "url": "https://twitter.com/SpiegelPeter/statuses/607901886323257344",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/SpiegelPeter/status/607901886323257344"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607891680176381952",
+        "url": "https://twitter.com/patrickwintour/statuses/607891680176381952",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/patrickwintour/status/607891680176381952"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607887424123854848",
+        "url": "https://twitter.com/patrickwintour/statuses/607887424123854848",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/patrickwintour/status/607887424123854848"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607889050746372096",
+        "url": "https://twitter.com/connollyberlin/statuses/607889050746372096",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/connollyberlin/status/607889050746372096"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/CG-dmA6WoAAHv_i.jpg",
+          "fields": {
+            "width": "960",
+            "height": "624",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/CG-dmA6WoAAHv_i.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "607877751299796992",
+        "url": "https://twitter.com/connollyberlin/statuses/607877751299796992",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/connollyberlin/status/607877751299796992"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607888100048683008",
+        "url": "https://twitter.com/connollyberlin/statuses/607888100048683008",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/connollyberlin/status/607888100048683008"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/CG-Zfd9W0AAxCqy.jpg",
+          "fields": {
+            "width": "993",
+            "height": "1024",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/CG-Zfd9W0AAxCqy.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "607873256520085504",
+        "url": "https://twitter.com/faisalislam/statuses/607873256520085504",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/faisalislam/status/607873256520085504"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/CG7WtRxWcAERA3k.jpg",
+          "fields": {
+            "width": "630",
+            "height": "1024",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/CG7WtRxWcAERA3k.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "607659081092972544",
+        "url": "https://twitter.com/hendopolis/statuses/607659081092972544",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/hendopolis/status/607659081092972544"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/CG7Tt-QWcAMPjTi.jpg",
+          "fields": {
+            "width": "768",
+            "height": "1024",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/CG7Tt-QWcAMPjTi.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "607655795329761280",
+        "url": "https://twitter.com/hendopolis/statuses/607655795329761280",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/hendopolis/status/607655795329761280"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/CG7TAx2WcAACcFR.jpg",
+          "fields": {
+            "width": "674",
+            "height": "1024",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/CG7TAx2WcAACcFR.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "607655019500990468",
+        "url": "https://twitter.com/hendopolis/statuses/607655019500990468",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/hendopolis/status/607655019500990468"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/CG-YU8fWoAAdrWo.png",
+          "fields": {
+            "width": "626",
+            "height": "283",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/CG-YU8fWoAAdrWo.png"
+          },
+          "mimeType": "image/png",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "607871961067339776",
+        "url": "https://twitter.com/MattChorley/statuses/607871961067339776",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/MattChorley/status/607871961067339776"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607869651016667136",
+        "url": "https://twitter.com/JGForsyth/statuses/607869651016667136",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/JGForsyth/status/607869651016667136"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607870266501406720",
+        "url": "https://twitter.com/JGForsyth/statuses/607870266501406720",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/JGForsyth/status/607870266501406720"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/CG98VDBXAAE2pXP.jpg",
+          "fields": {
+            "width": "1024",
+            "height": "682",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/CG98VDBXAAE2pXP.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "607841176587259904",
+        "url": "https://twitter.com/Elysee/statuses/607841176587259904",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/Elysee/status/607841176587259904"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607830294570369024",
+        "url": "https://twitter.com/DouglasCarswell/statuses/607830294570369024",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/DouglasCarswell/status/607830294570369024"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607836755719548928",
+        "url": "https://twitter.com/EricPickles/statuses/607836755719548928",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/EricPickles/status/607836755719548928"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "607800139814731776",
+        "url": "https://twitter.com/DanHannanMEP/statuses/607800139814731776",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/DanHannanMEP/status/607800139814731776"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2015-06-08",
+    "contentid": "5575492ae4b0f3282588ba52"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "830804130692268032",
+        "url": "https://twitter.com/realDonaldTrump/status/830804130692268032",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/realDonaldTrump/status/830804130692268032"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2017-02-12",
+    "contentid": "58a09425e4b09b65848eadf7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1255617400768086016",
+        "url": "https://twitter.com/theappeal/status/1255617400768086016",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/theappeal/status/1255617400768086016"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2020-04-29",
+    "contentid": "5ea9af0f8f0836aa495e8b76"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "333960900107182080",
+        "url": "https://twitter.com/PickardJE/status/333960900107182080",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/PickardJE/status/333960900107182080"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2013-05-13",
+    "contentid": "51909d04e4b0fa172fc1d9b7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "333895984063053824",
+        "url": "https://twitter.com/BBCJamesCook/status/333895984063053824",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/BBCJamesCook/status/333895984063053824"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2013-05-13",
+    "contentid": "51909d04e4b0fa172fc1d9b7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "333893942871457792",
+        "url": "https://twitter.com/rolandwatson66/status/333893942871457792",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/rolandwatson66/status/333893942871457792"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2013-05-13",
+    "contentid": "51909d04e4b0fa172fc1d9b7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "333881002185355265",
+        "url": "https://twitter.com/BBCNormanS/status/333881002185355265",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "originalUrl": "https://twitter.com/BBCNormanS/status/333881002185355265"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2013-05-13",
+    "contentid": "51909d04e4b0fa172fc1d9b7"
+  },
+  {
+    "element": {
+      "assets": [],
+      "fields": {
+        "id": "1001510358920695809",
+        "url": "https://twitter.com/alexisohanian/status/1001510358920695809",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/alexisohanian/status/1001510358920695809"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-05-29",
+    "contentid": "5b0de45ee4b02746e913d6a6"
+  },
+  {
+    "element": {
+      "assets": [
+        {
+          "url": "http://pbs.twimg.com/media/DZkAlr8WAAAhsqD.jpg",
+          "fields": {
+            "width": "787",
+            "height": "817",
+            "source": "Twitter",
+            "secureFile": "https://pbs.twimg.com/media/DZkAlr8WAAAhsqD.jpg"
+          },
+          "mimeType": "image/jpeg",
+          "assetType": "image"
+        }
+      ],
+      "fields": {
+        "id": "979815053808545794",
+        "url": "https://twitter.com/REALStaceyDash/status/979815053808545794",
+        "html": "REDACTED",
+        "source": "Twitter",
+        "isMandatory": "true",
+        "originalUrl": "https://twitter.com/REALStaceyDash/status/979815053808545794"
+      },
+      "elementType": "tweet"
+    },
+    "created": "2018-03-31",
+    "contentid": "5abf943ce4b0454820c8d067"
+  }
+]

--- a/src/elements/helpers/__tests__/transformFixtures.spec.ts
+++ b/src/elements/helpers/__tests__/transformFixtures.spec.ts
@@ -2,6 +2,7 @@ import { flow, omit } from "lodash";
 import {
   buildElementPlugin,
   createStandardElement,
+  createTweetElement,
   membershipElement,
   richlinkElement,
   tableElement,
@@ -35,6 +36,10 @@ describe("Element fixtures", () => {
     witness: deprecatedElement,
     vine: deprecatedElement,
     instagram: deprecatedElement,
+    tweet: createTweetElement({
+      checkThirdPartyTracking: Promise.resolve,
+      createCaptionPlugins: undefined,
+    }),
   } as const;
 
   const {

--- a/src/elements/helpers/transform.ts
+++ b/src/elements/helpers/transform.ts
@@ -8,6 +8,7 @@ import type { pullquoteFields } from "../pullquote/PullquoteSpec";
 import type { richlinkFields } from "../rich-link/RichlinkSpec";
 import { transformElement as standardElementTransform } from "../standard/standardDataTransformer";
 import type { tableFields } from "../table/TableSpec";
+import { transformElement as tweetElementTransform } from "../tweet/tweetDataTransformer";
 import { transformElement as defaultElementTransform } from "./defaultTransform";
 
 // A placeholder value for a dropdown option that represents no selection.
@@ -34,6 +35,7 @@ const transformMap = {
   vine: deprecatedElementTransform,
   instagram: deprecatedElementTransform,
   witness: deprecatedElementTransform,
+  tweet: tweetElementTransform,
 } as const;
 
 type TransformMap = typeof transformMap;

--- a/src/elements/tweet/TweetForm.tsx
+++ b/src/elements/tweet/TweetForm.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
+import type { FieldValidationErrors } from "../../plugin/elementSpec";
+import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
+import type { FieldNameToField } from "../../plugin/types/Element";
+import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
+import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
+import { EmbedTestId } from "../embed/EmbedForm";
+import { Preview } from "../helpers/Preview";
+import type { TrackingStatus } from "../helpers/ThirdPartyStatusChecks";
+import { TrackingStatusChecks } from "../helpers/ThirdPartyStatusChecks";
+import type { createTweetFields } from "./TweetSpec";
+
+type Props = {
+  fieldValues: FieldNameToValueMap<ReturnType<typeof createTweetFields>>;
+  errors: FieldValidationErrors;
+  fields: FieldNameToField<ReturnType<typeof createTweetFields>>;
+  checkThirdPartyTracking: (html: string) => Promise<TrackingStatus>;
+};
+
+export const TweetForm: React.FunctionComponent<Props> = ({
+  errors,
+  fields,
+  fieldValues,
+  checkThirdPartyTracking,
+}) => (
+  <div>
+    <FieldLayoutVertical data-cy={EmbedTestId}>
+      <Preview html={fieldValues.html} />
+      <CustomDropdownView
+        field={fields.role}
+        label="Weighting"
+        errors={errors.role}
+      />
+      <CustomCheckboxView
+        field={fields.isMandatory}
+        errors={errors.isMandatory}
+        label="This element is required for publication"
+      />
+      <TrackingStatusChecks
+        html={fieldValues.html}
+        isMandatory={fieldValues.isMandatory}
+        checkThirdPartyTracking={checkThirdPartyTracking}
+      />
+    </FieldLayoutVertical>
+  </div>
+);

--- a/src/elements/tweet/TweetSpec.tsx
+++ b/src/elements/tweet/TweetSpec.tsx
@@ -9,6 +9,7 @@ import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldVi
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { htmlMaxLength } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+import type { Asset } from "../helpers/defaultTransform";
 import { undefinedDropdownValue } from "../helpers/transform";
 import type { StandardElementOptions } from "../standard/StandardSpec";
 import { TweetForm } from "./TweetForm";
@@ -39,6 +40,9 @@ export const createTweetFields = (
     }),
     html: createTextField({ absentOnEmpty: true }),
     authorName: createTextField({ absentOnEmpty: true }),
+    hideMedia: createTextField({ absentOnEmpty: true }),
+    hideThread: createTextField({ absentOnEmpty: true }),
+    assets: createCustomField<Asset[]>([], undefined),
   };
 };
 

--- a/src/elements/tweet/TweetSpec.tsx
+++ b/src/elements/tweet/TweetSpec.tsx
@@ -1,0 +1,61 @@
+import type { Schema } from "prosemirror-model";
+import type { Plugin } from "prosemirror-state";
+import React from "react";
+import {
+  createCustomDropdownField,
+  createCustomField,
+} from "../../plugin/fieldViews/CustomFieldView";
+import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
+import { createTextField } from "../../plugin/fieldViews/TextFieldView";
+import { htmlMaxLength } from "../../plugin/helpers/validation";
+import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+import { undefinedDropdownValue } from "../helpers/transform";
+import type { StandardElementOptions } from "../standard/StandardSpec";
+import { TweetForm } from "./TweetForm";
+
+export const createTweetFields = (
+  createCaptionPlugins?: (schema: Schema) => Plugin[]
+) => {
+  return {
+    source: createTextField({ absentOnEmpty: true }),
+    isMandatory: createCustomField(true, true),
+    role: createCustomDropdownField(undefinedDropdownValue, [
+      { text: "inline (default)", value: undefinedDropdownValue },
+      { text: "supporting", value: "supporting" },
+      { text: "showcase", value: "showcase" },
+      { text: "thumbnail", value: "thumbnail" },
+      { text: "immersive", value: "immersive" },
+    ]),
+    url: createTextField({ absentOnEmpty: true }),
+    originalUrl: createTextField({ absentOnEmpty: true }),
+    id: createTextField({ absentOnEmpty: true }),
+    // This caption field is redundant as it never surfaces downstream in CAPI, but we are keeping it here to preserve old elements
+    caption: createFlatRichTextField({
+      createPlugins: createCaptionPlugins,
+      marks: "em strong link strike",
+      validators: [htmlMaxLength(1000, undefined, "WARN")],
+      placeholder: "Enter a caption for this media…",
+      absentOnEmpty: true,
+    }),
+    html: createTextField({ absentOnEmpty: true }),
+    authorName: createTextField({ absentOnEmpty: true }),
+  };
+};
+
+export const createTweetElement = ({
+  checkThirdPartyTracking,
+  createCaptionPlugins,
+}: StandardElementOptions) =>
+  createReactElementSpec(
+    createTweetFields(createCaptionPlugins),
+    ({ fields, errors, fieldValues }) => {
+      return (
+        <TweetForm
+          fields={fields}
+          errors={errors}
+          fieldValues={fieldValues}
+          checkThirdPartyTracking={checkThirdPartyTracking}
+        />
+      );
+    }
+  );

--- a/src/elements/tweet/tweetDataTransformer.ts
+++ b/src/elements/tweet/tweetDataTransformer.ts
@@ -1,4 +1,5 @@
 import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
+import type { Asset } from "../helpers/defaultTransform";
 import { undefinedDropdownValue } from "../helpers/transform";
 import type { TransformIn, TransformOut } from "../helpers/types/Transform";
 import type { createTweetFields } from "./TweetSpec";
@@ -13,23 +14,28 @@ export type ExternalTweetFields = {
   caption: string;
   html: string;
   authorName: string;
+  hideMedia?: string;
+  hideThread?: string;
 };
 
 export type ExternalData = {
+  assets: Asset[];
   fields: ExternalTweetFields;
 };
 
 export type PartialData = {
+  assets: Asset[];
   fields: Partial<ExternalTweetFields>;
 };
 
 export const transformElementIn: TransformIn<
   PartialData,
   ReturnType<typeof createTweetFields>
-> = ({ fields: { isMandatory, role, ...rest } }) => {
+> = ({ assets, fields: { isMandatory, role, ...rest } }) => {
   return {
     isMandatory: isMandatory === "true",
     role: role ?? undefinedDropdownValue,
+    assets,
     ...rest,
   };
 };
@@ -40,9 +46,11 @@ export const transformElementOut: TransformOut<
 > = ({
   isMandatory,
   role,
+  assets,
   ...rest
 }: FieldNameToValueMap<ReturnType<typeof createTweetFields>>): ExternalData => {
   return {
+    assets,
     fields: {
       isMandatory: isMandatory.toString(),
       role: role === undefinedDropdownValue ? undefined : role,

--- a/src/elements/tweet/tweetDataTransformer.ts
+++ b/src/elements/tweet/tweetDataTransformer.ts
@@ -1,0 +1,57 @@
+import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
+import { undefinedDropdownValue } from "../helpers/transform";
+import type { TransformIn, TransformOut } from "../helpers/types/Transform";
+import type { createTweetFields } from "./TweetSpec";
+
+export type ExternalTweetFields = {
+  source: string;
+  isMandatory: string;
+  role: string | undefined;
+  url: string;
+  originalUrl: string;
+  id: string;
+  caption: string;
+  html: string;
+  authorName: string;
+};
+
+export type ExternalData = {
+  fields: ExternalTweetFields;
+};
+
+export type PartialData = {
+  fields: Partial<ExternalTweetFields>;
+};
+
+export const transformElementIn: TransformIn<
+  PartialData,
+  ReturnType<typeof createTweetFields>
+> = ({ fields: { isMandatory, role, ...rest } }) => {
+  return {
+    isMandatory: isMandatory === "true",
+    role: role ?? undefinedDropdownValue,
+    ...rest,
+  };
+};
+
+export const transformElementOut: TransformOut<
+  ExternalData,
+  ReturnType<typeof createTweetFields>
+> = ({
+  isMandatory,
+  role,
+  ...rest
+}: FieldNameToValueMap<ReturnType<typeof createTweetFields>>): ExternalData => {
+  return {
+    fields: {
+      isMandatory: isMandatory.toString(),
+      role: role === undefinedDropdownValue ? undefined : role,
+      ...rest,
+    },
+  };
+};
+
+export const transformElement = {
+  in: transformElementIn,
+  out: transformElementOut,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export { richlinkElement } from "./elements/rich-link/RichlinkSpec";
 export { createInteractiveElement } from "./elements/interactive/InteractiveSpec";
 export { tableElement } from "./elements/table/TableSpec";
 export { deprecatedElement } from "./elements/deprecated/DeprecatedSpec";
+export { createTweetElement } from "./elements/tweet/TweetSpec";
 export {
   transformElementIn,
   transformElementOut,


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [ ] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [ ] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
