### PR TITLE
chore: Include repo url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "main": "dist/cjs/index.js",
+  "repository": "github:guardian/prosemirror-elements",
   "module": "dist/esm/index.js",
   "types": "dist/declaration/index.d.ts",
   "publishConfig": {


### PR DESCRIPTION
## What does this change?

As part of an npm audit, I'm adding gh links to package jsons that don't already include them if this repo is being published
Adds a link to the source code.
