### PR TITLE
fix: Tweet element fix

### DIFF
--- a/src/elements/helpers/defaultTransform.ts
+++ b/src/elements/helpers/defaultTransform.ts
@@ -60,7 +60,7 @@ export const transformElementDataOut = <
   if (isMandatory !== undefined) {
     transformedFields = {
       ...transformedFields,
-      isMandatory: isMandatory ? "true" : "false",
+      isMandatory: fields.isMandatory ? "true" : "false",
     };
   }
 

--- a/src/elements/helpers/defaultTransform.ts
+++ b/src/elements/helpers/defaultTransform.ts
@@ -34,6 +34,14 @@ export const transformElementDataIn = <FDesc extends FieldDescriptions<string>>(
       (transformedFields.role as string | undefined) ?? undefinedDropdownValue;
   }
 
+  if (transformedFields.isMandatory) {
+    type FieldWithIsMandatory = FieldNameToValueMap<FDesc> & {
+      isMandatory: boolean;
+    };
+    (transformedFields as FieldWithIsMandatory).isMandatory =
+      fields.isMandatory === "true";
+  }
+
   if (assets?.length) {
     return { ...transformedFields, assets };
   }

--- a/src/elements/rich-link/RichlinkSpec.tsx
+++ b/src/elements/rich-link/RichlinkSpec.tsx
@@ -1,5 +1,8 @@
 import React from "react";
-import { createCustomDropdownField } from "../../plugin/fieldViews/CustomFieldView";
+import {
+  createCustomDropdownField,
+  createCustomField,
+} from "../../plugin/fieldViews/CustomFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { RichlinkElementForm } from "./RichlinkForm";
@@ -16,6 +19,7 @@ export const richlinkFields = {
   draftReference: createTextField({ absentOnEmpty: true }),
   sponsorName: createTextField({ absentOnEmpty: true }),
   sponsorshipType: createTextField({ absentOnEmpty: true }),
+  isMandatory: createCustomField(true, true),
 };
 
 export const richlinkElement = createReactElementSpec(


### PR DESCRIPTION
## What does this change?
The Tweet element was not preserving changes to its 'Is required' field on refresh in Composer.

This PR makes sure that works, by transforming the 'isMandatory' field in and out of `prosemirror-elements`. Once this change is released, we can bump the version used by `flexible-content` to get the Tweet Element working there.

## How to test
1. Run `prosemirror-elements` locally according to the instructions in the readme, and toggle the data view on.
2. Add a Tweet element, and change the 'isRequired' field. Does the data view also update?
3. Install `yalc`, and run `yarn yalc` in `prosemirror-elements` locally.
4. Run `flexible-content` according to the instructions in its repo. Install your local `prosemirror-elements` branch with `yalc add @guardian/prosemirror-elements` in the Composer directory (and run npm install afterwards)
5. Add a tweet element, by pasting a [tweet url](https://twitter.com/win_icons/status/1559842481084067840) in its own line in Composer. Toggle the `isRequired` field, and refresh the page. Is the state always preserved on page refresh?