### PR TITLE
chore: Remove circular dependency caused by undefinedDropdownValue

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,7 +9,8 @@ module.exports = {
       rules: {
         "@typescript-eslint/unbound-method": 0,
         "@typescript-eslint/explicit-module-boundary-types": 0,
-        "@typescript-eslint/no-unused-vars": 2
+        "@typescript-eslint/no-unused-vars": 2,
+        "import/no-cycle": 2
       },
     },
   ],

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,8 +9,7 @@ module.exports = {
       rules: {
         "@typescript-eslint/unbound-method": 0,
         "@typescript-eslint/explicit-module-boundary-types": 0,
-        "@typescript-eslint/no-unused-vars": 2,
-        "import/no-cycle": 2
+        "@typescript-eslint/no-unused-vars": 2
       },
     },
   ],

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -26,11 +26,9 @@ import {
   pullquoteElement,
   richlinkElement,
   tableElement,
-} from "../src";
-import {
-  transformElementOut,
   undefinedDropdownValue,
-} from "../src/elements/helpers/transform";
+} from "../src";
+import { transformElementOut } from "../src/elements/helpers/transform";
 import type { MediaPayload } from "../src/elements/image/ImageElement";
 import { buildElementPlugin } from "../src/plugin/element";
 import {

--- a/src/elements/callout/Callout.tsx
+++ b/src/elements/callout/Callout.tsx
@@ -3,11 +3,11 @@ import {
   createCustomDropdownField,
   createCustomField,
 } from "../../plugin/fieldViews/CustomFieldView";
+import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 import { dropDownRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import { CalloutError, calloutStyles } from "../embed/Callout";
-import { undefinedDropdownValue } from "../helpers/transform";
 import { CalloutTable } from "./CalloutTable";
 
 export type Fields = {

--- a/src/elements/callout/calloutDataTransformer.ts
+++ b/src/elements/callout/calloutDataTransformer.ts
@@ -1,5 +1,5 @@
+import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
-import { undefinedDropdownValue } from "../helpers/transform";
 import type { TransformIn, TransformOut } from "../helpers/types/Transform";
 import type { calloutFields } from "./Callout";
 

--- a/src/elements/comment/CommentSpec.tsx
+++ b/src/elements/comment/CommentSpec.tsx
@@ -3,7 +3,7 @@ import {
   createCustomField,
 } from "../../plugin/fieldViews/CustomFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
-import { undefinedDropdownValue } from "../helpers/transform";
+import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 
 export const commentFields = {
   source: createTextField(),

--- a/src/elements/content-atom/ContentAtomForm.tsx
+++ b/src/elements/content-atom/ContentAtomForm.tsx
@@ -3,11 +3,11 @@ import { useEffect, useState } from "react";
 import { Error } from "../../editorial-source-components/Error";
 import { Label, NonBoldLabel } from "../../editorial-source-components/Label";
 import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
+import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import { Preview } from "../helpers/Preview";
-import { undefinedDropdownValue } from "../helpers/transform";
 import type { ContentAtomData, FetchContentAtomData } from "./ContentAtomSpec";
 import { contentAtomFields } from "./ContentAtomSpec";
 

--- a/src/elements/content-atom/ContentAtomSpec.tsx
+++ b/src/elements/content-atom/ContentAtomSpec.tsx
@@ -3,7 +3,7 @@ import {
   createCustomField,
 } from "../../plugin/fieldViews/CustomFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
-import { undefinedDropdownValue } from "../helpers/transform";
+import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 
 export type ContentAtomData = {
   defaultHtml: string;

--- a/src/elements/embed/EmbedSpec.tsx
+++ b/src/elements/embed/EmbedSpec.tsx
@@ -4,13 +4,13 @@ import {
 } from "../../plugin/fieldViews/CustomFieldView";
 import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
+import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 import {
   htmlMaxLength,
   maxLength,
   required,
 } from "../../plugin/helpers/validation";
 import { parseHtml } from "../helpers/html";
-import { undefinedDropdownValue } from "../helpers/transform";
 import type { MainEmbedOptions } from "./EmbedForm";
 
 export const getCalloutTag = (html: string) => {

--- a/src/elements/embed/embedComponents/__tests__/embedDataTransformer.spec.ts
+++ b/src/elements/embed/embedComponents/__tests__/embedDataTransformer.spec.ts
@@ -1,5 +1,5 @@
+import { undefinedDropdownValue } from "../../../../plugin/helpers/constants";
 import type { FieldNameToValueMap } from "../../../../plugin/helpers/fieldView";
-import { undefinedDropdownValue } from "../../../helpers/transform";
 import type { ExternalEmbedFields } from "../../embedDataTransformer";
 import { transformElement } from "../../embedDataTransformer";
 import type { createEmbedFields } from "../../EmbedSpec";

--- a/src/elements/embed/embedDataTransformer.ts
+++ b/src/elements/embed/embedDataTransformer.ts
@@ -1,7 +1,7 @@
 import pickBy from "lodash/pickBy";
+import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
 import { htmlContainsSingleIframe } from "../helpers/html";
-import { undefinedDropdownValue } from "../helpers/transform";
 import type { TransformIn, TransformOut } from "../helpers/types/Transform";
 import type { createEmbedFields } from "./EmbedSpec";
 

--- a/src/elements/helpers/defaultTransform.ts
+++ b/src/elements/helpers/defaultTransform.ts
@@ -1,6 +1,6 @@
+import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
 import type { FieldDescriptions } from "../../plugin/types/Element";
-import { undefinedDropdownValue } from "./transform";
 import type { TransformIn, TransformOut } from "./types/Transform";
 
 export type Asset = {

--- a/src/elements/helpers/transform.ts
+++ b/src/elements/helpers/transform.ts
@@ -14,9 +14,6 @@ import type { tableFields } from "../table/TableSpec";
 import type { createTweetFields } from "../tweet/TweetSpec";
 import { transformElement as defaultElementTransform } from "./defaultTransform";
 
-// A placeholder value for a dropdown option that represents no selection.
-export const undefinedDropdownValue = "none-selected";
-
 const transformMap = {
   code: defaultElementTransform<typeof codeFields>(),
   "content-atom": defaultElementTransform<typeof contentAtomFields>({

--- a/src/elements/image/ImageElement.tsx
+++ b/src/elements/image/ImageElement.tsx
@@ -7,9 +7,9 @@ import {
 import type { Options } from "../../plugin/fieldViews/DropdownFieldView";
 import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
+import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
 import type { Asset } from "../helpers/defaultTransform";
-import { undefinedDropdownValue } from "../helpers/transform";
 import { useTyperighterAttrs } from "../helpers/typerighter";
 import { largestAssetMinDimension } from "./imageElementValidation";
 

--- a/src/elements/image/__tests__/imageElementDataTransformer.spec.ts
+++ b/src/elements/image/__tests__/imageElementDataTransformer.spec.ts
@@ -1,5 +1,5 @@
+import { undefinedDropdownValue } from "../../../plugin/helpers/constants";
 import type { FieldNameToValueMap } from "../../../plugin/helpers/fieldView";
-import { undefinedDropdownValue } from "../../helpers/transform";
 import type { createImageFields } from "../ImageElement";
 import type { ImageFields } from "../imageElementDataTransformer";
 import { transformElement } from "../imageElementDataTransformer";

--- a/src/elements/image/imageElementDataTransformer.ts
+++ b/src/elements/image/imageElementDataTransformer.ts
@@ -1,7 +1,7 @@
 import pickBy from "lodash/pickBy";
+import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
 import type { Asset } from "../helpers/defaultTransform";
-import { undefinedDropdownValue } from "../helpers/transform";
 import type { TransformIn, TransformOut } from "../helpers/types/Transform";
 import type { createImageFields, MainImageData } from "./ImageElement";
 

--- a/src/elements/interactive/InteractiveSpec.tsx
+++ b/src/elements/interactive/InteractiveSpec.tsx
@@ -6,9 +6,9 @@ import {
 } from "../../plugin/fieldViews/CustomFieldView";
 import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
+import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
 import type { TrackingStatus } from "../helpers/ThirdPartyStatusChecks";
-import { undefinedDropdownValue } from "../helpers/transform";
 
 export type MainInteractiveProps = {
   checkThirdPartyTracking: (html: string) => Promise<TrackingStatus>;

--- a/src/elements/interactive/__tests__/interactiveDataTransformer.spec.ts
+++ b/src/elements/interactive/__tests__/interactiveDataTransformer.spec.ts
@@ -1,5 +1,5 @@
+import { undefinedDropdownValue } from "../../../plugin/helpers/constants";
 import type { FieldNameToValueMap } from "../../../plugin/helpers/fieldView";
-import { undefinedDropdownValue } from "../../helpers/transform";
 import type { ExternalInteractiveFields } from "../interactiveDataTransformer";
 import { transformElement } from "../interactiveDataTransformer";
 import type { createInteractiveFields } from "../InteractiveSpec";

--- a/src/elements/interactive/interactiveDataTransformer.ts
+++ b/src/elements/interactive/interactiveDataTransformer.ts
@@ -1,6 +1,6 @@
 import { pickBy } from "lodash";
+import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
-import { undefinedDropdownValue } from "../helpers/transform";
 import type { TransformIn, TransformOut } from "../helpers/types/Transform";
 import type { createInteractiveFields } from "./InteractiveSpec";
 

--- a/src/elements/membership/MembershipSpec.tsx
+++ b/src/elements/membership/MembershipSpec.tsx
@@ -1,6 +1,6 @@
 import { createCustomDropdownField } from "../../plugin/fieldViews/CustomFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
-import { undefinedDropdownValue } from "../helpers/transform";
+import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 
 export const membershipFields = {
   role: createCustomDropdownField("inline", [

--- a/src/elements/membership/membershipDataTransformer.ts
+++ b/src/elements/membership/membershipDataTransformer.ts
@@ -1,5 +1,5 @@
+import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
-import { undefinedDropdownValue } from "../helpers/transform";
 import type { TransformIn, TransformOut } from "../helpers/types/Transform";
 import type { membershipFields } from "./MembershipSpec";
 

--- a/src/elements/standard/StandardSpec.tsx
+++ b/src/elements/standard/StandardSpec.tsx
@@ -6,10 +6,10 @@ import {
 } from "../../plugin/fieldViews/CustomFieldView";
 import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
+import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 import { htmlMaxLength } from "../../plugin/helpers/validation";
 import type { Asset } from "../helpers/defaultTransform";
 import type { TrackingStatus } from "../helpers/ThirdPartyStatusChecks";
-import { undefinedDropdownValue } from "../helpers/transform";
 
 /**
  * A standard element represents every element covered by

--- a/src/elements/standard/standardDataTransformer.ts
+++ b/src/elements/standard/standardDataTransformer.ts
@@ -1,6 +1,6 @@
+import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
 import type { Asset } from "../helpers/defaultTransform";
-import { undefinedDropdownValue } from "../helpers/transform";
 import type { TransformIn, TransformOut } from "../helpers/types/Transform";
 import type { createStandardFields } from "./StandardSpec";
 

--- a/src/elements/table/TableSpec.ts
+++ b/src/elements/table/TableSpec.ts
@@ -3,7 +3,7 @@ import {
   createCustomField,
 } from "../../plugin/fieldViews/CustomFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
-import { undefinedDropdownValue } from "../helpers/transform";
+import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 
 export const tableFields = {
   source: createTextField({ absentOnEmpty: true }),

--- a/src/elements/tweet/TweetSpec.tsx
+++ b/src/elements/tweet/TweetSpec.tsx
@@ -6,9 +6,9 @@ import {
 } from "../../plugin/fieldViews/CustomFieldView";
 import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
+import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 import { htmlMaxLength } from "../../plugin/helpers/validation";
 import type { Asset } from "../helpers/defaultTransform";
-import { undefinedDropdownValue } from "../helpers/transform";
 
 export const createTweetFields = (
   createCaptionPlugins?: (schema: Schema) => Plugin[]

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,8 @@ export { createContentAtomElement } from "./elements/content-atom/ContentAtomFor
 export {
   transformElementIn,
   transformElementOut,
-  undefinedDropdownValue,
 } from "./elements/helpers/transform";
 export { useTyperighterAttr } from "./elements/helpers/typerighter";
 export { fieldGroupName, isProseMirrorElement } from "./plugin/nodeSpec";
 export type { Options } from "./plugin/fieldViews/DropdownFieldView";
+export { undefinedDropdownValue } from "./plugin/helpers/constants";

--- a/src/plugin/helpers/constants.ts
+++ b/src/plugin/helpers/constants.ts
@@ -1,0 +1,2 @@
+// A placeholder value for a dropdown option that represents no selection.
+export const undefinedDropdownValue = "none-selected";

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -1,4 +1,3 @@
-import { undefinedDropdownValue } from "../../elements/helpers/transform";
 import type {
   ErrorLevel,
   FieldValidationErrors,
@@ -8,6 +7,7 @@ import type {
 } from "../elementSpec";
 import type { FieldNameToValueMap } from "../helpers/fieldView";
 import type { FieldDescriptions } from "../types/Element";
+import { undefinedDropdownValue } from "./constants";
 
 export const createValidator = (
   fieldValidationMap: Record<string, FieldValidator[]>


### PR DESCRIPTION
## What does this change?

Removes a circular dependency caused by `undefinedDropdownValue` – this PR moves it to a `/constants` folder.

## How to test

A ✅ in the CI should be enough to prove this is good.

Additional circular dependencies exist that mean we can't yet include a linting rule. This will be added in a follow up PR, #267. 
