### PR TITLE
fix: Remove unescapeHTML, as it's no longer used

### DIFF
--- a/src/elements/helpers/ThirdPartyStatusChecks.tsx
+++ b/src/elements/helpers/ThirdPartyStatusChecks.tsx
@@ -90,7 +90,7 @@ export const TrackingStatusChecks = ({
     html: string,
     options: { isSubscribed: boolean }
   ) => {
-    checkThirdPartyTracking(unescapeHtml(html))
+    checkThirdPartyTracking(html)
       .then((response) => {
         if (options.isSubscribed) {
           updateTrackingStatus(response);

--- a/src/elements/helpers/ThirdPartyStatusChecks.tsx
+++ b/src/elements/helpers/ThirdPartyStatusChecks.tsx
@@ -1,7 +1,6 @@
 import { SvgAlertTriangle, SvgTickRound } from "@guardian/src-icons";
 import debounce from "lodash/debounce";
 import { useCallback, useEffect, useState } from "react";
-import { unescapeHtml } from "./html";
 import {
   message,
   naughtyColours,

--- a/src/elements/helpers/__tests__/ThirdPartyStatusChecks.spec.tsx
+++ b/src/elements/helpers/__tests__/ThirdPartyStatusChecks.spec.tsx
@@ -1,0 +1,26 @@
+import { render, waitFor } from "@testing-library/react";
+import { TrackingStatusChecks } from "../ThirdPartyStatusChecks";
+
+describe("Third party status checks", () => {
+  it("calls the callback with the original element HTML after a debounce", async () => {
+    const exampleHtml = "<p>Example html</p>";
+    const checkTrackingMock = jest.fn().mockReturnValue(Promise.resolve());
+
+    render(
+      <TrackingStatusChecks
+        html={exampleHtml}
+        checkThirdPartyTracking={checkTrackingMock}
+        isMandatory={false}
+      ></TrackingStatusChecks>
+    );
+
+    expect(checkTrackingMock.mock.calls[0]).toEqual(undefined);
+
+    await waitFor(
+      () => {
+        expect(checkTrackingMock.mock.calls[0]).toEqual([exampleHtml]);
+      },
+      { timeout: 2000 }
+    );
+  });
+});

--- a/src/elements/helpers/__tests__/html.spec.ts
+++ b/src/elements/helpers/__tests__/html.spec.ts
@@ -1,17 +1,4 @@
-import { htmlContainsSingleIframe, parseHtml, unescapeHtml } from "../html";
-
-describe("unescapeHtml", () => {
-  it("should unescape HTML", () => {
-    const escapedHtml =
-      "&lt;a href=&quot;https://www.example.com&quot;&gt;Example website&lt;/a&gt;";
-
-    const unescapedHtml = unescapeHtml(escapedHtml);
-
-    expect(unescapedHtml).toEqual(
-      '<a href="https://www.example.com">Example website</a>'
-    );
-  });
-});
+import { htmlContainsSingleIframe, parseHtml } from "../html";
 
 describe("parseHtml", () => {
   it("should return an object", () => {

--- a/src/elements/helpers/html.ts
+++ b/src/elements/helpers/html.ts
@@ -1,10 +1,3 @@
-export const unescapeHtml = (html: string): string => {
-  return (
-    new DOMParser().parseFromString(html, "text/html").documentElement
-      .textContent ?? ""
-  );
-};
-
 export const parseHtml = (html: string) => {
   const parsedHtml = new DOMParser().parseFromString(html, "text/html");
   return parsedHtml.body.firstElementChild;


### PR DESCRIPTION
## What does this change?

Following up on #218, we no longer need `unescapeHTML`.

This PR removes it completely, and the one place where it was still used, the third party tracking code, which fixes a bug where unnecessarily escaping the HTML sent to this function meant we were sending malformed data to our tracking callback.

## How to test

- The automated test added to test `ThirdPartyTracking` should fail before this change, and succeed afterwards.
