### PR TITLE
feat: Add an onRemove callback, which is called with the removed element's field data

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -27,6 +27,7 @@ import {
   richlinkElement,
   tableElement,
 } from "../src";
+import type { calloutFields } from "../src/elements/callout/Callout";
 import {
   transformElementOut,
   undefinedDropdownValue,
@@ -185,7 +186,8 @@ const {
       fetchCampaignList: () => Promise.resolve(sampleCampaignList),
       targetingUrl: "https://targeting.code.dev-gutools.co.uk/",
       applyTag: (tag: string) => console.log(`Apply ${tag} tag`),
-      onRemove: () => console.log("Remove callout"),
+      onRemove: (fields: typeof calloutFields) =>
+        console.log("Remove callout", fields),
     }),
     interactive: createInteractiveElement({
       checkThirdPartyTracking: mockThirdPartyTracking,

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -27,7 +27,6 @@ import {
   richlinkElement,
   tableElement,
 } from "../src";
-import type { calloutFields } from "../src/elements/callout/Callout";
 import {
   transformElementOut,
   undefinedDropdownValue,
@@ -186,7 +185,7 @@ const {
       fetchCampaignList: () => Promise.resolve(sampleCampaignList),
       targetingUrl: "https://targeting.code.dev-gutools.co.uk/",
       applyTag: (tag: string) => console.log(`Apply ${tag} tag`),
-      onRemove: (fields: typeof calloutFields) =>
+      onRemove: (fields: Record<string, unknown>) =>
         console.log("Remove callout", fields),
     }),
     interactive: createInteractiveElement({

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -185,6 +185,7 @@ const {
       fetchCampaignList: () => Promise.resolve(sampleCampaignList),
       targetingUrl: "https://targeting.code.dev-gutools.co.uk/",
       applyTag: (tag: string) => console.log(`Apply ${tag} tag`),
+      onRemove: () => console.log("Remove callout"),
     }),
     interactive: createInteractiveElement({
       checkThirdPartyTracking: mockThirdPartyTracking,

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -185,8 +185,7 @@ const {
       fetchCampaignList: () => Promise.resolve(sampleCampaignList),
       targetingUrl: "https://targeting.code.dev-gutools.co.uk/",
       applyTag: (tag: string) => console.log(`Apply ${tag} tag`),
-      onRemove: (fields: Record<string, unknown>) =>
-        console.log("Remove callout", fields),
+      onRemove: (fields) => console.log("Remove callout", fields),
     }),
     interactive: createInteractiveElement({
       checkThirdPartyTracking: mockThirdPartyTracking,

--- a/src/elements/callout/Callout.tsx
+++ b/src/elements/callout/Callout.tsx
@@ -40,6 +40,7 @@ type Props = {
   fetchCampaignList: () => Promise<Campaign[]>;
   targetingUrl: string;
   applyTag: (tagId: string) => void;
+  onRemove: () => void;
 };
 
 const getDropdownOptionsFromCampaignList = (campaignList: Campaign[]) => {
@@ -67,6 +68,7 @@ export const createCalloutElement = ({
   fetchCampaignList,
   targetingUrl,
   applyTag,
+  onRemove,
 }: Props) =>
   createReactElementSpec(calloutFields, ({ fields }) => {
     const campaignId = fields.campaignId.value;

--- a/src/elements/callout/Callout.tsx
+++ b/src/elements/callout/Callout.tsx
@@ -40,7 +40,7 @@ type Props = {
   fetchCampaignList: () => Promise<Campaign[]>;
   targetingUrl: string;
   applyTag: (tagId: string) => void;
-  onRemove: () => void;
+  onRemove: (fields: Record<string, unknown>) => void;
 };
 
 const getDropdownOptionsFromCampaignList = (campaignList: Campaign[]) => {
@@ -70,53 +70,63 @@ export const createCalloutElement = ({
   applyTag,
   onRemove,
 }: Props) =>
-  createReactElementSpec(calloutFields, ({ fields }) => {
-    const campaignId = fields.campaignId.value;
-    const [campaignList, setCampaignList] = useState<Campaign[]>([]);
-    useEffect(() => {
-      void fetchCampaignList().then((campaignList) => {
-        setCampaignList(campaignList);
-      });
-    }, []);
+  createReactElementSpec(
+    calloutFields,
+    ({ fields }) => {
+      const campaignId = fields.campaignId.value;
+      const [campaignList, setCampaignList] = useState<Campaign[]>([]);
+      useEffect(() => {
+        void fetchCampaignList().then((campaignList) => {
+          setCampaignList(campaignList);
+        });
+      }, []);
 
-    useEffect(() => {
-      if (campaignId === undefinedDropdownValue || campaignList.length === 0) {
-        return;
-      }
-      applyTag(getTag(campaignId));
-    }, [campaignId]);
+      useEffect(() => {
+        if (
+          campaignId === undefinedDropdownValue ||
+          campaignList.length === 0
+        ) {
+          return;
+        }
+        applyTag(getTag(campaignId));
+      }, [campaignId]);
 
-    const getTag = (id: string) => {
-      const campaign = campaignList.find((campaign) => campaign.id === id);
-      return campaign?.fields.tagName ?? "";
-    };
+      const getTag = (id: string) => {
+        const campaign = campaignList.find((campaign) => campaign.id === id);
+        return campaign?.fields.tagName ?? "";
+      };
 
-    const dropdownOptions = getDropdownOptionsFromCampaignList(campaignList);
-    const callout = campaignList.find((campaign) => campaign.id === campaignId);
+      const dropdownOptions = getDropdownOptionsFromCampaignList(campaignList);
+      const callout = campaignList.find(
+        (campaign) => campaign.id === campaignId
+      );
 
-    const trimmedTargetingUrl = targetingUrl.replace(/\/$/, "");
-    return campaignId && campaignId != "none-selected" ? (
-      <div css={calloutStyles}>
-        {callout ? (
-          <CalloutTable
-            calloutData={callout}
-            targetingUrl={trimmedTargetingUrl}
-            isNonCollapsible={fields.isNonCollapsible}
+      const trimmedTargetingUrl = targetingUrl.replace(/\/$/, "");
+      return campaignId && campaignId != "none-selected" ? (
+        <div css={calloutStyles}>
+          {callout ? (
+            <CalloutTable
+              calloutData={callout}
+              targetingUrl={trimmedTargetingUrl}
+              isNonCollapsible={fields.isNonCollapsible}
+            />
+          ) : (
+            <CalloutError
+              tag={getTag(campaignId)}
+              targetingUrl={trimmedTargetingUrl}
+            />
+          )}
+        </div>
+      ) : (
+        <div>
+          <CustomDropdownView
+            label="Callout"
+            field={fields.campaignId}
+            options={dropdownOptions}
           />
-        ) : (
-          <CalloutError
-            tag={getTag(campaignId)}
-            targetingUrl={trimmedTargetingUrl}
-          />
-        )}
-      </div>
-    ) : (
-      <div>
-        <CustomDropdownView
-          label="Callout"
-          field={fields.campaignId}
-          options={dropdownOptions}
-        />
-      </div>
-    );
-  });
+        </div>
+      );
+    },
+    undefined,
+    (fields) => onRemove(fields)
+  );

--- a/src/elements/callout/Callout.tsx
+++ b/src/elements/callout/Callout.tsx
@@ -3,6 +3,7 @@ import {
   createCustomDropdownField,
   createCustomField,
 } from "../../plugin/fieldViews/CustomFieldView";
+import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
 import { dropDownRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
@@ -36,13 +37,6 @@ export type Campaign = {
   activeUntil?: number;
 };
 
-type Props = {
-  fetchCampaignList: () => Promise<Campaign[]>;
-  targetingUrl: string;
-  applyTag: (tagId: string) => void;
-  onRemove: (fields: Record<string, unknown>) => void;
-};
-
 const getDropdownOptionsFromCampaignList = (campaignList: Campaign[]) => {
   const campaigns = campaignList.map((campaign) => {
     const name = campaign.name.replace("CALLOUT:", "").trimStart();
@@ -62,6 +56,13 @@ export const calloutFields = {
     [dropDownRequired(undefined, "WARN")]
   ),
   isNonCollapsible: createCustomField(false, true),
+};
+
+type Props = {
+  fetchCampaignList: () => Promise<Campaign[]>;
+  targetingUrl: string;
+  applyTag: (tagId: string) => void;
+  onRemove: (fields: FieldNameToValueMap<typeof calloutFields>) => void;
 };
 
 export const createCalloutElement = ({

--- a/src/plugin/helpers/element.ts
+++ b/src/plugin/helpers/element.ts
@@ -15,6 +15,7 @@ import {
 import type {
   ElementSpecMap,
   ExtractDataTypeFromElementSpec,
+  ExtractFieldValues,
   FieldDescription,
   FieldDescriptions,
   FieldNameToField,
@@ -100,10 +101,10 @@ export const createGetElementDataFromNode = <
     serializer
   );
 
-  return {
+  return ({
     elementName,
     values,
-  } as ExtractDataTypeFromElementSpec<ESpecMap, ElementNames>;
+  } as unknown) as ExtractDataTypeFromElementSpec<ESpecMap, ElementNames>;
 };
 
 export const getFieldValuesFromNode = <
@@ -137,7 +138,7 @@ export const getFieldValuesFromNode = <
     values[fieldName] = value;
   });
 
-  return values;
+  return values as ExtractFieldValues<FDesc>;
 };
 
 export const getFieldValueFromNode = (

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -10,6 +10,7 @@ import type {
   FieldDescriptions,
 } from "../plugin/types/Element";
 import { getFieldsFromNode, updateFieldsFromNode } from "./field";
+import { getFieldValuesFromNode } from "./helpers/element";
 import { updateFieldViewsFromNode } from "./helpers/fieldView";
 import type { Commands } from "./helpers/prosemirror";
 import { createUpdateDecorations } from "./helpers/prosemirror";
@@ -151,6 +152,7 @@ const createNodeView = <
 
   const serializer = DOMSerializer.fromSchema(initElementNode.type.schema);
   const initCommands = commands(getPos, view);
+
   const fields = getFieldsFromNode({
     node: initElementNode,
     fieldDescriptions: element.fieldDescriptions,
@@ -179,6 +181,9 @@ const createNodeView = <
   let currentIsSelected = false;
   let currentCommandValues = getCommandValues(initCommands);
 
+  const getElementDataFromNode = () =>
+    getFieldValuesFromNode(currentNode, element.fieldDescriptions, serializer);
+
   const update = element.createUpdator(
     dom,
     fields,
@@ -191,7 +196,8 @@ const createNodeView = <
       );
     },
     initCommands,
-    sendTelemetryEvent
+    sendTelemetryEvent,
+    getElementDataFromNode
   );
 
   return {

--- a/src/plugin/types/Element.ts
+++ b/src/plugin/types/Element.ts
@@ -106,7 +106,8 @@ export type ElementSpec<FDesc extends FieldDescriptions<string>> = {
     fields: FieldNameToField<FDesc>,
     updateState: (fields: FieldNameToValueMap<FDesc>) => void,
     commands: ReturnType<CommandCreator>,
-    sendTelemetryEvent: SendTelemetryEvent | undefined
+    sendTelemetryEvent: SendTelemetryEvent | undefined,
+    getElementData: () => ExtractFieldValues<FDesc>
   ) => (
     fields: FieldNameToField<FDesc>,
     commands: ReturnType<CommandCreator>,

--- a/src/renderers/react/ElementProvider.tsx
+++ b/src/renderers/react/ElementProvider.tsx
@@ -26,7 +26,7 @@ type IProps<FDesc extends FieldDescriptions<string>> = {
   validate: Validator<FDesc>;
   consumer: Consumer<ReactElement | null, FDesc>;
   sendTelemetryEvent: SendTelemetryEvent;
-  onRemove?: () => void;
+  onRemove?: (fields: Record<string, unknown>) => void;
 };
 
 type IState<FDesc extends FieldDescriptions<string>> = {
@@ -63,13 +63,32 @@ export class ElementProvider<
     this.props.onStateChange(fields);
   }
 
+  private extractValuesFromFields(
+    fields: FieldNameToField<FDesc>
+  ): Record<string, unknown> {
+    if (typeof fields === "object") {
+      const objectKeys = Object.keys(fields);
+      const res = objectKeys.reduce((obj, item) => {
+        return {
+          ...obj,
+          [item]: fields[item].value,
+        };
+      }, {});
+      return res;
+    }
+    return {};
+    // return fields;
+  }
+
   public render() {
+    const fieldValues = this.extractValuesFromFields(this.state.fields);
     return (
       <TelemetryContext.Provider value={this.props.sendTelemetryEvent}>
         <ElementWrapper
           {...this.state.commands}
           isSelected={this.state.isSelected}
           onRemove={this.props.onRemove}
+          fieldValues={fieldValues}
         >
           <this.Element
             fields={this.state.fields}

--- a/src/renderers/react/ElementProvider.tsx
+++ b/src/renderers/react/ElementProvider.tsx
@@ -26,7 +26,7 @@ type IProps<FDesc extends FieldDescriptions<string>> = {
   validate: Validator<FDesc>;
   consumer: Consumer<ReactElement | null, FDesc>;
   sendTelemetryEvent: SendTelemetryEvent;
-  onRemove?: (fields: Record<string, unknown>) => void;
+  onRemove?: () => void;
 };
 
 type IState<FDesc extends FieldDescriptions<string>> = {
@@ -63,32 +63,13 @@ export class ElementProvider<
     this.props.onStateChange(fields);
   }
 
-  private extractValuesFromFields(
-    fields: FieldNameToField<FDesc>
-  ): Record<string, unknown> {
-    if (typeof fields === "object") {
-      const objectKeys = Object.keys(fields);
-      const res = objectKeys.reduce((obj, item) => {
-        return {
-          ...obj,
-          [item]: fields[item].value,
-        };
-      }, {});
-      return res;
-    }
-    return {};
-    // return fields;
-  }
-
   public render() {
-    const fieldValues = this.extractValuesFromFields(this.state.fields);
     return (
       <TelemetryContext.Provider value={this.props.sendTelemetryEvent}>
         <ElementWrapper
           {...this.state.commands}
           isSelected={this.state.isSelected}
           onRemove={this.props.onRemove}
-          fieldValues={fieldValues}
         >
           <this.Element
             fields={this.state.fields}

--- a/src/renderers/react/ElementProvider.tsx
+++ b/src/renderers/react/ElementProvider.tsx
@@ -26,6 +26,7 @@ type IProps<FDesc extends FieldDescriptions<string>> = {
   validate: Validator<FDesc>;
   consumer: Consumer<ReactElement | null, FDesc>;
   sendTelemetryEvent: SendTelemetryEvent;
+  onRemove?: () => void;
 };
 
 type IState<FDesc extends FieldDescriptions<string>> = {
@@ -68,6 +69,7 @@ export class ElementProvider<
         <ElementWrapper
           {...this.state.commands}
           isSelected={this.state.isSelected}
+          onRemove={this.props.onRemove}
         >
           <this.Element
             fields={this.state.fields}

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -187,6 +187,7 @@ const LeftActions = styled(Actions)`
 type Props = {
   children?: ReactElement;
   isSelected: boolean;
+  onRemove?: () => void;
 } & ReturnType<CommandCreator>;
 
 export const elementWrapperTestId = "ElementWrapper";
@@ -205,6 +206,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
   remove,
   select,
   isSelected,
+  onRemove,
   children,
 }) => {
   const [closeClickedOnce, setCloseClickedOnce] = useState(false);
@@ -240,6 +242,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
                   CommandTelemetryType.PMERemoveButtonPressed
                 );
                 remove(true);
+                onRemove?.();
               } else {
                 setCloseClickedOnce(true);
                 setTimeout(() => {

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -184,11 +184,10 @@ const LeftActions = styled(Actions)`
   justify-content: space-between;
 `;
 
-type Props<T> = {
+type Props = {
   children?: ReactElement;
   isSelected: boolean;
-  onRemove?: (fieldValues: T) => void;
-  fieldValues: T;
+  onRemove?: () => void;
 } & ReturnType<CommandCreator>;
 
 export const elementWrapperTestId = "ElementWrapper";
@@ -199,7 +198,7 @@ export const moveDownTestId = "ElementWrapper__moveDown";
 export const removeTestId = "ElementWrapper__remove";
 export const selectTestId = "ElementWrapper__select";
 
-export function ElementWrapper<T>({
+export function ElementWrapper({
   moveUp,
   moveDown,
   moveTop,
@@ -208,9 +207,8 @@ export function ElementWrapper<T>({
   select,
   isSelected,
   onRemove,
-  fieldValues,
   children,
-}: Props<T>) {
+}: Props) {
   const [closeClickedOnce, setCloseClickedOnce] = useState(false);
   const sendTelemetryEvent = useContext(TelemetryContext);
 
@@ -244,7 +242,7 @@ export function ElementWrapper<T>({
                   CommandTelemetryType.PMERemoveButtonPressed
                 );
                 remove(true);
-                onRemove?.(fieldValues);
+                onRemove?.();
               } else {
                 setCloseClickedOnce(true);
                 setTimeout(() => {

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -184,10 +184,11 @@ const LeftActions = styled(Actions)`
   justify-content: space-between;
 `;
 
-type Props = {
+type Props<T> = {
   children?: ReactElement;
   isSelected: boolean;
-  onRemove?: () => void;
+  onRemove?: (fieldValues: T) => void;
+  fieldValues: T;
 } & ReturnType<CommandCreator>;
 
 export const elementWrapperTestId = "ElementWrapper";
@@ -198,7 +199,7 @@ export const moveDownTestId = "ElementWrapper__moveDown";
 export const removeTestId = "ElementWrapper__remove";
 export const selectTestId = "ElementWrapper__select";
 
-export const ElementWrapper: React.FunctionComponent<Props> = ({
+export function ElementWrapper<T>({
   moveUp,
   moveDown,
   moveTop,
@@ -207,8 +208,9 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
   select,
   isSelected,
   onRemove,
+  fieldValues,
   children,
-}) => {
+}: Props<T>) {
   const [closeClickedOnce, setCloseClickedOnce] = useState(false);
   const sendTelemetryEvent = useContext(TelemetryContext);
 
@@ -242,7 +244,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
                   CommandTelemetryType.PMERemoveButtonPressed
                 );
                 remove(true);
-                onRemove?.();
+                onRemove?.(fieldValues);
               } else {
                 setCloseClickedOnce(true);
                 setTimeout(() => {
@@ -335,4 +337,143 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
       </Body>
     </Container>
   );
-};
+}
+
+// export const ElementWrapper: React.FunctionComponent<Props> = ({
+//   moveUp,
+//   moveDown,
+//   moveTop,
+//   moveBottom,
+//   remove,
+//   select,
+//   isSelected,
+//   onRemove,
+//   children,
+// }) => {
+//   const [closeClickedOnce, setCloseClickedOnce] = useState(false);
+//   const sendTelemetryEvent = useContext(TelemetryContext);
+
+//   return (
+//     <Container
+//       className="ProsemirrorElement__wrapper"
+//       data-cy={elementWrapperTestId}
+//     >
+//       <Body>
+//         <LeftActions className="actions">
+//           <SeriousButton
+//             type="button"
+//             data-cy={selectTestId}
+//             disabled={!select(false)}
+//             onClick={() => {
+//               sendTelemetryEvent?.(CommandTelemetryType.PMESelectButtonPressed);
+//               select(true);
+//             }}
+//             aria-label="Select element"
+//           >
+//             <SvgHighlightAlt />
+//           </SeriousButton>
+//           <SeriousButton
+//             type="button"
+//             activated={closeClickedOnce}
+//             data-cy={removeTestId}
+//             disabled={!remove(false)}
+//             onClick={() => {
+//               if (closeClickedOnce) {
+//                 sendTelemetryEvent?.(
+//                   CommandTelemetryType.PMERemoveButtonPressed
+//                 );
+//                 remove(true);
+//                 onRemove?.();
+//               } else {
+//                 setCloseClickedOnce(true);
+//                 setTimeout(() => {
+//                   setCloseClickedOnce(false);
+//                 }, 5000);
+//               }
+//             }}
+//             aria-label="Delete element"
+//           >
+//             <SvgBin />
+//             {closeClickedOnce && <Tooltip>Click again to confirm</Tooltip>}
+//           </SeriousButton>
+//         </LeftActions>
+//         <Panel isSelected={isSelected}>
+//           {isSelected && <Overlay />}
+//           {children}
+//         </Panel>
+//         <RightActions className="actions">
+//           <Button
+//             type="button"
+//             data-cy={moveTopTestId}
+//             disabled={!moveTop(false)}
+//             onClick={() => {
+//               sendTelemetryEvent?.(CommandTelemetryType.PMEUpButtonPressed, {
+//                 jump: true,
+//               });
+//               moveTop(true);
+//             }}
+//             aria-label="Move element to top"
+//           >
+//             <div
+//               css={css`
+//                 transform: rotate(270deg) translate(1px, 1px);
+//               `}
+//             >
+//               <SvgChevronRightDouble />
+//             </div>
+//           </Button>
+//           <Button
+//             type="button"
+//             data-cy={moveUpTestId}
+//             expanded
+//             disabled={!moveUp(false)}
+//             onClick={() => {
+//               sendTelemetryEvent?.(CommandTelemetryType.PMEUpButtonPressed, {
+//                 jump: false,
+//               });
+//               moveUp(true);
+//             }}
+//             aria-label="Move element up"
+//           >
+//             <SvgArrowUpStraight />
+//           </Button>
+//           <Button
+//             type="button"
+//             data-cy={moveDownTestId}
+//             expanded
+//             disabled={!moveDown(false)}
+//             onClick={() => {
+//               sendTelemetryEvent?.(CommandTelemetryType.PMEDownButtonPressed, {
+//                 jump: false,
+//               });
+//               moveDown(true);
+//             }}
+//             aria-label="Move element down"
+//           >
+//             <SvgArrowDownStraight />
+//           </Button>
+//           <Button
+//             type="button"
+//             data-cy={moveBottomTestId}
+//             disabled={!moveBottom(false)}
+//             onClick={() => {
+//               sendTelemetryEvent?.(CommandTelemetryType.PMEDownButtonPressed, {
+//                 jump: true,
+//               });
+//               moveBottom(true);
+//             }}
+//             aria-label="Move element to bottom"
+//           >
+//             <div
+//               css={css`
+//                 transform: rotate(90deg) translate(-2px, 2px);
+//               `}
+//             >
+//               <SvgChevronRightDouble />
+//             </div>
+//           </Button>
+//         </RightActions>
+//       </Body>
+//     </Container>
+//   );
+// };

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -198,7 +198,7 @@ export const moveDownTestId = "ElementWrapper__moveDown";
 export const removeTestId = "ElementWrapper__remove";
 export const selectTestId = "ElementWrapper__select";
 
-export function ElementWrapper({
+export const ElementWrapper: React.FunctionComponent<Props> = ({
   moveUp,
   moveDown,
   moveTop,
@@ -208,7 +208,7 @@ export function ElementWrapper({
   isSelected,
   onRemove,
   children,
-}: Props) {
+}) => {
   const [closeClickedOnce, setCloseClickedOnce] = useState(false);
   const sendTelemetryEvent = useContext(TelemetryContext);
 
@@ -335,143 +335,4 @@ export function ElementWrapper({
       </Body>
     </Container>
   );
-}
-
-// export const ElementWrapper: React.FunctionComponent<Props> = ({
-//   moveUp,
-//   moveDown,
-//   moveTop,
-//   moveBottom,
-//   remove,
-//   select,
-//   isSelected,
-//   onRemove,
-//   children,
-// }) => {
-//   const [closeClickedOnce, setCloseClickedOnce] = useState(false);
-//   const sendTelemetryEvent = useContext(TelemetryContext);
-
-//   return (
-//     <Container
-//       className="ProsemirrorElement__wrapper"
-//       data-cy={elementWrapperTestId}
-//     >
-//       <Body>
-//         <LeftActions className="actions">
-//           <SeriousButton
-//             type="button"
-//             data-cy={selectTestId}
-//             disabled={!select(false)}
-//             onClick={() => {
-//               sendTelemetryEvent?.(CommandTelemetryType.PMESelectButtonPressed);
-//               select(true);
-//             }}
-//             aria-label="Select element"
-//           >
-//             <SvgHighlightAlt />
-//           </SeriousButton>
-//           <SeriousButton
-//             type="button"
-//             activated={closeClickedOnce}
-//             data-cy={removeTestId}
-//             disabled={!remove(false)}
-//             onClick={() => {
-//               if (closeClickedOnce) {
-//                 sendTelemetryEvent?.(
-//                   CommandTelemetryType.PMERemoveButtonPressed
-//                 );
-//                 remove(true);
-//                 onRemove?.();
-//               } else {
-//                 setCloseClickedOnce(true);
-//                 setTimeout(() => {
-//                   setCloseClickedOnce(false);
-//                 }, 5000);
-//               }
-//             }}
-//             aria-label="Delete element"
-//           >
-//             <SvgBin />
-//             {closeClickedOnce && <Tooltip>Click again to confirm</Tooltip>}
-//           </SeriousButton>
-//         </LeftActions>
-//         <Panel isSelected={isSelected}>
-//           {isSelected && <Overlay />}
-//           {children}
-//         </Panel>
-//         <RightActions className="actions">
-//           <Button
-//             type="button"
-//             data-cy={moveTopTestId}
-//             disabled={!moveTop(false)}
-//             onClick={() => {
-//               sendTelemetryEvent?.(CommandTelemetryType.PMEUpButtonPressed, {
-//                 jump: true,
-//               });
-//               moveTop(true);
-//             }}
-//             aria-label="Move element to top"
-//           >
-//             <div
-//               css={css`
-//                 transform: rotate(270deg) translate(1px, 1px);
-//               `}
-//             >
-//               <SvgChevronRightDouble />
-//             </div>
-//           </Button>
-//           <Button
-//             type="button"
-//             data-cy={moveUpTestId}
-//             expanded
-//             disabled={!moveUp(false)}
-//             onClick={() => {
-//               sendTelemetryEvent?.(CommandTelemetryType.PMEUpButtonPressed, {
-//                 jump: false,
-//               });
-//               moveUp(true);
-//             }}
-//             aria-label="Move element up"
-//           >
-//             <SvgArrowUpStraight />
-//           </Button>
-//           <Button
-//             type="button"
-//             data-cy={moveDownTestId}
-//             expanded
-//             disabled={!moveDown(false)}
-//             onClick={() => {
-//               sendTelemetryEvent?.(CommandTelemetryType.PMEDownButtonPressed, {
-//                 jump: false,
-//               });
-//               moveDown(true);
-//             }}
-//             aria-label="Move element down"
-//           >
-//             <SvgArrowDownStraight />
-//           </Button>
-//           <Button
-//             type="button"
-//             data-cy={moveBottomTestId}
-//             disabled={!moveBottom(false)}
-//             onClick={() => {
-//               sendTelemetryEvent?.(CommandTelemetryType.PMEDownButtonPressed, {
-//                 jump: true,
-//               });
-//               moveBottom(true);
-//             }}
-//             aria-label="Move element to bottom"
-//           >
-//             <div
-//               css={css`
-//                 transform: rotate(90deg) translate(-2px, 2px);
-//               `}
-//             >
-//               <SvgChevronRightDouble />
-//             </div>
-//           </Button>
-//         </RightActions>
-//       </Body>
-//     </Container>
-//   );
-// };
+};

--- a/src/renderers/react/createReactElementSpec.tsx
+++ b/src/renderers/react/createReactElementSpec.tsx
@@ -11,7 +11,7 @@ export const createReactElementSpec = <FDesc extends FieldDescriptions<string>>(
   fieldDescriptions: FDesc,
   consumer: Consumer<ReactElement | null, FDesc>,
   validate: Validator<FDesc> | undefined = undefined,
-  onRemove?: () => void
+  onRemove?: (fields: Record<string, unknown>) => void
 ) => {
   const renderer: Renderer<FDesc> = (
     validate,

--- a/src/renderers/react/createReactElementSpec.tsx
+++ b/src/renderers/react/createReactElementSpec.tsx
@@ -4,14 +4,17 @@ import { render, unmountComponentAtNode } from "react-dom";
 import { createElementSpec } from "../../plugin/elementSpec";
 import type { Renderer, Validator } from "../../plugin/elementSpec";
 import type { Consumer } from "../../plugin/types/Consumer";
-import type { FieldDescriptions } from "../../plugin/types/Element";
+import type {
+  ExtractFieldValues,
+  FieldDescriptions,
+} from "../../plugin/types/Element";
 import { ElementProvider } from "./ElementProvider";
 
 export const createReactElementSpec = <FDesc extends FieldDescriptions<string>>(
   fieldDescriptions: FDesc,
   consumer: Consumer<ReactElement | null, FDesc>,
   validate: Validator<FDesc> | undefined = undefined,
-  onRemove?: (fields: Record<string, unknown>) => void
+  onRemove?: (fields: ExtractFieldValues<FDesc>) => void
 ) => {
   const renderer: Renderer<FDesc> = (
     validate,
@@ -20,7 +23,8 @@ export const createReactElementSpec = <FDesc extends FieldDescriptions<string>>(
     updateState,
     commands,
     subscribe,
-    sendTelemetryEvent
+    sendTelemetryEvent,
+    getElementData
   ) =>
     render(
       <ElementProvider<FDesc>
@@ -31,7 +35,7 @@ export const createReactElementSpec = <FDesc extends FieldDescriptions<string>>(
         commands={commands}
         consumer={consumer}
         sendTelemetryEvent={sendTelemetryEvent}
-        onRemove={onRemove}
+        onRemove={() => onRemove?.(getElementData())}
       />,
       dom
     );

--- a/src/renderers/react/createReactElementSpec.tsx
+++ b/src/renderers/react/createReactElementSpec.tsx
@@ -10,7 +10,8 @@ import { ElementProvider } from "./ElementProvider";
 export const createReactElementSpec = <FDesc extends FieldDescriptions<string>>(
   fieldDescriptions: FDesc,
   consumer: Consumer<ReactElement | null, FDesc>,
-  validate: Validator<FDesc> | undefined = undefined
+  validate: Validator<FDesc> | undefined = undefined,
+  onRemove?: () => void
 ) => {
   const renderer: Renderer<FDesc> = (
     validate,
@@ -30,6 +31,7 @@ export const createReactElementSpec = <FDesc extends FieldDescriptions<string>>(
         commands={commands}
         consumer={consumer}
         sendTelemetryEvent={sendTelemetryEvent}
+        onRemove={onRemove}
       />,
       dom
     );


### PR DESCRIPTION
_NB: depends on #278 – please review that first!_

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR adds a `onRemove` prop for `createCalloutElement`. `onRemove` is a handler for when the element is deleted. The parameter passed to the handler is of type `FieldNameToValueMap` which includes all the element field values. 

To be able to pass field values to onRemove, the `elementSpec.ts` was updated in order to have access to element data at render stage. 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

This was tested both with prosemirror demo and also with composer locally. 
