### PR TITLE
Handle absent suppliersReference

### DIFF
--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -32,7 +32,7 @@ export type MainImageData = {
   mediaId?: string | undefined;
   mediaApiUri?: string | undefined;
   assets: Asset[];
-  suppliersReference: string;
+  suppliersReference?: string;
 };
 
 export type ImageSelector = (setMedia: SetMedia, mediaId?: string) => void;

--- a/src/elements/image/__tests__/imageElementDataTransformer.spec.ts
+++ b/src/elements/image/__tests__/imageElementDataTransformer.spec.ts
@@ -175,5 +175,14 @@ describe("image element transform", () => {
       const result = transformElement.out(element);
       expect(result).toEqual(externalElement());
     });
+    it("should be able to handle undefined fields in `mainImage` data", () => {
+      const element = fullPmeElement({
+        mainImage: {
+          assets: [],
+        },
+      });
+      const result = transformElement.out(element);
+      expect(result).toEqual(externalElement());
+    });
   });
 });

--- a/src/elements/image/imageElementDataTransformer.ts
+++ b/src/elements/image/imageElementDataTransformer.ts
@@ -87,7 +87,7 @@ export const transformElementOut: TransformOut<
       suppliersReference: mainImage.suppliersReference,
       mediaApiUri: mainImage.mediaApiUri ?? "",
     },
-    (field) => field.length > 0
+    (field) => field && field.length > 0
   );
 
   return {


### PR DESCRIPTION
## What does this change?

Sometimes, `suppliersReference` is absent in images. We don't account for this in some of our types.

By coincidence, when we instantiate an image element node directly, we provide this value via the ingress transformer – but we don't do this when we recrop. This means that if recropped images are missing a suppliersReference field, they'll blow up on egress.

This PR fixes this and adds a test.

## How to test

- The test should pass, and they should convince you we're testing the right thing.
- Within the editor, try adding an image without a `suppliersReference`, and recrop it. We shouldn't see any red ink, and the content should save as normal.
