### PR TITLE
feat: [repeater PR 1] Add repeater field to NodeSpec

### DIFF
--- a/src/plugin/__tests__/nodeSpec.spec.ts
+++ b/src/plugin/__tests__/nodeSpec.spec.ts
@@ -1,0 +1,21 @@
+import { createRepeaterField } from "../fieldViews/RepeaterFieldView";
+import { createTextField } from "../fieldViews/TextFieldView";
+import { getNodeSpecForField } from "../nodeSpec";
+
+describe("NodeSpec generation", () => {
+  describe("Repeater fields", () => {
+    it("should create a NodeSpec for the repeater field node", () => {
+      const nodeSpec = getNodeSpecForField(
+        "example-element",
+        "example-repeater",
+        createRepeaterField({
+          exampleField: createTextField(),
+        })
+      );
+
+      expect(nodeSpec).toBe({});
+    });
+
+    it("should create a NodeSpec for each child field of the repeater field node", () => {});
+  });
+});

--- a/src/plugin/__tests__/nodeSpec.spec.ts
+++ b/src/plugin/__tests__/nodeSpec.spec.ts
@@ -4,18 +4,39 @@ import { getNodeSpecForField } from "../nodeSpec";
 
 describe("NodeSpec generation", () => {
   describe("Repeater fields", () => {
-    it("should create a NodeSpec for the repeater field node", () => {
+    it("should create a NodeSpec for the repeater field node that permits the nested content, and a NodeSpec for the nested field", () => {
       const nodeSpec = getNodeSpecForField(
-        "example-element",
-        "example-repeater",
+        "exampleElement",
+        "exampleRepeater",
         createRepeaterField({
           exampleField: createTextField(),
         })
       );
 
-      expect(nodeSpec).toBe({});
+      expect(nodeSpec["exampleElement__exampleRepeater"]).toMatchObject({
+        content: "exampleElement__exampleField",
+      });
+      expect(nodeSpec["exampleElement__exampleField"]).toBeTruthy();
     });
 
-    it("should create a NodeSpec for each child field of the repeater field node", () => {});
+    it("should handle nested repeater fields", () => {
+      const nodeSpec = getNodeSpecForField(
+        "exampleElement",
+        "exampleRepeater",
+        createRepeaterField({
+          nestedRepeaterField: createRepeaterField({
+            exampleField: createTextField(),
+          }),
+        })
+      );
+
+      expect(nodeSpec["exampleElement__exampleRepeater"]).toMatchObject({
+        content: "exampleElement__nestedRepeaterField",
+      });
+      expect(nodeSpec["exampleElement__nestedRepeaterField"]).toMatchObject({
+        content: "exampleElement__exampleField",
+      });
+      expect(nodeSpec["exampleElement__exampleField"]).toBeTruthy();
+    });
   });
 });

--- a/src/plugin/fieldViews/FieldView.ts
+++ b/src/plugin/fieldViews/FieldView.ts
@@ -17,6 +17,8 @@ export enum FieldType {
   ATTRIBUTES = "ATTRIBUTES",
   // Uses node content to store field data.
   CONTENT = "CONTENT",
+  // Represents a node that contains nested fields.
+  REPEATER = "REPEATER",
 }
 
 /**

--- a/src/plugin/fieldViews/RepeaterFieldView.ts
+++ b/src/plugin/fieldViews/RepeaterFieldView.ts
@@ -22,8 +22,6 @@ export interface RepeaterFieldDescription<
 
 /**
  * A FieldView representing a node that contains user-defined child nodes.
- *
- * Offers methods to add, remove, and move nodes.
  */
 export class RepeaterFieldView {
   public static fieldName = repeaterFieldName;
@@ -49,14 +47,6 @@ export class RepeaterFieldView {
     this.decorations = decorations;
 
     return true;
-  }
-
-  public addNode() {
-    console.log("To be implemented: add a node");
-  }
-
-  public removeNode() {
-    console.log("To be implemented: remove a node");
   }
 
   public destroy() {

--- a/src/plugin/fieldViews/RepeaterFieldView.ts
+++ b/src/plugin/fieldViews/RepeaterFieldView.ts
@@ -28,6 +28,7 @@ export interface RepeaterFieldDescription<
 export class RepeaterFieldView {
   public static fieldName = repeaterFieldName;
   public static fieldType = FieldType.REPEATER;
+  public static defaultValue = [];
 
   public constructor(
     private node: Node,
@@ -56,5 +57,9 @@ export class RepeaterFieldView {
 
   public removeNode() {
     console.log("To be implemented: remove a node");
+  }
+
+  public destroy() {
+    console.log("To be implemented: destroy");
   }
 }

--- a/src/plugin/fieldViews/RepeaterFieldView.ts
+++ b/src/plugin/fieldViews/RepeaterFieldView.ts
@@ -1,0 +1,60 @@
+import type { Node } from "prosemirror-model";
+import type { Decoration, DecorationSet } from "prosemirror-view";
+import type { FieldDescriptions } from "../types/Element";
+import type { BaseFieldDescription } from "./FieldView";
+import { FieldType } from "./FieldView";
+
+export const repeaterFieldName = "repeater" as const;
+
+export const createRepeaterField = <FDesc extends FieldDescriptions<string>>(
+  fields: FDesc
+) => ({
+  type: repeaterFieldName,
+  fields,
+});
+
+export interface RepeaterFieldDescription<
+  FDesc extends FieldDescriptions<string>
+> extends BaseFieldDescription<unknown> {
+  type: typeof repeaterFieldName;
+  fields: FDesc;
+}
+
+/**
+ * A FieldView representing a node that contains user-defined child nodes.
+ *
+ * Offers methods to add, remove, and move nodes.
+ */
+export class RepeaterFieldView {
+  public static fieldName = repeaterFieldName;
+  public static fieldType = FieldType.REPEATER;
+
+  public constructor(
+    private node: Node,
+    private elementOffset: number,
+    private decorations: DecorationSet | Decoration[]
+  ) {}
+
+  /**
+   * Called when the fieldView is updated from the parent editor.
+   */
+  public onUpdate(
+    node: Node,
+    elementOffset: number,
+    decorations: DecorationSet | Decoration[]
+  ): boolean {
+    this.node = node;
+    this.elementOffset = elementOffset;
+    this.decorations = decorations;
+
+    return true;
+  }
+
+  public addNode() {
+    console.log("To be implemented: add a node");
+  }
+
+  public removeNode() {
+    console.log("To be implemented: remove a node");
+  }
+}

--- a/src/plugin/fieldViews/RepeaterFieldView.ts
+++ b/src/plugin/fieldViews/RepeaterFieldView.ts
@@ -2,7 +2,7 @@ import type { Node } from "prosemirror-model";
 import type { Decoration, DecorationSet } from "prosemirror-view";
 import type { FieldDescriptions } from "../types/Element";
 import type { BaseFieldDescription } from "./FieldView";
-import { FieldType } from "./FieldView";
+import { FieldType, FieldView } from "./FieldView";
 
 export const repeaterFieldName = "repeater" as const;
 
@@ -23,16 +23,19 @@ export interface RepeaterFieldDescription<
 /**
  * A FieldView representing a node that contains user-defined child nodes.
  */
-export class RepeaterFieldView {
+export class RepeaterFieldView extends FieldView<unknown> {
   public static fieldName = repeaterFieldName;
   public static fieldType = FieldType.REPEATER;
   public static defaultValue = [];
+  public fieldViewElement?: undefined;
 
   public constructor(
     private node: Node,
     private elementOffset: number,
     private decorations: DecorationSet | Decoration[]
-  ) {}
+  ) {
+    super();
+  }
 
   /**
    * Called when the fieldView is updated from the parent editor.
@@ -47,6 +50,10 @@ export class RepeaterFieldView {
     this.decorations = decorations;
 
     return true;
+  }
+
+  public update() {
+    console.log("To be implemented: update");
   }
 
   public destroy() {

--- a/src/plugin/helpers/fieldView.ts
+++ b/src/plugin/helpers/fieldView.ts
@@ -5,6 +5,8 @@ import type { CheckboxValue } from "../fieldViews/CheckboxFieldView";
 import type { CustomFieldDescription } from "../fieldViews/CustomFieldView";
 import { CustomFieldView } from "../fieldViews/CustomFieldView";
 import { DropdownFieldView } from "../fieldViews/DropdownFieldView";
+import type { RepeaterFieldDescription } from "../fieldViews/RepeaterFieldView";
+import { RepeaterFieldView } from "../fieldViews/RepeaterFieldView";
 import { RichTextFieldView } from "../fieldViews/RichTextFieldView";
 import { TextFieldView } from "../fieldViews/TextFieldView";
 import { getFieldNameFromNode } from "../nodeSpec";
@@ -22,6 +24,7 @@ export const fieldTypeToViewMap = {
   [CheckboxFieldView.fieldName]: CheckboxFieldView,
   [DropdownFieldView.fieldName]: DropdownFieldView,
   [CustomFieldView.fieldName]: CustomFieldView,
+  [RepeaterFieldView.fieldName]: RepeaterFieldView,
 };
 
 export type FieldTypeToViewMap<Field> = {
@@ -32,6 +35,7 @@ export type FieldTypeToViewMap<Field> = {
   [CustomFieldView.fieldName]: Field extends CustomFieldDescription<infer Data>
     ? CustomFieldView<Data>
     : never;
+  [RepeaterFieldView.fieldName]: RepeaterFieldView;
 };
 
 /**
@@ -49,6 +53,11 @@ export type FieldTypeToValueMap<
     infer Data
   >
     ? Data
+    : never;
+  [RepeaterFieldView.fieldName]: FDesc[Name] extends RepeaterFieldDescription<
+    infer NestedFDesc
+  >
+    ? FieldTypeToValueMap<NestedFDesc, keyof NestedFDesc>
     : never;
 };
 

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -1,11 +1,6 @@
 import OrderedMap from "orderedmap";
 import type { Node, NodeSpec, NodeType, Schema } from "prosemirror-model";
 import { DOMParser } from "prosemirror-model";
-import { FieldType } from "./fieldViews/FieldView";
-import {
-  repeaterFieldName,
-  RepeaterFieldView,
-} from "./fieldViews/RepeaterFieldView";
 import type { FieldNameToValueMap } from "./helpers/fieldView";
 import { fieldTypeToViewMap } from "./helpers/fieldView";
 import type { FieldDescription, FieldDescriptions } from "./types/Element";
@@ -185,8 +180,11 @@ export const getNodeSpecForField = (
         {}
       );
 
-      // The repeater nodes content will be these fields, in order
-      const content = getDeterministicFieldOrder(Object.keys(extraFields)).join(
+      // The repeater nodes content will be the immediate child fields of this repeater, in order
+      const immediateChildFields = Object.keys(field.fields).map((fieldName) =>
+        getNodeNameFromField(fieldName, elementName)
+      );
+      const content = getDeterministicFieldOrder(immediateChildFields).join(
         " "
       );
 

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -191,7 +191,7 @@ const createNodeView = <
       // no guarantee that the node's `name` matches our spec. The errors above should
       // help to defend when something's wrong.
       update: (value: unknown) =>
-        (fieldView.update as (value: unknown) => void)(value),
+        fieldView && (fieldView.update as (value: unknown) => void)(value),
     } as unknown) as FieldNameToField<FDesc>[typeof fieldName];
   });
 


### PR DESCRIPTION
## What does this change?

Adds a field of type `repeater` to our `NodeSpec` generation.

A repeater field is a field that contains 0-many children, each containing their own set of field descriptions. We can imagine it being used to implement any field that includes repeated content – for example, a photo gallery, or tabular data.

This PR is a step in this direction, providing the necessary userland field creator, and modelling that field within Prosemirror. Subsequent PRs will need to flesh out:

- how this new field type interacts with field values as they are passed in and out of the RTE
- how this new field type is represented as a field within the renderer
- adding the ability to add, remove, and possibly move repeater node children in relation to their parent.

## Implementation notes

There are two ways I could think of to model our repeater nodes:

1. As a series of nodes modelled without a parent, where repeater nodes exist alongside existing fields:
```mermaid
flowchart TB
  doc-->textFieldInstance
  doc-->repeaterInstance1
  doc-->repeaterInstance2
  repeaterInstance1-->childFieldInstance1
  repeaterInstance2-->childFieldInstance2
```

2. As a single parent that contains all the repeater nodes of its type:
```mermaid
flowchart TB
  doc-->textField
  doc-->repeaterParentField1
  repeaterParentField1-->repeaterInstance1
  repeaterParentField1-->repeaterInstance2
  repeaterInstance1-->childFieldInstance1
  repeaterInstance2-->childFieldInstance2
```

(Let me know if another occurs to you, dear reader!)

The second approach looks neater, in that it's very clear where all instances of a particular repeater field are located. However, it adds another layer of complexity in the schema generation, and there's also the performance cost (unmeasured, and it may be trivial for our use-cases) of building, maintaining and serializing a larger tree during runtime.

As a result, I've opted for 1. for now, but if there turns out to be a compelling use-case for 2., it's fairly straightforward to switch – feedback would be much appreciated.

## How to test

- The existing automated tests should pass – they're pretty comprehensive, so we shouldn't have regressions.
- The new tests should pass. They ensure that the right `NodeSpec`s are created, and that they permit the appropriate content, for both single repeaters and nested repeater fields. Hopefully they are comprehensive, but it might be good to add additional tests if there are edge cases that aren't covered here.