### PR TITLE
feat: add error handling to callout

### DIFF
--- a/demo/sampleElements.ts
+++ b/demo/sampleElements.ts
@@ -411,8 +411,8 @@ export const sampleCampaignList = [
         matchAllTags: false,
       },
     ],
-    activeFrom: 1645488000000,
-    activeUntil: 1769645037000,
+    activeFrom: new Date("2021-01-29T00:00:00.000Z").getTime(),
+    activeUntil: new Date("2026-01-29T00:00:00.000Z").getTime(),
     priority: 0,
     displayOnSensitive: false,
     fields: {
@@ -430,8 +430,8 @@ export const sampleCampaignList = [
     name: "Expired callout",
     rules: [],
     priority: 0,
-    activeFrom: 1645488000000,
-    activeUntil: 1645488000001,
+    activeFrom: new Date("2021-01-29T00:00:00.000Z").getTime(),
+    activeUntil: new Date("2021-02-29T00:00:00.000Z").getTime(),
     displayOnSensitive: false,
     fields: {
       callout: "callout-expired",
@@ -448,8 +448,8 @@ export const sampleCampaignList = [
     name: "Broken callout",
     rules: [],
     priority: 0,
-    activeFrom: 1645488000000,
-    activeUntil: 1769645037000,
+    activeFrom: new Date("2021-01-29T00:00:00.000Z").getTime(),
+    activeUntil: new Date("2026-01-29T00:00:00.000Z").getTime(),
     displayOnSensitive: false,
     fields: {
       callout: "callout-2",
@@ -461,14 +461,13 @@ export const sampleCampaignList = [
       _type: "callout",
     },
   },
-
   {
     id: "1237",
     name: "empty tag name callout",
     rules: [],
     priority: 0,
-    activeFrom: 1645488000000,
-    activeUntil: 1769645037000,
+    activeFrom: new Date("2021-01-29T00:00:00.000Z").getTime(),
+    activeUntil: new Date("2026-01-29T00:00:00.000Z").getTime(),
     displayOnSensitive: false,
     fields: {
       callout: "callout-2",

--- a/demo/sampleElements.ts
+++ b/demo/sampleElements.ts
@@ -412,7 +412,7 @@ export const sampleCampaignList = [
       },
     ],
     activeFrom: 1645488000000,
-    activeUntil: 1645488000001,
+    activeUntil: 1769645037000,
     priority: 0,
     displayOnSensitive: false,
     fields: {
@@ -427,11 +427,29 @@ export const sampleCampaignList = [
   },
   {
     id: "1235",
-    name: "Broken callout",
+    name: "Expired callout",
     rules: [],
     priority: 0,
     activeFrom: 1645488000000,
     activeUntil: 1645488000001,
+    displayOnSensitive: false,
+    fields: {
+      callout: "callout-expired",
+      formId: 11121,
+      tagName: "callout-callout",
+      description: "this is an expired callout",
+      formFields: [],
+      formUrl: "formstack.co.uk",
+      _type: "callout",
+    },
+  },
+  {
+    id: "1236",
+    name: "Broken callout",
+    rules: [],
+    priority: 0,
+    activeFrom: 1645488000000,
+    activeUntil: 1769645037000,
     displayOnSensitive: false,
     fields: {
       callout: "callout-2",
@@ -445,12 +463,12 @@ export const sampleCampaignList = [
   },
 
   {
-    id: "1236",
+    id: "1237",
     name: "empty tag name callout",
     rules: [],
     priority: 0,
     activeFrom: 1645488000000,
-    activeUntil: 1645488000001,
+    activeUntil: 1769645037000,
     displayOnSensitive: false,
     fields: {
       callout: "callout-2",

--- a/src/elements/callout/Callout.tsx
+++ b/src/elements/callout/Callout.tsx
@@ -1,3 +1,6 @@
+import { css } from "@emotion/react";
+import { neutral, space, text } from "@guardian/src-foundations";
+import { textSans } from "@guardian/src-foundations/dist/types/typography";
 import React, { useEffect, useState } from "react";
 import {
   createCustomDropdownField,
@@ -8,7 +11,6 @@ import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
 import { dropDownRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
-import { calloutStyles } from "../embed/Callout";
 import { CalloutError } from "./CalloutError";
 import { CalloutTable } from "./CalloutTable";
 
@@ -63,6 +65,45 @@ export const calloutFields = {
   ),
   isNonCollapsible: createCustomField(false, true),
 };
+
+const calloutStyles = css`
+  ${textSans.small({ fontWeight: "regular", lineHeight: "loose" })}
+  font-family: "Guardian Agate Sans";
+  a {
+    color: ${text.anchorPrimary};
+  }
+  code {
+    font-family: monospace;
+    background-color: ${neutral[86]};
+    border-radius: ${space[1]}px;
+    padding: 1px 4px;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    border: 1px solid ${neutral[86]};
+    font-size: 14px;
+  }
+  th,
+  tr,
+  td {
+    border: 1px solid ${neutral[86]};
+    padding: ${space[1]}px;
+    line-height: 14px;
+    vertical-align: top;
+  }
+  th {
+    text-align: left;
+  }
+  p,
+  p:first-child {
+    margin-top: 0px;
+    margin-bottom: 0px;
+  }
+  ul {
+    margin-bottom: 0px;
+  }
+`;
 
 type Props = {
   fetchCampaignList: () => Promise<Campaign[]>;

--- a/src/elements/callout/Callout.tsx
+++ b/src/elements/callout/Callout.tsx
@@ -108,7 +108,8 @@ export const createCalloutElement = ({
         (campaign) => campaign.id === campaignId
       );
       const isActiveCallout =
-        callout?.activeUntil && callout?.activeUntil >= Date.now();
+        !callout?.activeUntil ||
+        (callout?.activeUntil && callout?.activeUntil >= Date.now());
       const trimmedTargetingUrl = targetingUrl.replace(/\/$/, "");
 
       return campaignId && campaignId != "none-selected" ? (

--- a/src/elements/callout/Callout.tsx
+++ b/src/elements/callout/Callout.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import { neutral, space, text } from "@guardian/src-foundations";
-import { textSans } from "@guardian/src-foundations/dist/types/typography";
+import { textSans } from "@guardian/src-foundations/typography";
 import React, { useEffect, useState } from "react";
 import {
   createCustomDropdownField,
@@ -13,32 +13,7 @@ import { createReactElementSpec } from "../../renderers/react/createReactElement
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import { CalloutError } from "./CalloutError";
 import { CalloutTable } from "./CalloutTable";
-
-export type Fields = {
-  callout: string;
-  formId: number;
-  tagName: string;
-  description?: string;
-  formUrl?: string;
-  _type: string;
-};
-
-export type Rules = {
-  requiredTags: string[];
-  lackingTags: string[];
-  matchAllTags: boolean;
-};
-
-export type Campaign = {
-  id: string;
-  name: string;
-  fields: Fields;
-  rules: Rules[];
-  priority: number;
-  displayOnSensitive: boolean;
-  activeFrom?: number;
-  activeUntil?: number;
-};
+import type { Campaign } from "./CalloutTypes";
 
 const getDropdownOptionsFromCampaignList = (campaignList: Campaign[]) => {
   const campaigns = campaignList.map((campaign) => {
@@ -149,8 +124,7 @@ export const createCalloutElement = ({
         (campaign) => campaign.id === campaignId
       );
       const isActiveCallout =
-        !callout?.activeUntil ||
-        (callout?.activeUntil && callout?.activeUntil >= Date.now());
+        !callout?.activeUntil || callout.activeUntil >= Date.now();
       const trimmedTargetingUrl = targetingUrl.replace(/\/$/, "");
 
       return campaignId && campaignId != "none-selected" ? (

--- a/src/elements/callout/CalloutError.tsx
+++ b/src/elements/callout/CalloutError.tsx
@@ -22,17 +22,17 @@ export const CalloutError = ({
   callout,
   targetingUrl,
   calloutId,
-  isActiveCallout,
+  isExpired,
 }: {
   callout: Campaign | undefined;
   targetingUrl: string;
   calloutId: string;
-  isActiveCallout: boolean;
+  isExpired: boolean;
 }) => {
   const edToolsEmail = "editorial.tools.dev@theguardian.com";
   const centralProdEmail = "central.production@theguardian.com";
 
-  return callout && !isActiveCallout ? (
+  return callout && isExpired ? (
     <>
       <Error css={[error, marginBottom]}>
         <SvgAlertTriangle />

--- a/src/elements/callout/CalloutError.tsx
+++ b/src/elements/callout/CalloutError.tsx
@@ -2,8 +2,8 @@ import { css } from "@emotion/react";
 import { space, text } from "@guardian/src-foundations";
 import { SvgAlertTriangle } from "@guardian/src-icons";
 import { Error } from "../../editorial-source-components/Error";
-import { Campaign } from "./Callout";
 import { CalloutTableHeader } from "./CalloutTable";
+import type { Campaign } from "./CalloutTypes";
 
 const marginBottom = css`
   margin-bottom: ${space[2]}px !important;
@@ -18,6 +18,7 @@ const error = css`
     margin-right: ${space[1]}px;
   }
 `;
+
 export const CalloutError = ({
   callout,
   targetingUrl,
@@ -51,6 +52,14 @@ export const CalloutError = ({
       <Error css={[error, marginBottom]}>
         <SvgAlertTriangle />
         Composer was unable to find this callout.
+        <a
+          css={css`
+            margin-right: ${space[4]}px;
+          `}
+          href={`${targetingUrl}/campaigns/`}
+        >
+          Open in targeting tool
+        </a>
       </Error>
       <p css={marginBottom}>
         It is likely that the callout has been deleted. Please check in the

--- a/src/elements/callout/CalloutError.tsx
+++ b/src/elements/callout/CalloutError.tsx
@@ -17,6 +17,9 @@ const error = css`
     fill: ${text.error};
     margin-right: ${space[1]}px;
   }
+  a {
+    margin-left: auto;
+  }
 `;
 
 export const CalloutError = ({
@@ -52,18 +55,13 @@ export const CalloutError = ({
       <Error css={[error, marginBottom]}>
         <SvgAlertTriangle />
         Composer was unable to find this callout.
-        <a
-          css={css`
-            margin-right: ${space[4]}px;
-          `}
-          href={`${targetingUrl}/campaigns/`}
-        >
-          Open in targeting tool
-        </a>
+        <a href={`${targetingUrl}`}>Open in targeting tool</a>
       </Error>
       <p css={marginBottom}>
-        It is likely that the callout has been deleted. Please check in the
-        targeting tool to check if this callout is available.
+        It is likely that the callout has been deleted. Please check in
+        the&nbsp;
+        <a href={`${targetingUrl}`}>targeting tool</a> to check if this callout
+        is available.
       </p>
       <p>
         If the problem persists, you may wish to contact Central Production (

--- a/src/elements/callout/CalloutError.tsx
+++ b/src/elements/callout/CalloutError.tsx
@@ -1,0 +1,67 @@
+import { css } from "@emotion/react";
+import { space, text } from "@guardian/src-foundations";
+import { SvgAlertTriangle } from "@guardian/src-icons";
+import { Error } from "../../editorial-source-components/Error";
+import { Campaign } from "./Callout";
+import { CalloutTableHeader } from "./CalloutTable";
+
+const marginBottom = css`
+  margin-bottom: ${space[2]}px !important;
+`;
+
+const error = css`
+  display: flex;
+  align-items: center;
+  svg {
+    height: 20px;
+    fill: ${text.error};
+    margin-right: ${space[1]}px;
+  }
+`;
+export const CalloutError = ({
+  callout,
+  targetingUrl,
+  calloutId,
+  isActiveCallout,
+}: {
+  callout: Campaign | undefined;
+  targetingUrl: string;
+  calloutId: string;
+  isActiveCallout: boolean;
+}) => {
+  const edToolsEmail = "editorial.tools.dev@theguardian.com";
+  const centralProdEmail = "central.production@theguardian.com";
+
+  return callout && !isActiveCallout ? (
+    <>
+      <Error css={[error, marginBottom]}>
+        <SvgAlertTriangle />
+        <p>This callout has expired and will not appear in the article.</p>
+      </Error>
+      <CalloutTableHeader
+        title={callout.fields.callout}
+        tagName={callout.fields.tagName}
+        targetingUrl={targetingUrl}
+        calloutId={calloutId}
+        formUrl={callout.fields.formUrl ?? ""}
+      />
+    </>
+  ) : (
+    <div>
+      <Error css={[error, marginBottom]}>
+        <SvgAlertTriangle />
+        Composer was unable to find this callout.
+      </Error>
+      <p css={marginBottom}>
+        It is likely that the callout has been deleted. Please check in the
+        targeting tool to check if this callout is available.
+      </p>
+      <p>
+        If the problem persists, you may wish to contact Central Production (
+        <a href={`mailto:${centralProdEmail}`}>{centralProdEmail}</a>) and the
+        Editorial Tools team (
+        <a href={`mailto:${edToolsEmail}`}>{edToolsEmail}</a>) for assistance.
+      </p>
+    </div>
+  );
+};

--- a/src/elements/callout/CalloutTable.tsx
+++ b/src/elements/callout/CalloutTable.tsx
@@ -3,7 +3,7 @@ import { neutral, space } from "@guardian/src-foundations";
 import { Label } from "../../editorial-source-components/Label";
 import type { CustomField } from "../../plugin/types/Element";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
-import type { Campaign } from "./Callout";
+import type { Campaign } from "./CalloutTypes";
 
 const containerStyle = css`
   display: flex;

--- a/src/elements/callout/CalloutTable.tsx
+++ b/src/elements/callout/CalloutTable.tsx
@@ -26,7 +26,7 @@ const cellStyle = css`
   border-right: 1px solid ${neutral[100]};
   padding: 3px 5px;
 
-  &:first-child {
+  &:first-of-type {
     padding-left: ${space[3]}px;
   }
 

--- a/src/elements/callout/CalloutTable.tsx
+++ b/src/elements/callout/CalloutTable.tsx
@@ -58,26 +58,29 @@ const strongStyle = css`
   font-weight: 700;
 `;
 
-export const CalloutTable = ({
-  calloutData,
+export const CalloutTableHeader = ({
+  title,
+  tagName,
   targetingUrl,
-  isNonCollapsible,
+  calloutId,
+  formUrl,
 }: {
-  calloutData: Campaign;
+  title: string;
+  tagName: string;
   targetingUrl: string;
-  isNonCollapsible: CustomField<boolean, boolean>;
+  calloutId: string;
+  formUrl: string;
 }) => {
-  const { tagName, callout, description, formUrl } = calloutData.fields;
   return (
-    <div css={containerStyle}>
+    <>
       <div css={headerStyle}>
-        <Label>CALLOUT: {tagName}</Label>
+        <Label>CALLOUT: {title}</Label>
         <span>
           <a
             css={css`
               margin-right: ${space[4]}px;
             `}
-            href={`${targetingUrl}/campaigns/${calloutData.id}`}
+            href={`${targetingUrl}/campaigns/${calloutId}`}
           >
             Open in targeting tool
           </a>
@@ -91,6 +94,28 @@ export const CalloutTable = ({
         </span>
         <span css={[cellStyle, tagNameStyle]}>{tagName}</span>
       </div>
+    </>
+  );
+};
+export const CalloutTable = ({
+  calloutData,
+  targetingUrl,
+  isNonCollapsible,
+}: {
+  calloutData: Campaign;
+  targetingUrl: string;
+  isNonCollapsible: CustomField<boolean, boolean>;
+}) => {
+  const { tagName, callout, description, formUrl } = calloutData.fields;
+  return (
+    <div css={containerStyle}>
+      <CalloutTableHeader
+        title={callout}
+        tagName={tagName}
+        formUrl={formUrl ?? ""}
+        targetingUrl={targetingUrl}
+        calloutId={calloutData.id}
+      />
       <div css={bodyStyle}>
         <span>
           <span css={strongStyle}>Callout title: </span>

--- a/src/elements/callout/CalloutTypes.ts
+++ b/src/elements/callout/CalloutTypes.ts
@@ -1,0 +1,25 @@
+export type Fields = {
+  callout: string;
+  formId: number;
+  tagName: string;
+  description?: string;
+  formUrl?: string;
+  _type: string;
+};
+
+export type Rules = {
+  requiredTags: string[];
+  lackingTags: string[];
+  matchAllTags: boolean;
+};
+
+export type Campaign = {
+  id: string;
+  name: string;
+  fields: Fields;
+  rules: Rules[];
+  priority: number;
+  displayOnSensitive: boolean;
+  activeFrom?: number;
+  activeUntil?: number;
+};

--- a/src/elements/embed/Callout.tsx
+++ b/src/elements/embed/Callout.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from "react";
 import { Error } from "../../editorial-source-components/Error";
 import { Label } from "../../editorial-source-components/Label";
 import { FieldLayoutVertical } from "../../editorial-source-components/VerticalFieldLayout";
-import type { Campaign } from "../callout/Callout";
+import type { Campaign } from "../callout/CalloutTypes";
 import { EmbedTestId } from "./EmbedForm";
 
 type Props = {

--- a/src/elements/embed/Callout.tsx
+++ b/src/elements/embed/Callout.tsx
@@ -13,7 +13,7 @@ type Props = {
   targetingUrl: string;
 };
 
-export const calloutStyles = css`
+const calloutStyles = css`
   ${textSans.small({ fontWeight: "regular", lineHeight: "loose" })}
   font-family: "Guardian Agate Sans";
   a {


### PR DESCRIPTION
## What does this change?
Displays a non-blocking error message if one of the following occurs:

1. The callout has not been selected. This is handled out-of-the-box and displays as a warn in composer. 
2. The callout has an active until that has expired.
3. The callout no longer exists in the list of available callouts. 



## How to test
Error 1 - The callout has not been selected
- This can be tested in prosemirror or in composer by adding a callout but not selecting anything from the drop down.
- In composer,  there should also be a warn message when hovering over the publish button.
- The article should be publishable with this error.

Error 2 - The callout has not been selected
- This can be tested in prosemirror by selecting the expired callout from the list. It is more difficult to test in composer as we filter out expired callouts from the list. Commenting out this line will reveal expired callouts in composer. 
- The article should be publishable with this error.

Error 3 - The callout no longer exists in the list of available callouts
- This can be tested in prosemirror by forcing a callout into the dropdown that is not available in the campaign list. This can be done by adding the following code.
-  Alternatively, It is more difficult to test in composer as we filter out expired callouts from the list. Commenting out this line will reveal expired callouts in composer. 
- The article should be publishable with this error.

## Images

| none selected     | 
|-------------|
| ![ none-selected ][] | 

[none-selected]: https://user-images.githubusercontent.com/20416599/206424051-f8929456-552b-4697-bc39-33cc72dcf22b.png

| callout expired     | 
|-------------|
| ![ expired ][] | 

[expired]: https://user-images.githubusercontent.com/20416599/206424780-b0acc47e-ce8d-4b3c-87ab-470b84e10ce4.png

| callout unavailable     | 
|-------------|
| ![ unavailable ][] | 

[unavailable]: https://user-images.githubusercontent.com/20416599/206424156-f7533d17-3a86-4ca4-912e-76ccc81b9798.png


## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [ ] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [ ] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
