### PR TITLE
fix: Improve deprecated element description

### DIFF
--- a/src/elements/deprecated/DeprecatedForm.tsx
+++ b/src/elements/deprecated/DeprecatedForm.tsx
@@ -18,24 +18,36 @@ const elementTypeToName = {
 
 export const DeprecatedForm: React.FunctionComponent<Props> = ({
   fieldValues,
-}) => (
-  <div>
-    <FieldLayoutVertical>
-      <InputHeading
-        headingLabel={`Content from ${
-          elementTypeToName[fieldValues.type] || upperFirst(fieldValues.type)
-        }`}
-      />
-      <Description>
-        <p>
-          This way of representing content of this type is no longer used, and
-          may not appear on some or all platforms.
-        </p>
-        <details>
-          <summary>Show content data</summary>
-          <pre>{JSON.stringify(JSON.parse(fieldValues.data), null, 2)}</pre>
-        </details>
-      </Description>
-    </FieldLayoutVertical>
-  </div>
-);
+}) => {
+  const elementType =
+    elementTypeToName[fieldValues.type] || upperFirst(fieldValues.type);
+  return (
+    <div>
+      <FieldLayoutVertical>
+        <InputHeading headingLabel={`Content from ${elementType}`} />
+        <Description>
+          <p>
+            This element represents content from {elementType}. It was added in
+            an older version of Composer and may no longer be supported by all
+            of our platforms.
+          </p>
+          <p>
+            Please contact{" "}
+            <a
+              target="_blank"
+              rel="noopener"
+              href="central.production@guardian.co.uk"
+            >
+              Central Production
+            </a>{" "}
+            if you need more information.
+          </p>
+          <details>
+            <summary>Show content data</summary>
+            <pre>{JSON.stringify(JSON.parse(fieldValues.data), null, 2)}</pre>
+          </details>
+        </Description>
+      </FieldLayoutVertical>
+    </div>
+  );
+};


### PR DESCRIPTION
## What does this change?

Improves our deprecated element description after feedback.

|Before|After|
|--|--|
|<img width="828" alt="Screenshot 2022-03-28 at 16 16 39" src="https://user-images.githubusercontent.com/7767575/160430756-fb1161d0-271c-4b5c-893d-a5ad9b86c414.png">|<img width="828" alt="Screenshot 2022-03-28 at 16 15 26" src="https://user-images.githubusercontent.com/7767575/160430767-c3ac5459-4909-4a0d-b9b2-8703d6139836.png">|

## How to test

Take a look above, or in the sandbox. All ok?