### PR TITLE
feat: Mod-a within field selects only that field's text

### DIFF
--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -438,7 +438,7 @@ describe("ImageElement", () => {
         );
       });
 
-      it.only("should select the correct range in ProseMirror when the select all shortcut is used within the field", () => {
+      it("should select the correct range in ProseMirror when the select all shortcut is used within the field", () => {
         addImageElement({
           caption: "Hello, world.",
           src: "Foobar.",

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -275,6 +275,19 @@ describe("ImageElement", () => {
           "The remaining field."
         );
       });
+
+      it("should select the correct range in ProseMirror when the select all shortcut is used within the field", () => {
+        addImageElement({
+          caption: "Hello, world.",
+          src: "Foobar.",
+        });
+        typeIntoElementField("caption", `${selectAllShortcut()}`);
+
+        getDocSelection().then(([from, to]) => {
+          expect(from).to.equal(5);
+          expect(to).to.equal(18);
+        });
+      });
     });
 
     describe("Text field", () => {
@@ -423,6 +436,20 @@ describe("ImageElement", () => {
           "have.text",
           "The remaining field."
         );
+      });
+
+      it("should select the correct range in ProseMirror when the select all shortcut is used within the field", () => {
+        addImageElement({
+          caption: "Hello, world.",
+          src: "Foobar.",
+        });
+        typeIntoElementField("src", `${selectAllShortcut()}`);
+
+        getDocSelection().then(([from, to]) => {
+          // The selection should be at the first field of the element
+          expect(from).to.equal(5);
+          expect(to).to.equal(5);
+        });
       });
     });
 

--- a/cypress/tests/ImageElement.spec.ts
+++ b/cypress/tests/ImageElement.spec.ts
@@ -438,7 +438,7 @@ describe("ImageElement", () => {
         );
       });
 
-      it("should select the correct range in ProseMirror when the select all shortcut is used within the field", () => {
+      it.only("should select the correct range in ProseMirror when the select all shortcut is used within the field", () => {
         addImageElement({
           caption: "Hello, world.",
           src: "Foobar.",
@@ -447,8 +447,8 @@ describe("ImageElement", () => {
 
         getDocSelection().then(([from, to]) => {
           // The selection should be at the first field of the element
-          expect(from).to.equal(5);
-          expect(to).to.equal(5);
+          expect(from).to.equal(30);
+          expect(to).to.equal(37);
         });
       });
     });

--- a/src/plugin/fieldViews/RichTextFieldView.ts
+++ b/src/plugin/fieldViews/RichTextFieldView.ts
@@ -3,6 +3,7 @@ import { redo, undo } from "prosemirror-history";
 import { keymap } from "prosemirror-keymap";
 import type { AttributeSpec, Node, Schema } from "prosemirror-model";
 import type { EditorState, Plugin, Transaction } from "prosemirror-state";
+import { TextSelection } from "prosemirror-state";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import type { FieldValidator } from "../elementSpec";
 import { filteredKeymap } from "../helpers/keymap";
@@ -133,6 +134,17 @@ export class RichTextFieldView extends ProseMirrorFieldView {
         keymap({
           "Mod-z": () => undo(outerView.state, outerView.dispatch),
           "Mod-y": () => redo(outerView.state, outerView.dispatch),
+          "Mod-a": (
+            state: EditorState,
+            dispatch?: (tr: Transaction) => void
+          ) => {
+            dispatch?.(
+              state.tr.setSelection(
+                TextSelection.create(state.doc, 0, state.doc.content.size)
+              )
+            );
+            return true;
+          },
           ...filteredKeymap,
         }),
         ...(createPlugins ? createPlugins(node.type.schema) : []),

--- a/src/plugin/fieldViews/RichTextFieldView.ts
+++ b/src/plugin/fieldViews/RichTextFieldView.ts
@@ -3,11 +3,11 @@ import { redo, undo } from "prosemirror-history";
 import { keymap } from "prosemirror-keymap";
 import type { AttributeSpec, Node, Schema } from "prosemirror-model";
 import type { EditorState, Plugin, Transaction } from "prosemirror-state";
-import { TextSelection } from "prosemirror-state";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import type { FieldValidator } from "../elementSpec";
 import { filteredKeymap } from "../helpers/keymap";
 import type { PlaceholderOption } from "../helpers/placeholder";
+import { selectAllText } from "../helpers/prosemirror";
 import type { AbstractTextFieldDescription } from "./ProseMirrorFieldView";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
 
@@ -134,17 +134,7 @@ export class RichTextFieldView extends ProseMirrorFieldView {
         keymap({
           "Mod-z": () => undo(outerView.state, outerView.dispatch),
           "Mod-y": () => redo(outerView.state, outerView.dispatch),
-          "Mod-a": (
-            state: EditorState,
-            dispatch?: (tr: Transaction) => void
-          ) => {
-            dispatch?.(
-              state.tr.setSelection(
-                TextSelection.create(state.doc, 0, state.doc.content.size)
-              )
-            );
-            return true;
-          },
+          "Mod-a": selectAllText,
           ...filteredKeymap,
         }),
         ...(createPlugins ? createPlugins(node.type.schema) : []),

--- a/src/plugin/fieldViews/TextFieldView.ts
+++ b/src/plugin/fieldViews/TextFieldView.ts
@@ -96,14 +96,8 @@ export class TextFieldView extends ProseMirrorFieldView {
       isResizeable,
     }: TextFieldDescription
   ) {
-    const {
-      /* eslint-disable @typescript-eslint/no-unused-vars -- remove commands from keycaps list */
-      Enter,
-      "Mod-Enter": ModEnter,
-      "Mod-a": ModA,
-      /* eslint-enable @typescript-eslint/no-unused-vars */
-      ...modifiedBaseKeymap
-    } = baseKeymap;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- remove 'enter' commands from keymap
+    const { Enter, "Mod-Enter": ModEnter, ...modifiedBaseKeymap } = baseKeymap;
     const keymapping: Record<string, Command> = {
       ...modifiedBaseKeymap,
       "Mod-z": () => undo(outerView.state, outerView.dispatch),

--- a/src/plugin/fieldViews/TextFieldView.ts
+++ b/src/plugin/fieldViews/TextFieldView.ts
@@ -4,11 +4,11 @@ import { redo, undo } from "prosemirror-history";
 import { keymap } from "prosemirror-keymap";
 import type { AttributeSpec, Node, Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
-import { TextSelection } from "prosemirror-state";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import type { FieldValidator } from "../elementSpec";
 import { filteredKeymap } from "../helpers/keymap";
 import type { PlaceholderOption } from "../helpers/placeholder";
+import { selectAllText } from "../helpers/prosemirror";
 import type { AbstractTextFieldDescription } from "./ProseMirrorFieldView";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
 
@@ -121,17 +121,7 @@ export class TextFieldView extends ProseMirrorFieldView {
       keymapping["Enter"] = newLineCommand;
     }
 
-    keymapping["Mod-a"] = (
-      state: EditorState,
-      dispatch?: (tr: Transaction) => void
-    ) => {
-      dispatch?.(
-        state.tr.setSelection(
-          TextSelection.create(state.doc, 0, state.doc.content.size)
-        )
-      );
-      return true;
-    };
+    keymapping["Mod-a"] = selectAllText;
 
     super(
       node,

--- a/src/plugin/fieldViews/TextFieldView.ts
+++ b/src/plugin/fieldViews/TextFieldView.ts
@@ -96,11 +96,12 @@ export class TextFieldView extends ProseMirrorFieldView {
       isResizeable,
     }: TextFieldDescription
   ) {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- remove 'enter' commands from keymap
     const {
+      /* eslint-disable @typescript-eslint/no-unused-vars -- remove commands from keycaps list */
       Enter,
       "Mod-Enter": ModEnter,
       "Mod-a": ModA,
+      /* eslint-enable @typescript-eslint/no-unused-vars */
       ...modifiedBaseKeymap
     } = baseKeymap;
     const keymapping: Record<string, Command> = {

--- a/src/plugin/fieldViews/TextFieldView.ts
+++ b/src/plugin/fieldViews/TextFieldView.ts
@@ -4,6 +4,7 @@ import { redo, undo } from "prosemirror-history";
 import { keymap } from "prosemirror-keymap";
 import type { AttributeSpec, Node, Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
+import { TextSelection } from "prosemirror-state";
 import type { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import type { FieldValidator } from "../elementSpec";
 import { filteredKeymap } from "../helpers/keymap";
@@ -96,7 +97,12 @@ export class TextFieldView extends ProseMirrorFieldView {
     }: TextFieldDescription
   ) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars -- remove 'enter' commands from keymap
-    const { Enter, "Mod-Enter": ModEnter, ...modifiedBaseKeymap } = baseKeymap;
+    const {
+      Enter,
+      "Mod-Enter": ModEnter,
+      "Mod-a": ModA,
+      ...modifiedBaseKeymap
+    } = baseKeymap;
     const keymapping: Record<string, Command> = {
       ...modifiedBaseKeymap,
       "Mod-z": () => undo(outerView.state, outerView.dispatch),
@@ -119,6 +125,18 @@ export class TextFieldView extends ProseMirrorFieldView {
           };
       keymapping["Enter"] = newLineCommand;
     }
+
+    keymapping["Mod-a"] = (
+      state: EditorState,
+      dispatch?: (tr: Transaction) => void
+    ) => {
+      dispatch?.(
+        state.tr.setSelection(
+          TextSelection.create(state.doc, 0, state.doc.content.size)
+        )
+      );
+      return true;
+    };
 
     super(
       node,

--- a/src/plugin/helpers/keymap.ts
+++ b/src/plugin/helpers/keymap.ts
@@ -1,6 +1,6 @@
 import { baseKeymap } from "prosemirror-commands";
 
-const blockedKeys = ["Enter", "Mod-Enter"];
+const blockedKeys = ["Enter", "Mod-Enter", "Mod-a"];
 
 export const filteredKeymap = Object.fromEntries(
   Object.entries(baseKeymap).filter(([key]) => !blockedKeys.includes(key))

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -1,7 +1,7 @@
 import type { Node, Schema } from "prosemirror-model";
 import { DOMParser, DOMSerializer } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
-import { AllSelection, NodeSelection } from "prosemirror-state";
+import { AllSelection, NodeSelection, TextSelection } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 import { Decoration, DecorationSet } from "prosemirror-view";
 
@@ -250,6 +250,22 @@ const htmlToDoc = (parser: DOMParser, html: string) => {
   return parser.parse(dom);
 };
 
+// Select all text within a node, as opposed to AllSelection
+const selectAllText = (
+  state: EditorState,
+  dispatch?: (tr: Transaction) => void
+) => {
+  dispatch?.(
+    state.tr.setSelection(
+      TextSelection.between(
+        state.doc.resolve(0),
+        state.doc.resolve(state.doc.content.size)
+      )
+    )
+  );
+  return true;
+};
+
 export {
   buildCommands,
   defaultPredicate,
@@ -257,4 +273,5 @@ export {
   createParsers,
   docToHtml,
   htmlToDoc,
+  selectAllText,
 };


### PR DESCRIPTION
## What does this change?
<kbd>Mod-a</kbd> (i.e. <kbd>ctrl-a/cmd-a</kbd>) currently selects all Prosemirror elements when used within an element. 

This PR means that using <kbd>mod-a</kbd> within a text field selects only that field's text. 

## How to test
1. Run prosemirror-elements locally following the instructions in the readme.
2. Create an element, click on a text field, type some text in an element and use <kbd>Mod-a</kbd>.
3. Try this in both rich text field (e.g. the image caption) and non-rich text fields (e.g. the pullquote)\

Does this select all of the the text in the field?

## Images
| Before | After |
| --- | --- |
| ![2022-05-04 15 07 01](https://user-images.githubusercontent.com/34686302/166886190-a3655ecf-b474-4bec-8d26-a22d543436cd.gif) | ![2022-05-04 14 49 52](https://user-images.githubusercontent.com/34686302/166886227-96be550b-cd56-4e84-83df-3372187cdd7c.gif) |
