### PR TITLE
refactor: consolidate callout types

### DIFF
--- a/demo/sampleElements.ts
+++ b/demo/sampleElements.ts
@@ -267,7 +267,7 @@ export const sampleCallout = {
   altText: "",
   caption: "",
   html:
-    '<div data-callout-tagname="test-form-six"><h2>Callout<h2><p>test-form-six</p></div>',
+    '<div data-callout-tagname="callout-demo-2"><h2>Callout<h2><p>callout-demo-2</p></div>',
 };
 
 export const sampleCampaignCalloutList = {};

--- a/src/elements/callout/Callout.tsx
+++ b/src/elements/callout/Callout.tsx
@@ -7,7 +7,7 @@ import { CustomDropdownView } from "../../renderers/react/customFieldViewCompone
 import { CalloutError, calloutStyles, CalloutTable } from "../embed/Callout";
 import { undefinedDropdownValue } from "../helpers/transform";
 
-type Fields = {
+export type Fields = {
   callout: string;
   formId: number;
   tagName: string;
@@ -16,7 +16,7 @@ type Fields = {
   _type: string;
 };
 
-type Rules = {
+export type Rules = {
   requiredTags: string[];
   lackingTags: string[];
   matchAllTags: boolean;

--- a/src/elements/embed/Callout.tsx
+++ b/src/elements/embed/Callout.tsx
@@ -5,24 +5,12 @@ import React, { useEffect, useState } from "react";
 import { Error } from "../../editorial-source-components/Error";
 import { Label } from "../../editorial-source-components/Label";
 import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
+import type { Campaign } from "../callout/Callout";
 import { EmbedTestId } from "./EmbedForm";
 
 type Props = {
   tag: string;
   targetingUrl: string;
-};
-
-type Callout = {
-  id: string;
-  name: string;
-  fields: TagFields;
-};
-
-type TagFields = {
-  tagName: string;
-  callout: string;
-  description?: string;
-  formUrl?: string;
 };
 
 export const calloutStyles = css`
@@ -69,7 +57,7 @@ const marginBottom = css`
 `;
 
 const getCampaigns = (targetingDomain: string) => {
-  let campaigns: Promise<Callout[]> | undefined = undefined;
+  let campaigns: Promise<Campaign[]> | undefined = undefined;
   return () => {
     if (campaigns === undefined) {
       campaigns = fetch(`${targetingDomain}/api/campaigns`).then((response) =>
@@ -84,7 +72,7 @@ const memoisedGetCampaigns = (targetingDomain: string) =>
   getCampaigns(targetingDomain);
 
 const getCalloutByTag = (tag: string, targetingDomain: string) =>
-  memoisedGetCampaigns(targetingDomain)().then((data: Callout[]) => {
+  memoisedGetCampaigns(targetingDomain)().then((data: Campaign[]) => {
     return data.find((callout) => callout.fields.tagName === tag);
   });
 
@@ -92,7 +80,7 @@ export const CalloutTable = ({
   calloutData,
   targetingUrl,
 }: {
-  calloutData: Callout;
+  calloutData: Campaign;
   targetingUrl: string;
 }) => {
   return (
@@ -189,7 +177,7 @@ export const Callout: React.FunctionComponent<Props> = ({
   tag,
   targetingUrl,
 }) => {
-  const [callout, setCallout] = useState<Callout | undefined>(undefined);
+  const [callout, setCallout] = useState<Campaign | undefined>(undefined);
 
   useEffect(() => {
     getCalloutByTag(tag, targetingUrl)


### PR DESCRIPTION
Paired on this: @marjisound & @abeddow91 

## What does this change?
We currently have two callout components which should share the same type. This PR export the types from the `callout/callout` element component so that they can be shared by the `embed/callout` element. 
These changes were requested in https://github.com/guardian/prosemirror-elements/pull/270

## How to test
Add a callout and a campaign callout and ensure there are no runtime errors. 
