### PR TITLE
feat: Add options for interactives

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -56,6 +56,7 @@ import {
   sampleForm,
   sampleImage,
   sampleInteractive,
+  sampleInteractiveAtom,
   sampleMap,
   sampleMembership,
   samplePullquote,
@@ -391,7 +392,12 @@ const createEditor = (server: CollabServer) => {
     { label: "Form", name: formElementName, values: sampleForm },
     { label: "Vine", name: vineElementName, values: sampleVine },
     { label: "Tweet", name: tweetElementName, values: sampleTweet },
-    { label: "Content-atom", name: contentAtomName, values: sampleContentAtom },
+    { label: "Recipe atom", name: contentAtomName, values: sampleContentAtom },
+    {
+      label: "Interactive atom",
+      name: contentAtomName,
+      values: sampleInteractiveAtom,
+    },
     { label: "Comment", name: commentElementName, values: sampleComment },
   ] as const;
 

--- a/demo/sampleElements.ts
+++ b/demo/sampleElements.ts
@@ -363,6 +363,13 @@ export const sampleContentAtom = {
   atomType: "recipe",
 };
 
+export const sampleInteractiveAtom = {
+  id: "interactives/2022/03/erdington-byelection-slope-chart/slope",
+  role: "supporting",
+  atomType: "interactive",
+  isMandatory: "true",
+};
+
 export const sampleComment = {
   source: "Guardian Discussion",
   discussionKey: "/p/6ey2y",

--- a/src/elements/content-atom/ContentAtomForm.tsx
+++ b/src/elements/content-atom/ContentAtomForm.tsx
@@ -9,6 +9,7 @@ import type { FieldNameToField } from "../../plugin/types/Element";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import { Preview } from "../helpers/Preview";
+import { undefinedDropdownValue } from "../helpers/transform";
 import type {
   ContentAtomData,
   contentAtomFields,
@@ -21,6 +22,14 @@ type Props = {
   errors: FieldValidationErrors;
   fetchContentAtomData: FetchContentAtomData;
 };
+
+const interactiveOptions = [
+  { text: "inline (default)", value: undefinedDropdownValue },
+  { text: "supporting", value: "supporting" },
+  { text: "showcase", value: "showcase" },
+  { text: "thumbnail", value: "thumbnail" },
+  { text: "immersive", value: "immersive" },
+];
 
 export const ContentAtomForm: React.FunctionComponent<Props> = ({
   fields,
@@ -39,6 +48,11 @@ export const ContentAtomForm: React.FunctionComponent<Props> = ({
       setContentAtomData(data);
     });
   }, [atomType, id]);
+
+  const weightingOptions =
+    atomType === "interactive"
+      ? interactiveOptions
+      : fields.role.description.props;
 
   return (
     <div>
@@ -82,6 +96,7 @@ export const ContentAtomForm: React.FunctionComponent<Props> = ({
           field={fields.role}
           label="Weighting"
           errors={errors.role}
+          options={weightingOptions}
         />
         <CustomCheckboxView
           field={fields.isMandatory}


### PR DESCRIPTION
## What does this change?

Adds additional weighting options for interactives to match the behaviour of the element this replaces.

The old options looked like:

![Screenshot 2022-06-24 at 09 39 11](https://user-images.githubusercontent.com/7767575/175503095-4d1d1244-5a46-420e-a6c0-1a32a73972a7.png)

## How to test

Running locally, or in Composer via `yalc`, add an interactive element to the document – I've added a new button, `Add interactive atom`, to make testing easy. Compare with other atoms by adding a Recipe atom in the same way. You should see that role options for non-interactive atoms have not changed, but interactive atoms now have the full gamut of options, as in this video: 

https://user-images.githubusercontent.com/7767575/175502697-d95cc0ed-2d35-4f9c-afed-5c624ba4cb2d.mov
