### PR TITLE
feat: add callout transformer and update callout ui

### DIFF
--- a/src/elements/callout/Callout.tsx
+++ b/src/elements/callout/Callout.tsx
@@ -60,7 +60,7 @@ export const calloutFields = {
     [],
     [dropDownRequired(undefined, "WARN")]
   ),
-  isNonCollapsable: createCustomField(false, false),
+  isNonCollapsible: createCustomField(false, true),
 };
 
 export const createCalloutElement = ({
@@ -100,8 +100,8 @@ export const createCalloutElement = ({
             resetCampaign={() => fields.campaignId.update("none-selected")}
             calloutData={callout}
             targetingUrl={trimmedTargetingUrl}
-            isNonCollapsable={fields.isNonCollapsable}
-            isNonCollapsableError={errors.isNonCollapsable}
+            isNonCollapsible={fields.isNonCollapsible}
+            isNonCollapsibleError={errors.isNonCollapsible}
           />
         ) : (
           <CalloutError

--- a/src/elements/callout/Callout.tsx
+++ b/src/elements/callout/Callout.tsx
@@ -100,7 +100,6 @@ export const createCalloutElement = ({
             calloutData={callout}
             targetingUrl={trimmedTargetingUrl}
             isNonCollapsible={fields.isNonCollapsible}
-            isNonCollapsibleError={errors.isNonCollapsible}
           />
         ) : (
           <CalloutError

--- a/src/elements/callout/Callout.tsx
+++ b/src/elements/callout/Callout.tsx
@@ -1,11 +1,14 @@
 import React, { useEffect, useState } from "react";
-import { Label } from "../../editorial-source-components/Label";
-import { createCustomDropdownField } from "../../plugin/fieldViews/CustomFieldView";
+import {
+  createCustomDropdownField,
+  createCustomField,
+} from "../../plugin/fieldViews/CustomFieldView";
 import { dropDownRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
-import { CalloutError, calloutStyles, CalloutTable } from "../embed/Callout";
+import { CalloutError, calloutStyles } from "../embed/Callout";
 import { undefinedDropdownValue } from "../helpers/transform";
+import { CalloutTable } from "./CalloutTable";
 
 export type Fields = {
   callout: string;
@@ -57,6 +60,7 @@ export const calloutFields = {
     [],
     [dropDownRequired(undefined, "WARN")]
   ),
+  isNonCollapsable: createCustomField(false, false),
 };
 
 export const createCalloutElement = ({
@@ -88,13 +92,22 @@ export const createCalloutElement = ({
     const dropdownOptions = getDropdownOptionsFromCampaignList(campaignList);
     const callout = campaignList.find((campaign) => campaign.id === campaignId);
 
+    const trimmedTargetingUrl = targetingUrl.replace(/\/$/, "");
     return campaignId && campaignId != "none-selected" ? (
       <div css={calloutStyles}>
-        <Label>Callout</Label>
         {callout ? (
-          <CalloutTable calloutData={callout} targetingUrl={targetingUrl} />
+          <CalloutTable
+            resetCampaign={() => fields.campaignId.update("none-selected")}
+            calloutData={callout}
+            targetingUrl={trimmedTargetingUrl}
+            isNonCollapsable={fields.isNonCollapsable}
+            isNonCollapsableError={errors.isNonCollapsable}
+          />
         ) : (
-          <CalloutError tag={getTag(campaignId)} targetingUrl={targetingUrl} />
+          <CalloutError
+            tag={getTag(campaignId)}
+            targetingUrl={trimmedTargetingUrl}
+          />
         )}
       </div>
     ) : (

--- a/src/elements/callout/Callout.tsx
+++ b/src/elements/callout/Callout.tsx
@@ -97,7 +97,6 @@ export const createCalloutElement = ({
       <div css={calloutStyles}>
         {callout ? (
           <CalloutTable
-            resetCampaign={() => fields.campaignId.update("none-selected")}
             calloutData={callout}
             targetingUrl={trimmedTargetingUrl}
             isNonCollapsible={fields.isNonCollapsible}

--- a/src/elements/callout/CalloutTable.tsx
+++ b/src/elements/callout/CalloutTable.tsx
@@ -1,7 +1,6 @@
 import { css } from "@emotion/react";
 import { neutral, space } from "@guardian/src-foundations";
 import { Label } from "../../editorial-source-components/Label";
-import type { ValidationError } from "../../plugin/elementSpec";
 import type { CustomField } from "../../plugin/types/Element";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
 import type { Campaign } from "./Callout";
@@ -63,12 +62,10 @@ export const CalloutTable = ({
   calloutData,
   targetingUrl,
   isNonCollapsible,
-  isNonCollapsibleError,
 }: {
   calloutData: Campaign;
   targetingUrl: string;
   isNonCollapsible: CustomField<boolean, boolean>;
-  isNonCollapsibleError: ValidationError[];
 }) => {
   const { tagName, callout, description, formUrl } = calloutData.fields;
   return (
@@ -111,7 +108,6 @@ export const CalloutTable = ({
       </div>
       <CustomCheckboxView
         field={isNonCollapsible}
-        errors={isNonCollapsibleError}
         label="Show as non-collapsable"
       />
     </div>

--- a/src/elements/callout/CalloutTable.tsx
+++ b/src/elements/callout/CalloutTable.tsx
@@ -10,16 +10,13 @@ const containerStyle = css`
   display: flex;
   flex-direction: column;
 `;
+
 const headerStyle = css`
   display: flex;
   justify-content: space-between;
 `;
 
-const headerLinkStyle = css`
-  margin-right: ${space[4]}px;
-`;
-
-const tagRowStyle = css`
+const tagStyle = css`
   background-color: ${neutral[93]};
   display: flex;
   align-items: center;
@@ -39,7 +36,7 @@ const cellStyle = css`
   }
 `;
 
-const tagStyle = css`
+const tagTypeStyle = css`
   background-color: ${neutral[100]};
   padding: 2px 6px;
   width: fit-content;
@@ -51,11 +48,7 @@ const tagNameStyle = css`
   width: 50%;
 `;
 
-const tagSectionStyle = css`
-  width: 35%;
-`;
-
-const campaignTitleStyle = css`
+const bodyStyle = css`
   display: flex;
   flex-direction: column;
   margin-bottom: ${space[9]}px;
@@ -84,7 +77,9 @@ export const CalloutTable = ({
         <Label>CALLOUT: {tagName}</Label>
         <span>
           <a
-            css={headerLinkStyle}
+            css={css`
+              margin-right: ${space[4]}px;
+            `}
             href={`${targetingUrl}/campaigns/${calloutData.id}`}
           >
             Open in targeting tool
@@ -93,14 +88,13 @@ export const CalloutTable = ({
         </span>
       </div>
 
-      <div css={tagRowStyle}>
+      <div css={tagStyle}>
         <span css={cellStyle}>
-          <p css={tagStyle}>CAMPAIGN</p>
+          <p css={tagTypeStyle}>CAMPAIGN</p>
         </span>
         <span css={[cellStyle, tagNameStyle]}>{tagName}</span>
-        <span css={[cellStyle, tagSectionStyle]}>Global</span>
       </div>
-      <div css={campaignTitleStyle}>
+      <div css={bodyStyle}>
         <span>
           <span css={strongStyle}>Callout title: </span>
           {callout}

--- a/src/elements/callout/CalloutTable.tsx
+++ b/src/elements/callout/CalloutTable.tsx
@@ -1,0 +1,142 @@
+import { css } from "@emotion/react";
+import { neutral, space } from "@guardian/src-foundations";
+import { Label } from "../../editorial-source-components/Label";
+import type { ValidationError } from "../../plugin/elementSpec";
+import type { CustomField } from "../../plugin/types/Element";
+import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
+import type { Campaign } from "./Callout";
+
+const containerStyle = css`
+  display: flex;
+  flex-direction: column;
+`;
+const headerStyle = css`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const headerTitleStyle = css`
+  display: flex;
+  column-gap: ${space[2]}px;
+`;
+const headerLinkStyle = css`
+  margin-right: ${space[4]}px;
+`;
+
+const changeStyle = css`
+  all: unset;
+  cursor: pointer;
+  color: #007abc;
+  text-decoration: underline;
+`;
+
+const tagRowStyle = css`
+  background-color: ${neutral[93]};
+  display: flex;
+  align-items: center;
+  margin: ${space[4]}px 0;
+`;
+
+const cellStyle = css`
+  border-right: 1px solid ${neutral[100]};
+  padding: 3px 5px;
+
+  &:first-child {
+    padding-left: ${space[3]}px;
+  }
+
+  &:last-child {
+    border-right: 0;
+  }
+`;
+
+const tagStyle = css`
+  background-color: ${neutral[100]};
+  padding: 2px 6px;
+  width: fit-content;
+  font-size: 12px;
+  font-weight: 700;
+`;
+
+const tagNameStyle = css`
+  width: 50%;
+`;
+
+const tagSectionStyle = css`
+  width: 35%;
+`;
+
+const campaignTitleStyle = css`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: ${space[9]}px;
+  row-gap: ${space[2]}px;
+`;
+
+const strongStyle = css`
+  font-weight: 700;
+`;
+export const CalloutTable = ({
+  calloutData,
+  targetingUrl,
+  resetCampaign,
+  isNonCollapsable,
+  isNonCollapsableError,
+}: {
+  calloutData: Campaign;
+  targetingUrl: string;
+  resetCampaign: () => void;
+  isNonCollapsable: CustomField<boolean, boolean>;
+  isNonCollapsableError: ValidationError[];
+}) => {
+  const { tagName, callout, description, formUrl } = calloutData.fields;
+  return (
+    <div css={containerStyle}>
+      <div css={headerStyle}>
+        <span css={headerTitleStyle}>
+          <Label>CALLOUT: {tagName}</Label>
+          <button css={changeStyle} onClick={resetCampaign}>
+            Change
+          </button>
+        </span>
+        <span>
+          <a
+            css={headerLinkStyle}
+            href={`${targetingUrl}/campaigns/${calloutData.id}`}
+          >
+            Open in targeting tool
+          </a>
+          <a href={formUrl}>Open in Formstack</a>
+        </span>
+      </div>
+
+      <div css={tagRowStyle}>
+        <span css={cellStyle}>
+          <p css={tagStyle}>CAMPAIGN</p>
+        </span>
+        <span css={[cellStyle, tagNameStyle]}>{tagName}</span>
+        <span css={[cellStyle, tagSectionStyle]}>Global</span>
+      </div>
+      <div css={campaignTitleStyle}>
+        <span>
+          <span css={strongStyle}>Callout title: </span>
+          {callout}
+        </span>
+        <span>
+          <span css={strongStyle}>Callout description:</span>
+          <br></br>
+          <div
+            dangerouslySetInnerHTML={{
+              __html: description ?? "",
+            }}
+          ></div>
+        </span>
+      </div>
+      <CustomCheckboxView
+        field={isNonCollapsable}
+        errors={isNonCollapsableError}
+        label="Show as non-collapsable"
+      />
+    </div>
+  );
+};

--- a/src/elements/callout/CalloutTable.tsx
+++ b/src/elements/callout/CalloutTable.tsx
@@ -15,19 +15,8 @@ const headerStyle = css`
   justify-content: space-between;
 `;
 
-const headerTitleStyle = css`
-  display: flex;
-  column-gap: ${space[2]}px;
-`;
 const headerLinkStyle = css`
   margin-right: ${space[4]}px;
-`;
-
-const changeStyle = css`
-  all: unset;
-  cursor: pointer;
-  color: #007abc;
-  text-decoration: underline;
 `;
 
 const tagRowStyle = css`
@@ -76,16 +65,15 @@ const campaignTitleStyle = css`
 const strongStyle = css`
   font-weight: 700;
 `;
+
 export const CalloutTable = ({
   calloutData,
   targetingUrl,
-  resetCampaign,
   isNonCollapsible,
   isNonCollapsibleError,
 }: {
   calloutData: Campaign;
   targetingUrl: string;
-  resetCampaign: () => void;
   isNonCollapsible: CustomField<boolean, boolean>;
   isNonCollapsibleError: ValidationError[];
 }) => {
@@ -93,12 +81,7 @@ export const CalloutTable = ({
   return (
     <div css={containerStyle}>
       <div css={headerStyle}>
-        <span css={headerTitleStyle}>
-          <Label>CALLOUT: {tagName}</Label>
-          <button css={changeStyle} onClick={resetCampaign}>
-            Change
-          </button>
-        </span>
+        <Label>CALLOUT: {tagName}</Label>
         <span>
           <a
             css={headerLinkStyle}

--- a/src/elements/callout/CalloutTable.tsx
+++ b/src/elements/callout/CalloutTable.tsx
@@ -80,14 +80,14 @@ export const CalloutTable = ({
   calloutData,
   targetingUrl,
   resetCampaign,
-  isNonCollapsable,
-  isNonCollapsableError,
+  isNonCollapsible,
+  isNonCollapsibleError,
 }: {
   calloutData: Campaign;
   targetingUrl: string;
   resetCampaign: () => void;
-  isNonCollapsable: CustomField<boolean, boolean>;
-  isNonCollapsableError: ValidationError[];
+  isNonCollapsible: CustomField<boolean, boolean>;
+  isNonCollapsibleError: ValidationError[];
 }) => {
   const { tagName, callout, description, formUrl } = calloutData.fields;
   return (
@@ -133,8 +133,8 @@ export const CalloutTable = ({
         </span>
       </div>
       <CustomCheckboxView
-        field={isNonCollapsable}
-        errors={isNonCollapsableError}
+        field={isNonCollapsible}
+        errors={isNonCollapsibleError}
         label="Show as non-collapsable"
       />
     </div>

--- a/src/elements/callout/calloutDataTransformer.ts
+++ b/src/elements/callout/calloutDataTransformer.ts
@@ -1,0 +1,52 @@
+import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
+import { undefinedDropdownValue } from "../helpers/transform";
+import type { TransformIn, TransformOut } from "../helpers/types/Transform";
+import type { calloutFields } from "./Callout";
+
+export type ExternalCalloutFields = {
+  campaignId: string | undefined;
+  isNonCollapsible: string;
+};
+
+export type ExternalCalloutData = {
+  fields: ExternalCalloutFields;
+  assets: [];
+};
+
+export type PartialEmbedData = {
+  fields: Partial<ExternalCalloutFields>;
+};
+
+export const transformElementIn: TransformIn<
+  PartialEmbedData,
+  typeof calloutFields
+> = ({ fields }) => {
+  const { campaignId, isNonCollapsible } = fields;
+
+  return {
+    isNonCollapsible: isNonCollapsible === "true",
+    campaignId: campaignId ?? undefinedDropdownValue,
+  };
+};
+
+export const transformElementOut: TransformOut<
+  ExternalCalloutData,
+  typeof calloutFields
+> = ({
+  isNonCollapsible,
+  campaignId,
+}: FieldNameToValueMap<typeof calloutFields>): ExternalCalloutData => {
+  return {
+    assets: [],
+    fields: {
+      isNonCollapsible: isNonCollapsible.toString(),
+      campaignId:
+        campaignId === undefinedDropdownValue ? undefined : campaignId,
+    },
+  };
+};
+
+export const transformElement = {
+  in: transformElementIn,
+  out: transformElementOut,
+};

--- a/src/elements/helpers/transform.ts
+++ b/src/elements/helpers/transform.ts
@@ -1,4 +1,4 @@
-import type { calloutFields } from "../callout/Callout";
+import { transformElement as calloutElementTransform } from "../callout/calloutDataTransformer";
 import type { codeFields } from "../code/CodeElementSpec";
 import type { commentFields } from "../comment/CommentSpec";
 import type { contentAtomFields } from "../content-atom/ContentAtomSpec";
@@ -24,7 +24,7 @@ const transformMap = {
     transformRole: true,
   }),
   embed: embedElementTransform,
-  callout: defaultElementTransform<typeof calloutFields>(),
+  callout: calloutElementTransform,
   image: imageElementTransform,
   interactive: interactiveElementTransform,
   pullquote: defaultElementTransform<typeof pullquoteFields>(),


### PR DESCRIPTION
paired on with @abeddow91 & @marjisound 
## What does this change?
This PR adds a custom callout transformer to transform the checkbox boolean to string and "none-selected" to undefined.

It also 

- updates the callout UI
- adds in a isNonCollapsible checkbox

 
## How to test
This can be tested locally via a yalc link in Composer. 


## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![Screenshot 2022-10-11 at 15 19 34](https://user-images.githubusercontent.com/20416599/195116967-154a904f-060d-421b-9b37-b9c001be6394.png)


## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [ ] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [ ] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
