### PR TITLE
feat: Improve label accessibility

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -185,6 +185,7 @@ const {
       fetchCampaignList: () => Promise.resolve(sampleCampaignList),
       targetingUrl: "https://targeting.code.dev-gutools.co.uk/",
       applyTag: (tag: string) => console.log(`Apply ${tag} tag`),
+      onRemove: (fields) => console.log("Remove callout", fields),
     }),
     interactive: createInteractiveElement({
       checkThirdPartyTracking: mockThirdPartyTracking,

--- a/src/editorial-source-components/FieldWrapper.tsx
+++ b/src/editorial-source-components/FieldWrapper.tsx
@@ -25,6 +25,7 @@ export const FieldWrapper = <F extends Field<TFieldView<unknown>>>({
   <div className={className}>
     <InputHeading
       name={field.name}
+      labelId={field.view.getId()}
       headingLabel={headingLabel}
       headingContent={headingContent}
       description={description}

--- a/src/editorial-source-components/FieldWrapper.tsx
+++ b/src/editorial-source-components/FieldWrapper.tsx
@@ -25,7 +25,7 @@ export const FieldWrapper = <F extends Field<TFieldView<unknown>>>({
   <div className={className}>
     <InputHeading
       name={field.name}
-      labelId={field.view.getId()}
+      fieldId={field.view.getId()}
       headingLabel={headingLabel}
       headingContent={headingContent}
       description={description}

--- a/src/editorial-source-components/InputHeading.tsx
+++ b/src/editorial-source-components/InputHeading.tsx
@@ -14,7 +14,7 @@ const InputHeadingContainer = styled.div`
 // Because the `for` label element cannot be used with contenteditable,
 // we must use `aria-labelledby` for the correct accessibility – but we
 // lose the label onclick behaviour that we'd usually get with `for`. This
-// link backfills that behaviour.
+// link backfills that behaviour. See https://stackoverflow.com/a/54792667.
 const LabelLink = styled.a`
   color: inherit;
   text-decoration: none;

--- a/src/editorial-source-components/InputHeading.tsx
+++ b/src/editorial-source-components/InputHeading.tsx
@@ -18,6 +18,7 @@ export const getFieldHeadingTestId = (name: string) => `FieldHeading-${name}`;
 
 export type InputHeadingProps = {
   headingLabel: React.ReactNode;
+  labelId?: string;
   headingContent?: React.ReactNode;
   description?: React.ReactNode;
   errors?: string[];
@@ -30,10 +31,11 @@ export const InputHeading = ({
   description,
   errors,
   name,
+  labelId,
 }: InputHeadingProps) => (
   <InputHeadingContainer data-cy={getFieldHeadingTestId(name ?? "")}>
     <Heading>
-      <Label>{headingLabel}</Label>
+      <Label id={labelId}>{headingLabel}</Label>
       {headingContent}
     </Heading>
     {errors && errors.length > 0 ? (

--- a/src/editorial-source-components/InputHeading.tsx
+++ b/src/editorial-source-components/InputHeading.tsx
@@ -11,6 +11,16 @@ const InputHeadingContainer = styled.div`
   margin-bottom: ${space[2]}px;
 `;
 
+// Because the `for` label element cannot be used with contenteditable,
+// we must use `aria-labelledby` for the correct accessibility – but we
+// lose the label onclick behaviour that we'd usually get with `for`. This
+// link backfills that behaviour.
+const LabelLink = styled.a`
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+`;
+
 const Errors = ({ errors }: { errors: string[] }) =>
   !errors.length ? null : <Error>{errors.join(", ")}</Error>;
 
@@ -18,7 +28,7 @@ export const getFieldHeadingTestId = (name: string) => `FieldHeading-${name}`;
 
 export type InputHeadingProps = {
   headingLabel: React.ReactNode;
-  labelId?: string;
+  fieldId?: string;
   headingContent?: React.ReactNode;
   description?: React.ReactNode;
   errors?: string[];
@@ -31,11 +41,13 @@ export const InputHeading = ({
   description,
   errors,
   name,
-  labelId,
+  fieldId,
 }: InputHeadingProps) => (
   <InputHeadingContainer data-cy={getFieldHeadingTestId(name ?? "")}>
     <Heading>
-      <Label id={labelId}>{headingLabel}</Label>
+      <LabelLink href={fieldId ? `#${fieldId}` : ""}>
+        <Label id={fieldId ? `label-${fieldId}` : ""}>{headingLabel}</Label>
+      </LabelLink>
       {headingContent}
     </Heading>
     {errors && errors.length > 0 ? (

--- a/src/editorial-source-components/Label.tsx
+++ b/src/editorial-source-components/Label.tsx
@@ -7,6 +7,7 @@ export const labelStyles = css`
   font-family: "Guardian Agate Sans";
   display: block;
   user-select: none;
+  cursor: pointer;
 `;
 
 export const Label = styled.label`

--- a/src/elements/callout/Callout.tsx
+++ b/src/elements/callout/Callout.tsx
@@ -3,6 +3,7 @@ import {
   createCustomDropdownField,
   createCustomField,
 } from "../../plugin/fieldViews/CustomFieldView";
+import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
 import { dropDownRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
@@ -36,12 +37,6 @@ export type Campaign = {
   activeUntil?: number;
 };
 
-type Props = {
-  fetchCampaignList: () => Promise<Campaign[]>;
-  targetingUrl: string;
-  applyTag: (tagId: string) => void;
-};
-
 const getDropdownOptionsFromCampaignList = (campaignList: Campaign[]) => {
   const campaigns = campaignList.map((campaign) => {
     const name = campaign.name.replace("CALLOUT:", "").trimStart();
@@ -63,58 +58,76 @@ export const calloutFields = {
   isNonCollapsible: createCustomField(false, true),
 };
 
+type Props = {
+  fetchCampaignList: () => Promise<Campaign[]>;
+  targetingUrl: string;
+  applyTag: (tagId: string) => void;
+  onRemove: (fields: FieldNameToValueMap<typeof calloutFields>) => void;
+};
+
 export const createCalloutElement = ({
   fetchCampaignList,
   targetingUrl,
   applyTag,
+  onRemove,
 }: Props) =>
-  createReactElementSpec(calloutFields, ({ fields }) => {
-    const campaignId = fields.campaignId.value;
-    const [campaignList, setCampaignList] = useState<Campaign[]>([]);
-    useEffect(() => {
-      void fetchCampaignList().then((campaignList) => {
-        setCampaignList(campaignList);
-      });
-    }, []);
+  createReactElementSpec(
+    calloutFields,
+    ({ fields }) => {
+      const campaignId = fields.campaignId.value;
+      const [campaignList, setCampaignList] = useState<Campaign[]>([]);
+      useEffect(() => {
+        void fetchCampaignList().then((campaignList) => {
+          setCampaignList(campaignList);
+        });
+      }, []);
 
-    useEffect(() => {
-      if (campaignId === undefinedDropdownValue || campaignList.length === 0) {
-        return;
-      }
-      applyTag(getTag(campaignId));
-    }, [campaignId]);
+      useEffect(() => {
+        if (
+          campaignId === undefinedDropdownValue ||
+          campaignList.length === 0
+        ) {
+          return;
+        }
+        applyTag(getTag(campaignId));
+      }, [campaignId]);
 
-    const getTag = (id: string) => {
-      const campaign = campaignList.find((campaign) => campaign.id === id);
-      return campaign?.fields.tagName ?? "";
-    };
+      const getTag = (id: string) => {
+        const campaign = campaignList.find((campaign) => campaign.id === id);
+        return campaign?.fields.tagName ?? "";
+      };
 
-    const dropdownOptions = getDropdownOptionsFromCampaignList(campaignList);
-    const callout = campaignList.find((campaign) => campaign.id === campaignId);
+      const dropdownOptions = getDropdownOptionsFromCampaignList(campaignList);
+      const callout = campaignList.find(
+        (campaign) => campaign.id === campaignId
+      );
 
-    const trimmedTargetingUrl = targetingUrl.replace(/\/$/, "");
-    return campaignId && campaignId != "none-selected" ? (
-      <div css={calloutStyles}>
-        {callout ? (
-          <CalloutTable
-            calloutData={callout}
-            targetingUrl={trimmedTargetingUrl}
-            isNonCollapsible={fields.isNonCollapsible}
+      const trimmedTargetingUrl = targetingUrl.replace(/\/$/, "");
+      return campaignId && campaignId != "none-selected" ? (
+        <div css={calloutStyles}>
+          {callout ? (
+            <CalloutTable
+              calloutData={callout}
+              targetingUrl={trimmedTargetingUrl}
+              isNonCollapsible={fields.isNonCollapsible}
+            />
+          ) : (
+            <CalloutError
+              tag={getTag(campaignId)}
+              targetingUrl={trimmedTargetingUrl}
+            />
+          )}
+        </div>
+      ) : (
+        <div>
+          <CustomDropdownView
+            label="Callout"
+            field={fields.campaignId}
+            options={dropdownOptions}
           />
-        ) : (
-          <CalloutError
-            tag={getTag(campaignId)}
-            targetingUrl={trimmedTargetingUrl}
-          />
-        )}
-      </div>
-    ) : (
-      <div>
-        <CustomDropdownView
-          label="Callout"
-          field={fields.campaignId}
-          options={dropdownOptions}
-        />
-      </div>
-    );
-  });
+        </div>
+      );
+    },
+    undefined,
+    (fields) => onRemove(fields)
+  );

--- a/src/plugin/fieldViews/AttributeFieldView.ts
+++ b/src/plugin/fieldViews/AttributeFieldView.ts
@@ -1,13 +1,13 @@
 import type { Node, NodeType } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
-import type { FieldView } from "./FieldView";
-import { FieldType } from "./FieldView";
+import { FieldType, FieldView } from "./FieldView";
 
 /**
  * A FieldView representing a node that contains fields that are updated atomically.
  */
-export abstract class AttributeFieldView<Value extends unknown>
-  implements FieldView<Value> {
+export abstract class AttributeFieldView<
+  Value extends unknown
+> extends FieldView<Value> {
   public static fieldName: string;
   public static fieldType = FieldType.ATTRIBUTES;
   // The parent DOM element for this view. Public
@@ -25,6 +25,7 @@ export abstract class AttributeFieldView<Value extends unknown>
     // The offset of this node relative to its parent FieldView.
     public offset: number
   ) {
+    super();
     this.nodeType = node.type;
   }
 

--- a/src/plugin/fieldViews/CustomFieldView.ts
+++ b/src/plugin/fieldViews/CustomFieldView.ts
@@ -2,8 +2,8 @@ import type { Node } from "prosemirror-model";
 import type { EditorView } from "prosemirror-view";
 import type { FieldValidator } from "../elementSpec";
 import type { Options } from "./DropdownFieldView";
-import type { BaseFieldDescription, FieldView } from "./FieldView";
-import { FieldType } from "./FieldView";
+import type { BaseFieldDescription } from "./FieldView";
+import { FieldType, FieldView } from "./FieldView";
 
 export interface CustomFieldDescription<Data = unknown, Props = unknown>
   extends BaseFieldDescription<Data> {
@@ -45,10 +45,11 @@ type Subscriber<Fields extends unknown> = (fields: Fields) => void;
  * state changes. In this way, consuming code can manage state and UI changes itself,
  * perhaps in its own renderer format.
  */
-export class CustomFieldView<Value = unknown> implements FieldView<Value> {
+export class CustomFieldView<Value = unknown> extends FieldView<Value> {
   public static fieldName = "custom" as const;
   public static fieldType = FieldType.ATTRIBUTES;
   public static defaultValue = undefined;
+  public fieldViewElement?: undefined;
 
   private subscribers: Array<Subscriber<Value>> = [];
 
@@ -61,7 +62,9 @@ export class CustomFieldView<Value = unknown> implements FieldView<Value> {
     protected getPos: () => number,
     // The offset of this node relative to its parent FieldView.
     public offset: number
-  ) {}
+  ) {
+    super();
+  }
 
   /**
    * @returns A function that can be called to update the node fields.

--- a/src/plugin/fieldViews/FieldView.ts
+++ b/src/plugin/fieldViews/FieldView.ts
@@ -34,7 +34,7 @@ export abstract class FieldView<NodeValue> {
 
   private id = uniqueId();
 
-  public getId = () => this.id;
+  public getId = () => `field-${this.id}`;
 
   /**
    * Called when the fieldView is updated from the parent editor.

--- a/src/plugin/fieldViews/FieldView.ts
+++ b/src/plugin/fieldViews/FieldView.ts
@@ -1,3 +1,4 @@
+import { uniqueId } from "lodash";
 import type { Node } from "prosemirror-model";
 import type { Decoration, DecorationSet } from "prosemirror-view";
 import type { FieldValidator } from "../elementSpec";
@@ -30,6 +31,10 @@ export abstract class FieldView<NodeValue> {
   // The HTML element this fieldView renders content into.
   public abstract fieldViewElement?: HTMLElement;
   public abstract offset: number;
+
+  private id = uniqueId();
+
+  public getId = () => this.id;
 
   /**
    * Called when the fieldView is updated from the parent editor.

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -1,5 +1,6 @@
+import uniqueId from "lodash/uniqueId";
 import type { AttributeSpec, Node } from "prosemirror-model";
-import { DOMParser, DOMSerializer } from "prosemirror-model";
+import { DOMParser } from "prosemirror-model";
 import type { Plugin, Transaction } from "prosemirror-state";
 import { EditorState } from "prosemirror-state";
 import { Mapping, StepMap } from "prosemirror-transform";
@@ -10,8 +11,8 @@ import {
   createPlaceholderPlugin,
   PME_UPDATE_PLACEHOLDER,
 } from "../helpers/placeholder";
-import type { BaseFieldDescription, FieldView } from "./FieldView";
-import { FieldType } from "./FieldView";
+import type { BaseFieldDescription } from "./FieldView";
+import { FieldType, FieldView } from "./FieldView";
 
 export interface AbstractTextFieldDescription
   extends BaseFieldDescription<string> {
@@ -28,7 +29,7 @@ export interface AbstractTextFieldDescription
 /**
  * A FieldView that represents a nested prosemirror instance.
  */
-export abstract class ProseMirrorFieldView implements FieldView<string> {
+export abstract class ProseMirrorFieldView extends FieldView<string> {
   public static fieldType = FieldType.CONTENT;
   public static defaultValue = "";
 
@@ -48,8 +49,6 @@ export abstract class ProseMirrorFieldView implements FieldView<string> {
     | undefined;
   // Do we have a change in our decorations that is yet to be rendered?
   private decorationsPending = false;
-  // The serialiser for the Node.
-  private serialiser: DOMSerializer;
   // The parser for the Node.
   private parser: DOMParser;
 
@@ -73,9 +72,10 @@ export abstract class ProseMirrorFieldView implements FieldView<string> {
     // Is this text field resizeable?
     isResizeable = false
   ) {
+    super();
+
     this.applyDecorationsFromOuterEditor(decorations, node, offset);
     this.setupFocusHandler();
-    this.serialiser = DOMSerializer.fromSchema(node.type.schema);
     this.parser = DOMParser.fromSchema(node.type.schema);
 
     const localPlugins = placeholder
@@ -251,7 +251,7 @@ export abstract class ProseMirrorFieldView implements FieldView<string> {
   }
 
   private createInnerEditorView(plugins?: Plugin[]) {
-    return new EditorView(this.fieldViewElement, {
+    const view = new EditorView(this.fieldViewElement, {
       state: EditorState.create({
         doc: this.node,
         plugins,
@@ -261,6 +261,10 @@ export abstract class ProseMirrorFieldView implements FieldView<string> {
       dispatchTransaction: this.dispatchTransaction.bind(this),
       decorations: () => this.decorations,
     });
+
+    view.dom.setAttribute("aria-labelledby", this.getId());
+
+    return view;
   }
 
   private applyDecorationsFromOuterEditor(

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -1,4 +1,3 @@
-import uniqueId from "lodash/uniqueId";
 import type { AttributeSpec, Node } from "prosemirror-model";
 import { DOMParser } from "prosemirror-model";
 import type { Plugin, Transaction } from "prosemirror-state";

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -262,7 +262,8 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
       decorations: () => this.decorations,
     });
 
-    view.dom.setAttribute("aria-labelledby", this.getId());
+    view.dom.id = this.getId();
+    view.dom.setAttribute("aria-labelledby", `label-${this.getId()}`);
 
     return view;
   }

--- a/src/plugin/fieldViews/__tests__/AttributeFieldView.spec.ts
+++ b/src/plugin/fieldViews/__tests__/AttributeFieldView.spec.ts
@@ -3,7 +3,7 @@ import { Schema } from "prosemirror-model";
 import { schema } from "prosemirror-schema-basic";
 import { createEditorWithElements } from "../../helpers/test";
 import { getNodeNameFromField, getNodeSpecForField } from "../../nodeSpec";
-import { AttributeFieldView } from "../AttributeFieldView";
+import AttributeFieldView from "../AttributeFieldView";
 
 const createInnerViewSpy = jest.fn();
 const updateInnerViewSpy = jest.fn();

--- a/src/plugin/fieldViews/__tests__/AttributeFieldView.spec.ts
+++ b/src/plugin/fieldViews/__tests__/AttributeFieldView.spec.ts
@@ -3,7 +3,7 @@ import { Schema } from "prosemirror-model";
 import { schema } from "prosemirror-schema-basic";
 import { createEditorWithElements } from "../../helpers/test";
 import { getNodeNameFromField, getNodeSpecForField } from "../../nodeSpec";
-import AttributeFieldView from "../AttributeFieldView";
+import { AttributeFieldView } from "../AttributeFieldView";
 
 const createInnerViewSpy = jest.fn();
 const updateInnerViewSpy = jest.fn();

--- a/src/plugin/helpers/element.ts
+++ b/src/plugin/helpers/element.ts
@@ -15,6 +15,7 @@ import {
 import type {
   ElementSpecMap,
   ExtractDataTypeFromElementSpec,
+  ExtractFieldValues,
   FieldDescription,
   FieldDescriptions,
   FieldNameToField,
@@ -100,10 +101,10 @@ export const createGetElementDataFromNode = <
     serializer
   );
 
-  return {
+  return ({
     elementName,
     values,
-  } as ExtractDataTypeFromElementSpec<ESpecMap, ElementNames>;
+  } as unknown) as ExtractDataTypeFromElementSpec<ESpecMap, ElementNames>;
 };
 
 export const getFieldValuesFromNode = <
@@ -137,7 +138,7 @@ export const getFieldValuesFromNode = <
     values[fieldName] = value;
   });
 
-  return values;
+  return values as ExtractFieldValues<FDesc>;
 };
 
 export const getFieldValueFromNode = (

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -10,6 +10,7 @@ import type {
   FieldDescriptions,
 } from "../plugin/types/Element";
 import { getFieldsFromNode, updateFieldsFromNode } from "./field";
+import { getFieldValuesFromNode } from "./helpers/element";
 import { updateFieldViewsFromNode } from "./helpers/fieldView";
 import type { Commands } from "./helpers/prosemirror";
 import { createUpdateDecorations } from "./helpers/prosemirror";
@@ -151,6 +152,7 @@ const createNodeView = <
 
   const serializer = DOMSerializer.fromSchema(initElementNode.type.schema);
   const initCommands = commands(getPos, view);
+
   const fields = getFieldsFromNode({
     node: initElementNode,
     fieldDescriptions: element.fieldDescriptions,
@@ -179,6 +181,9 @@ const createNodeView = <
   let currentIsSelected = false;
   let currentCommandValues = getCommandValues(initCommands);
 
+  const getElementDataFromNode = () =>
+    getFieldValuesFromNode(currentNode, element.fieldDescriptions, serializer);
+
   const update = element.createUpdator(
     dom,
     fields,
@@ -191,7 +196,8 @@ const createNodeView = <
       );
     },
     initCommands,
-    sendTelemetryEvent
+    sendTelemetryEvent,
+    getElementDataFromNode
   );
 
   return {

--- a/src/plugin/types/Element.ts
+++ b/src/plugin/types/Element.ts
@@ -106,7 +106,8 @@ export type ElementSpec<FDesc extends FieldDescriptions<string>> = {
     fields: FieldNameToField<FDesc>,
     updateState: (fields: FieldNameToValueMap<FDesc>) => void,
     commands: ReturnType<CommandCreator>,
-    sendTelemetryEvent: SendTelemetryEvent | undefined
+    sendTelemetryEvent: SendTelemetryEvent | undefined,
+    getElementData: () => ExtractFieldValues<FDesc>
   ) => (
     fields: FieldNameToField<FDesc>,
     commands: ReturnType<CommandCreator>,

--- a/src/renderers/react/ElementProvider.tsx
+++ b/src/renderers/react/ElementProvider.tsx
@@ -26,6 +26,7 @@ type IProps<FDesc extends FieldDescriptions<string>> = {
   validate: Validator<FDesc>;
   consumer: Consumer<ReactElement | null, FDesc>;
   sendTelemetryEvent: SendTelemetryEvent;
+  onRemove?: () => void;
 };
 
 type IState<FDesc extends FieldDescriptions<string>> = {
@@ -68,6 +69,7 @@ export class ElementProvider<
         <ElementWrapper
           {...this.state.commands}
           isSelected={this.state.isSelected}
+          onRemove={this.props.onRemove}
         >
           <this.Element
             fields={this.state.fields}

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -187,6 +187,7 @@ const LeftActions = styled(Actions)`
 type Props = {
   children?: ReactElement;
   isSelected: boolean;
+  onRemove?: () => void;
 } & ReturnType<CommandCreator>;
 
 export const elementWrapperTestId = "ElementWrapper";
@@ -205,6 +206,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
   remove,
   select,
   isSelected,
+  onRemove,
   children,
 }) => {
   const [closeClickedOnce, setCloseClickedOnce] = useState(false);
@@ -240,6 +242,7 @@ export const ElementWrapper: React.FunctionComponent<Props> = ({
                   CommandTelemetryType.PMERemoveButtonPressed
                 );
                 remove(true);
+                onRemove?.();
               } else {
                 setCloseClickedOnce(true);
                 setTimeout(() => {

--- a/src/renderers/react/__tests__/createReactElementSpec.spec.tsx
+++ b/src/renderers/react/__tests__/createReactElementSpec.spec.tsx
@@ -1,0 +1,40 @@
+import { getByLabelText, getByText, waitFor } from "@testing-library/dom";
+import { FieldWrapper } from "../../../editorial-source-components/FieldWrapper";
+import { createTextField } from "../../../plugin/fieldViews/TextFieldView";
+import { createEditorWithElements } from "../../../plugin/helpers/test";
+import { createReactElementSpec } from "../createReactElementSpec";
+
+describe("createReactElementSpec", () => {
+  const testElement = createReactElementSpec(
+    {
+      field1: createTextField(),
+    },
+    ({ fields }) => (
+      <div>
+        <FieldWrapper
+          headingLabel="field1"
+          field={fields.field1}
+        ></FieldWrapper>
+      </div>
+    ),
+    undefined
+  );
+
+  it("should render an element and mount its fields", async () => {
+    const { view, insertElement } = createEditorWithElements({ testElement });
+    insertElement({
+      elementName: "testElement",
+      values: { field1: "Example text" },
+    })(view.state, view.dispatch);
+
+    const dom = view.dom as HTMLElement;
+
+    await waitFor(() => {
+      expect(getByLabelText(dom, "field1")).toBeTruthy();
+    });
+
+    await waitFor(() => {
+      expect(getByText(dom, "Example text")).toBeTruthy();
+    });
+  });
+});

--- a/src/renderers/react/createReactElementSpec.tsx
+++ b/src/renderers/react/createReactElementSpec.tsx
@@ -4,13 +4,17 @@ import { render, unmountComponentAtNode } from "react-dom";
 import { createElementSpec } from "../../plugin/elementSpec";
 import type { Renderer, Validator } from "../../plugin/elementSpec";
 import type { Consumer } from "../../plugin/types/Consumer";
-import type { FieldDescriptions } from "../../plugin/types/Element";
+import type {
+  ExtractFieldValues,
+  FieldDescriptions,
+} from "../../plugin/types/Element";
 import { ElementProvider } from "./ElementProvider";
 
 export const createReactElementSpec = <FDesc extends FieldDescriptions<string>>(
   fieldDescriptions: FDesc,
   consumer: Consumer<ReactElement | null, FDesc>,
-  validate: Validator<FDesc> | undefined = undefined
+  validate: Validator<FDesc> | undefined = undefined,
+  onRemove?: (fields: ExtractFieldValues<FDesc>) => void
 ) => {
   const renderer: Renderer<FDesc> = (
     validate,
@@ -19,7 +23,8 @@ export const createReactElementSpec = <FDesc extends FieldDescriptions<string>>(
     updateState,
     commands,
     subscribe,
-    sendTelemetryEvent
+    sendTelemetryEvent,
+    getElementData
   ) =>
     render(
       <ElementProvider<FDesc>
@@ -30,6 +35,7 @@ export const createReactElementSpec = <FDesc extends FieldDescriptions<string>>(
         commands={commands}
         consumer={consumer}
         sendTelemetryEvent={sendTelemetryEvent}
+        onRemove={() => onRemove?.(getElementData())}
       />,
       dom
     );


### PR DESCRIPTION
## What does this change?

#275 requires some React-based unit tests, but in order for `testing-library` to pass tests using our React wrappers, our accessibility story for labels needed to be improved, or we get the error:

```
Found a label with the text of: field1, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
```

(How lovely for a testing library to point that out!)

This PR adds a test that verifies the accessibility of our labels by proxy, and adds the functionality that satisfies the test. Because we cannot add a `for` attribute to our label (`contenteditable` elements cannot be addressed by this attribute [per the spec](https://stackoverflow.com/questions/54792126/html-label-with-for-div-id-to-focus-a-contenteditable-div-does-label-label)), we add an a tag with a link to simulate the usual label behaviour – clicking on the label should give a pointer on hover, and focus the field input on click.

## How to test

- The automated test should pass.
- Have a play with the labels that relate to text fields of any sort, on any element. Hovering should show a pointer cursor. Clicking should focus the field.
