### PR TITLE
fix: change default value of custom node attributes to something composer API understands

### DIFF
--- a/src/plugin/__tests__/nodeSpec.spec.ts
+++ b/src/plugin/__tests__/nodeSpec.spec.ts
@@ -177,9 +177,7 @@ describe("nodeSpec generation", () => {
           attrs: {
             fields: {
               default: {
-                value: {
-                  arbitraryField: "hai",
-                },
+                arbitraryField: "hai",
               },
             },
           },

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -166,7 +166,7 @@ export const getNodeSpecForField = (
           parseDOM: getDefaultParseDOMForLeafNode(nodeName),
           attrs: {
             fields: {
-              default: { value: field.defaultValue },
+              default: field.defaultValue,
             },
           },
         },


### PR DESCRIPTION
## What does this change?
This changes the structure of the default value that Prosemirror sets for custom node attributes to a format that composer API understands. The current format is causing save requests to fail. 

You can see this happening in composer when pressing the up-arrow underneath a pull-quote element and then typing in some text:

https://user-images.githubusercontent.com/33927854/178706419-4997e148-a3cd-4071-9316-414527a68912.mov

After the fix:

https://user-images.githubusercontent.com/33927854/178711752-cdbef638-fef5-426c-b4c6-9706f586edeb.mov

We suspect this is caused by an edge case where we do something unexpected (in this case, trying to type free text into a drop-down field) which triggers Prosemirror to try to recreate the element using its defaults.

Note, this does not fix the unexpected cursor behaviour which is a much larger subject to be addressed separately.

## How to test
You can replicate the behaviour in local composer captured in the videos above.
