### PR TITLE
fix: Add thumbnail to table element, and conditionally add thumbnail to standard elements

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -166,7 +166,11 @@ const {
     code: codeElement,
     pullquote: pullquoteElement,
     "rich-link": richlinkElement,
-    video: standardElement,
+    video: createStandardElement({
+      createCaptionPlugins,
+      checkThirdPartyTracking: mockThirdPartyTracking,
+      hasThumbnailRole: false,
+    }),
     audio: standardElement,
     map: standardElement,
     table: tableElement,

--- a/src/elements/deprecated/DeprecatedForm.tsx
+++ b/src/elements/deprecated/DeprecatedForm.tsx
@@ -28,8 +28,8 @@ export const DeprecatedForm: React.FunctionComponent<Props> = ({
         <Description>
           <p>
             This element represents content from {elementType}. It was added in
-            an older version of Composer and may no longer be supported by all
-            of our platforms.
+            an older version of Composer and may not be supported or render
+            correctly on all platforms.
           </p>
           <p>
             Please contact{" "}

--- a/src/elements/standard/StandardSpec.tsx
+++ b/src/elements/standard/StandardSpec.tsx
@@ -32,6 +32,7 @@ export const createStandardFields = (
       { text: "supporting", value: "supporting" },
       { text: "showcase", value: "showcase" },
       { text: "immersive", value: "immersive" },
+      { text: "thumbnail", value: "thumbnail" },
     ]),
     url: createTextField({ absentOnEmpty: true }),
     description: createTextField({ absentOnEmpty: true }),

--- a/src/elements/standard/StandardSpec.tsx
+++ b/src/elements/standard/StandardSpec.tsx
@@ -22,18 +22,24 @@ import { StandardForm, StandardFormLargePreview } from "./StandardForm";
  * which only use a subset of their flexible-model fields.
  */
 export const createStandardFields = (
-  createCaptionPlugins?: (schema: Schema) => Plugin[]
+  createCaptionPlugins?: (schema: Schema) => Plugin[],
+  hasThumbnailRole = true
 ) => {
+  const roles = [
+    { text: "inline (default)", value: undefinedDropdownValue },
+    { text: "supporting", value: "supporting" },
+    { text: "showcase", value: "showcase" },
+    { text: "immersive", value: "immersive" },
+  ];
+
+  if (hasThumbnailRole) {
+    roles.push({ text: "thumbnail", value: "thumbnail" });
+  }
+
   return {
     source: createTextField({ absentOnEmpty: true }),
     isMandatory: createCustomField(true, true),
-    role: createCustomDropdownField(undefinedDropdownValue, [
-      { text: "inline (default)", value: undefinedDropdownValue },
-      { text: "supporting", value: "supporting" },
-      { text: "showcase", value: "showcase" },
-      { text: "immersive", value: "immersive" },
-      { text: "thumbnail", value: "thumbnail" },
-    ]),
+    role: createCustomDropdownField(undefinedDropdownValue, roles),
     url: createTextField({ absentOnEmpty: true }),
     description: createTextField({ absentOnEmpty: true }),
     originalUrl: createTextField({ absentOnEmpty: true }),
@@ -57,15 +63,17 @@ export type StandardElementOptions = {
   createCaptionPlugins?: (schema: Schema) => Plugin[];
   checkThirdPartyTracking: (html: string) => Promise<TrackingStatus>;
   useLargePreview?: boolean;
+  hasThumbnailRole?: boolean;
 };
 
 export const createStandardElement = ({
   createCaptionPlugins,
   checkThirdPartyTracking,
   useLargePreview,
+  hasThumbnailRole,
 }: StandardElementOptions) =>
   createReactElementSpec(
-    createStandardFields(createCaptionPlugins),
+    createStandardFields(createCaptionPlugins, hasThumbnailRole),
     (props) => {
       const Form = useLargePreview ? StandardFormLargePreview : StandardForm;
       return (

--- a/src/elements/table/TableSpec.ts
+++ b/src/elements/table/TableSpec.ts
@@ -15,6 +15,7 @@ export const tableFields = {
     { text: "supporting", value: "supporting" },
     { text: "showcase", value: "showcase" },
     { text: "immersive", value: "immersive" },
+    { text: "thumbnail", value: "thumbnail" },
   ]),
   url: createTextField({ absentOnEmpty: true }),
   originalUrl: createTextField({ absentOnEmpty: true }),


### PR DESCRIPTION
## What does this change?

Comparing elements in Composer, table, audio, document and map elements permit the thumbnail role. This PR adds the thumbnail role to the table element, and the ability to remove the thumbnail role from a standard element, adding it by default (as the majority of elements using the standard template do have it).

It also sneaks in a minor change to the deprecated element copy, in line with recommendations from stakeholders.

## How to test

Take a look at the video, table, audio, document and map elements. Video shouldn't have a thumbnail. Everything else, should.