### PR TITLE
fix: Add 'required' validation to form element

### DIFF
--- a/demo/sampleElements.ts
+++ b/demo/sampleElements.ts
@@ -341,7 +341,8 @@ export const sampleForm = {
   originalUrl: "https://www.formstack.com/forms/?2353564-tOfqZ3Kxj2/",
   html: "<<REDACTED>>",
   isMandatory: false,
-  data: `{"id": "1956117", "alt": "Formstack form embed", "source": "Formstack", "viewKey": "tOfqZ3Kxj2", "iframeUrl": "https://profile.theguardian.com/form/embed/1956117-tOfqZ3Kxj2", "scriptUrl": "https://assets-secure.guim.co.uk/javascripts/vendor/formstack-interactive/0.1/boot.03e0d0dfd005f551febc8caa63566ca4.js", "scriptName": "iframe-wrapper"}`,
+  id: "1956117",
+  data: `{"alt": "Formstack form embed", "source": "Formstack", "viewKey": "tOfqZ3Kxj2", "iframeUrl": "https://profile.theguardian.com/form/embed/1956117-tOfqZ3Kxj2", "scriptUrl": "https://assets-secure.guim.co.uk/javascripts/vendor/formstack-interactive/0.1/boot.03e0d0dfd005f551febc8caa63566ca4.js", "scriptName": "iframe-wrapper"}`,
 };
 
 export const sampleVine = {

--- a/src/elements/form/FormElementForm.tsx
+++ b/src/elements/form/FormElementForm.tsx
@@ -23,7 +23,12 @@ export const FormElementForm: React.FunctionComponent<Props> = ({
   checkThirdPartyTracking,
 }) => (
   <FieldLayoutVertical>
-    <a href={fieldValues.originalUrl}>Edit on Formstack</a>
+    <a
+      target="_blank"
+      href={`https://www.formstack.com/admin/form/overview/${fieldValues.id}`}
+    >
+      Edit on Formstack
+    </a>
     <FieldWrapper
       headingLabel="Signed out text"
       field={fields.signedOutAltText}

--- a/src/elements/form/FormElementSpec.tsx
+++ b/src/elements/form/FormElementSpec.tsx
@@ -3,7 +3,7 @@ import type { Plugin } from "prosemirror-state";
 import { createCustomField } from "../../plugin/fieldViews/CustomFieldView";
 import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
-import { htmlMaxLength } from "../../plugin/helpers/validation";
+import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import type { TrackingStatus } from "../helpers/ThirdPartyStatusChecks";
 import { FormElementForm } from "./FormElementForm";
@@ -36,7 +36,10 @@ export const createFormFields = ({ createCaptionPlugins }: MainFormProps) => ({
   signedOutAltText: createFlatRichTextField({
     createPlugins: createCaptionPlugins,
     marks: "em strong link strike",
-    validators: [htmlMaxLength(signedOutAltTextMaxLength, undefined, "WARN")],
+    validators: [
+      htmlRequired(undefined, "WARN"),
+      htmlMaxLength(signedOutAltTextMaxLength, undefined, "WARN"),
+    ],
     placeholder: "Text to show users if they aren't signed in",
   }),
   html: createTextField(),

--- a/src/elements/form/FormElementSpec.tsx
+++ b/src/elements/form/FormElementSpec.tsx
@@ -13,12 +13,12 @@ export type ExtraFormData = {
   scriptName?: string;
   source?: string;
   viewKey?: string;
-  id?: string;
   scriptUrl?: string;
   alt?: string;
 };
 
 export type FormData = {
+  id?: string;
   signedOutAltText: string;
   html: string;
   originalUrl: string;
@@ -43,6 +43,7 @@ export const createFormFields = ({ createCaptionPlugins }: MainFormProps) => ({
     placeholder: "Text to show users if they aren't signed in",
   }),
   html: createTextField(),
+  id: createTextField(),
   originalUrl: createTextField(),
   isMandatory: createCustomField(true, true),
   data: createCustomField("", undefined),

--- a/src/elements/form/formTransformer.ts
+++ b/src/elements/form/formTransformer.ts
@@ -15,8 +15,9 @@ export const transformElementIn: TransformIn<
   ExternalFormData,
   ReturnType<typeof createFormFields>
 > = ({
-  fields: { html, originalUrl, isMandatory, signedOutAltText, ...rest },
+  fields: { id, html, originalUrl, isMandatory, signedOutAltText, ...rest },
 }) => ({
+  id,
   html,
   originalUrl,
   isMandatory,
@@ -27,9 +28,10 @@ export const transformElementIn: TransformIn<
 export const transformElementOut: TransformOut<
   ExternalFormData,
   ReturnType<typeof createFormFields>
-> = ({ html, originalUrl, isMandatory, signedOutAltText, data }) => {
+> = ({ id, html, originalUrl, isMandatory, signedOutAltText, data }) => {
   return {
     fields: {
+      id,
       html,
       originalUrl,
       isMandatory,


### PR DESCRIPTION
## What does this change?

Makes a few changes as a result of testing in our CMS:

- Adds the 'required' validation to the form element, something that I didn't spot in #242. It's at a `WARN` level to match the current behaviour in our CMS, where this error does not prevent publication. 
- Corrects the 'edit' link, which was reasonably assumed to be `originalUrl`, but this doesn't link to an editable entity in formstack.
- Opens the edit link in a new window when clicked.

## How to test

Add a form element. Are the above addressed?