### PR TITLE
Add a way of programmatically updating a text field's placeholder value

### DIFF
--- a/src/elements/demo-image/DemoImageElementForm.tsx
+++ b/src/elements/demo-image/DemoImageElementForm.tsx
@@ -30,6 +30,11 @@ export const ImageElementForm: React.FunctionComponent<Props> = ({
       field={fields.caption}
       errors={errors.caption}
     />
+    <button
+      onClick={() => fields.caption.view.updatePlaceholder("A new placeholder")}
+    >
+      Update caption placeholder
+    </button>
     <FieldWrapper
       headingLabel="Alt text"
       field={fields.altText}

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -6,7 +6,10 @@ import { Mapping, StepMap } from "prosemirror-transform";
 import type { Decoration } from "prosemirror-view";
 import { DecorationSet, EditorView } from "prosemirror-view";
 import type { PlaceholderOption } from "../helpers/placeholder";
-import { createPlaceholderPlugin } from "../helpers/placeholder";
+import {
+  createPlaceholderPlugin,
+  PME_UPDATE_PLACEHOLDER,
+} from "../helpers/placeholder";
 import type { BaseFieldDescription, FieldView } from "./FieldView";
 import { FieldType } from "./FieldView";
 
@@ -107,6 +110,12 @@ export abstract class ProseMirrorFieldView implements FieldView<string> {
     const tr = this.innerEditorView.state.tr;
     tr.replaceWith(0, this.innerEditorView.state.doc.content.size, node);
     this.dispatchTransaction(tr);
+  }
+
+  public updatePlaceholder(value: PlaceholderOption) {
+    this.innerEditorView?.dispatch(
+      this.innerEditorView.state.tr.setMeta(PME_UPDATE_PLACEHOLDER, value)
+    );
   }
 
   public destroy() {

--- a/src/plugin/helpers/__tests__/placeholder.spec.ts
+++ b/src/plugin/helpers/__tests__/placeholder.spec.ts
@@ -1,36 +1,77 @@
+import type { Node } from "prosemirror-model";
 import { schema } from "prosemirror-schema-basic";
-import { DecorationSet } from "prosemirror-view";
-import { createPlaceholderDecos } from "../placeholder";
+import { EditorState } from "prosemirror-state";
+import { DecorationSet, EditorView } from "prosemirror-view";
+import type { PlaceholderOption } from "../placeholder";
+import {
+  createPlaceholderPlugin,
+  PME_UPDATE_PLACEHOLDER,
+} from "../placeholder";
 import { getDecoSpecs } from "../test";
 
 describe("createPlaceholderDecos", () => {
+  const getDecosFromView = (view: EditorView): DecorationSet =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call -- someProp always provides an `any` type.
+    view.someProp("decorations")(view.state) as DecorationSet;
+
+  const getViewWithPlaceholderPlugin = (
+    initialDoc: Node = schema.nodes.doc.create({}, schema.text("Content")),
+    initialPlaceholder: PlaceholderOption = "Placeholder"
+  ) => {
+    const state = EditorState.create({
+      doc: initialDoc,
+      plugins: [createPlaceholderPlugin(initialPlaceholder)],
+    });
+    const view = new EditorView(undefined, { state });
+    const decorations = getDecosFromView(view);
+
+    return { view, decorations };
+  };
+
   it("should not add a decoration given a contentful inline doc", () => {
-    const doc = schema.nodes.doc.create({}, schema.text("Content"));
-    expect(createPlaceholderDecos("Placeholder")({ doc })).toBe(
-      DecorationSet.empty
-    );
+    const { decorations } = getViewWithPlaceholderPlugin();
+    expect(decorations).toBe(DecorationSet.empty);
   });
+
   it("should add a decoration given a contentless inline doc", () => {
     const doc = schema.nodes.doc.create({});
-    const decoSpecs = getDecoSpecs(
-      createPlaceholderDecos("Placeholder")({ doc })
-    );
+    const { decorations } = getViewWithPlaceholderPlugin(doc);
+    const decoSpecs = getDecoSpecs(decorations);
+
     expect(decoSpecs).toEqual([{ from: 0, to: 0 }]);
   });
+
   it("should not add a decoration given a contentful doc with paragraphs", () => {
     const doc = schema.nodes.doc.create(
       {},
       schema.nodes.paragraph.create({}, schema.text("Content"))
     );
-    expect(createPlaceholderDecos("Placeholder")({ doc })).toBe(
-      DecorationSet.empty
-    );
+    const { decorations } = getViewWithPlaceholderPlugin(doc);
+
+    expect(decorations).toBe(DecorationSet.empty);
   });
+
   it("should add a decoration given a contentless doc with paragraphs", () => {
     const doc = schema.nodes.doc.create({}, schema.nodes.paragraph.create({}));
-    const decoSpecs = getDecoSpecs(
-      createPlaceholderDecos("Placeholder")({ doc })
-    );
+    const { decorations } = getViewWithPlaceholderPlugin(doc);
+    const decoSpecs = getDecoSpecs(decorations);
+
     expect(decoSpecs).toEqual([{ from: 1, to: 1 }]);
+  });
+
+  it("should change the decorations when we change the plugin state", () => {
+    const doc = schema.nodes.doc.create({});
+    const { view } = getViewWithPlaceholderPlugin(doc);
+    const tr = view.state.tr.setMeta(PME_UPDATE_PLACEHOLDER, "New placeholder");
+
+    view.dispatch(tr);
+
+    const decorations = getDecosFromView(view);
+    const decorationSpecs = decorations.find().map((decoration) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access -- This API is not public, but is stable, and lets us assert that our decoration contains the correct content.
+      return (decoration as any).type.toDOM.textContent as string;
+    });
+
+    expect(decorationSpecs).toEqual(["New placeholder"]);
   });
 });

--- a/src/plugin/helpers/placeholder.ts
+++ b/src/plugin/helpers/placeholder.ts
@@ -1,5 +1,6 @@
 import type { Node } from "prosemirror-model";
-import { Plugin } from "prosemirror-state";
+import type { EditorState } from "prosemirror-state";
+import { Plugin, PluginKey } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
 
 export const placeholderTestAttribute = "placeholder";
@@ -38,26 +39,51 @@ const getFirstPlaceholderPosition = (node: Node, currentPos = 0): number =>
 
 export type PlaceholderOption = string | (() => HTMLElement);
 
-export const createPlaceholderDecos = (placeholder: PlaceholderOption) => {
-  const getPlaceholder =
-    typeof placeholder === "string"
-      ? getDefaultPlaceholder(placeholder)
-      : placeholder;
+const placeholderPluginKey = new PluginKey<PlaceholderOption>(
+  "pme_placeholder_plugin"
+);
 
-  return ({ doc }: { doc: Node }) => {
-    if (doc.textContent) {
-      return DecorationSet.empty;
-    }
-
-    // If the document contains inline content only, just place the widget at its start.
-    const pos = doc.inlineContent ? 0 : getFirstPlaceholderPosition(doc);
-    return DecorationSet.create(doc, [Decoration.widget(pos, getPlaceholder)]);
-  };
-};
+export const PME_UPDATE_PLACEHOLDER = "PME_UPDATE_PLACEHOLDER";
 
 export const createPlaceholderPlugin = (text: PlaceholderOption) =>
-  new Plugin({
+  new Plugin<PlaceholderOption>({
+    key: placeholderPluginKey,
+    state: {
+      init() {
+        return text;
+      },
+      apply(tr, oldPlaceholder) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- getMeta always returns an any value
+        const newPlaceholder: PlaceholderOption | undefined = tr.getMeta(
+          PME_UPDATE_PLACEHOLDER
+        );
+
+        return newPlaceholder ? newPlaceholder : oldPlaceholder;
+      },
+    },
     props: {
-      decorations: createPlaceholderDecos(text),
+      decorations: (state: EditorState) => {
+        const placeholder = placeholderPluginKey.getState(state);
+        if (!placeholder) {
+          return DecorationSet.empty;
+        }
+
+        const getPlaceholder =
+          typeof placeholder === "string"
+            ? getDefaultPlaceholder(placeholder)
+            : placeholder;
+
+        if (state.doc.textContent) {
+          return DecorationSet.empty;
+        }
+
+        // If the document contains inline content only, just place the widget at its start.
+        const pos = state.doc.inlineContent
+          ? 0
+          : getFirstPlaceholderPosition(state.doc);
+        return DecorationSet.create(state.doc, [
+          Decoration.widget(pos, getPlaceholder),
+        ]);
+      },
     },
   });


### PR DESCRIPTION
## What does this change

Adds a way of programmatically updating a text field's placeeholder value.

We've added this to the view API. Calls will look like:

```ts
fields.fieldName.view.updatePlaceholder("New placeholder value")
```

## How to test

- The automated tests should pass (I've refactored the tests for the placeholder plugin), and should cover the new update functionality.
- I've altered our demo element to give us an example. Run the sandbox locally, add a 'Demo Image Element' to the editor, and click the 'update placeholder' button underneath the caption. The placeholder should update as expected.