### PR TITLE
feat: Improves publication checks

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -209,7 +209,8 @@ const {
           <p><strong>second post</strong></p>
           <p><p>- test</p></p>
         </div>`,
-        published: true,
+        isPublished: false,
+        hasUnpublishedChanges: true,
         embedLink: "https://example.com",
         editorLink: "https://example.com",
       })

--- a/src/elements/content-atom/ContentAtomForm.tsx
+++ b/src/elements/content-atom/ContentAtomForm.tsx
@@ -43,9 +43,13 @@ export const ContentAtomForm: React.FunctionComponent<Props> = ({
   return (
     <div>
       <FieldLayoutVertical>
-        {!contentAtomData?.published && (
-          <Error>This {atomType} has unpublished changes.</Error>
+        {!contentAtomData?.isPublished && (
+          <Error>This {atomType} is not published.</Error>
         )}
+        {contentAtomData?.isPublished &&
+          contentAtomData.hasUnpublishedChanges && (
+            <Error>This {atomType} has unpublished changes.</Error>
+          )}
         <FieldLayoutVertical>
           <Label>
             Content atom (

--- a/src/elements/content-atom/ContentAtomSpec.tsx
+++ b/src/elements/content-atom/ContentAtomSpec.tsx
@@ -10,7 +10,8 @@ import { ContentAtomForm } from "./ContentAtomForm";
 
 export type ContentAtomData = {
   defaultHtml: string;
-  published: boolean;
+  hasUnpublishedChanges: boolean;
+  isPublished: boolean;
   title: string;
   embedLink: string;
   editorLink: string;

--- a/src/elements/helpers/__tests__/transformFixtures.spec.ts
+++ b/src/elements/helpers/__tests__/transformFixtures.spec.ts
@@ -36,6 +36,8 @@ describe("Element fixtures", () => {
         published: true,
         embedLink: "",
         editorLink: "",
+        isPublished: true,
+        hasUnpublishedChanges: false,
       })
     ),
     "rich-link": richlinkElement,


### PR DESCRIPTION
## What does this change?

We used to have a feature where we checked an atom's publication state, but this was dropped for unknown reasons. This PR revives that feature and expands on the state check.

We now check for two states: whether the atom is published at all, and if it is published, whether or not there are unpublished changes available in Preview.

![image](https://user-images.githubusercontent.com/40991816/164692874-40a94caa-0170-4014-aa36-5eb95ee2e6e9.png)

![image](https://user-images.githubusercontent.com/40991816/164693057-9eca4c27-dde4-4611-b386-0b1873a3319d.png)



