### PR TITLE
feat: add tagId field to callout and remove the applyTag & onRemove handlers 

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -181,8 +181,6 @@ const {
     callout: createCalloutElement({
       fetchCampaignList: () => Promise.resolve(sampleCampaignList),
       targetingUrl: "https://targeting.code.dev-gutools.co.uk/",
-      applyTag: (tag: string) => console.log(`Apply ${tag} tag`),
-      onRemove: (fields) => console.log("Remove callout", fields),
     }),
     interactive: createInteractiveElement({
       checkThirdPartyTracking: mockThirdPartyTracking,

--- a/src/elements/callout/Callout.tsx
+++ b/src/elements/callout/Callout.tsx
@@ -8,7 +8,6 @@ import {
 } from "../../plugin/fieldViews/CustomFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { undefinedDropdownValue } from "../../plugin/helpers/constants";
-import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
 import { dropDownRequired } from "../../plugin/helpers/validation";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";

--- a/src/elements/callout/Callout.tsx
+++ b/src/elements/callout/Callout.tsx
@@ -6,6 +6,7 @@ import {
   createCustomDropdownField,
   createCustomField,
 } from "../../plugin/fieldViews/CustomFieldView";
+import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
 import { dropDownRequired } from "../../plugin/helpers/validation";
@@ -39,6 +40,7 @@ export const calloutFields = {
     ]
   ),
   isNonCollapsible: createCustomField(false, true),
+  tagId: createTextField(),
 };
 
 const calloutStyles = css`
@@ -83,77 +85,60 @@ const calloutStyles = css`
 type Props = {
   fetchCampaignList: () => Promise<Campaign[]>;
   targetingUrl: string;
-  applyTag: (tagId: string) => void;
-  onRemove: (fields: FieldNameToValueMap<typeof calloutFields>) => void;
 };
 
 export const createCalloutElement = ({
   fetchCampaignList,
   targetingUrl,
-  applyTag,
-  onRemove,
 }: Props) =>
-  createReactElementSpec(
-    calloutFields,
-    ({ fields }) => {
-      const campaignId = fields.campaignId.value;
-      const [campaignList, setCampaignList] = useState<Campaign[]>([]);
+  createReactElementSpec(calloutFields, ({ fields }) => {
+    const campaignId = fields.campaignId.value;
+    const [campaignList, setCampaignList] = useState<Campaign[]>([]);
 
-      useEffect(() => {
-        void fetchCampaignList().then((campaignList) => {
-          setCampaignList(campaignList);
-        });
-      }, []);
+    useEffect(() => {
+      void fetchCampaignList().then((campaignList) => {
+        setCampaignList(campaignList);
+      });
+    }, []);
 
-      useEffect(() => {
-        if (
-          campaignId === undefinedDropdownValue ||
-          campaignList.length === 0
-        ) {
-          return;
-        }
-        applyTag(getTag(campaignId));
-      }, [campaignId]);
+    const getTag = (id: string) => {
+      const campaign = campaignList.find((campaign) => campaign.id === id);
+      return campaign?.fields.tagName ?? "";
+    };
+    const dropdownOptions = getDropdownOptionsFromCampaignList(campaignList);
+    const callout = campaignList.find((campaign) => campaign.id === campaignId);
+    const isActiveCallout =
+      !callout?.activeUntil || callout.activeUntil >= Date.now();
+    const trimmedTargetingUrl = targetingUrl.replace(/\/$/, "");
 
-      const getTag = (id: string) => {
-        const campaign = campaignList.find((campaign) => campaign.id === id);
-        return campaign?.fields.tagName ?? "";
-      };
-      const dropdownOptions = getDropdownOptionsFromCampaignList(campaignList);
-      const callout = campaignList.find(
-        (campaign) => campaign.id === campaignId
-      );
-      const isActiveCallout =
-        !callout?.activeUntil || callout.activeUntil >= Date.now();
-      const trimmedTargetingUrl = targetingUrl.replace(/\/$/, "");
-
-      return campaignId && campaignId != "none-selected" ? (
-        <div css={calloutStyles}>
-          {callout && isActiveCallout ? (
-            <CalloutTable
-              calloutData={callout}
-              targetingUrl={trimmedTargetingUrl}
-              isNonCollapsible={fields.isNonCollapsible}
-            />
-          ) : (
-            <CalloutError
-              isExpired={!isActiveCallout}
-              targetingUrl={trimmedTargetingUrl}
-              callout={callout}
-              calloutId={campaignId}
-            />
-          )}
-        </div>
-      ) : (
-        <div>
-          <CustomDropdownView
-            label="Callout"
-            field={fields.campaignId}
-            options={dropdownOptions}
+    return campaignId && campaignId != "none-selected" ? (
+      <div css={calloutStyles}>
+        {callout && isActiveCallout ? (
+          <CalloutTable
+            calloutData={callout}
+            targetingUrl={trimmedTargetingUrl}
+            isNonCollapsible={fields.isNonCollapsible}
           />
-        </div>
-      );
-    },
-    undefined,
-    (fields) => onRemove(fields)
-  );
+        ) : (
+          <CalloutError
+            isExpired={!isActiveCallout}
+            targetingUrl={trimmedTargetingUrl}
+            callout={callout}
+            calloutId={campaignId}
+          />
+        )}
+      </div>
+    ) : (
+      <div>
+        <CustomDropdownView
+          label="Callout"
+          field={fields.campaignId}
+          options={dropdownOptions}
+          onChange={(value) => {
+            const tagId = getTag(value);
+            fields.tagId.update(tagId);
+          }}
+        />
+      </div>
+    );
+  });

--- a/src/elements/callout/calloutDataTransformer.ts
+++ b/src/elements/callout/calloutDataTransformer.ts
@@ -6,6 +6,7 @@ import type { calloutFields } from "./Callout";
 export type ExternalCalloutFields = {
   campaignId: string | undefined;
   isNonCollapsible: string;
+  tagId: string | undefined;
 };
 
 export type ExternalCalloutData = {
@@ -21,11 +22,12 @@ export const transformElementIn: TransformIn<
   PartialEmbedData,
   typeof calloutFields
 > = ({ fields }) => {
-  const { campaignId, isNonCollapsible } = fields;
+  const { campaignId, isNonCollapsible, tagId } = fields;
 
   return {
     isNonCollapsible: isNonCollapsible === "true",
     campaignId: campaignId ?? undefinedDropdownValue,
+    tagId,
   };
 };
 
@@ -35,6 +37,7 @@ export const transformElementOut: TransformOut<
 > = ({
   isNonCollapsible,
   campaignId,
+  tagId,
 }: FieldNameToValueMap<typeof calloutFields>): ExternalCalloutData => {
   return {
     assets: [],
@@ -42,6 +45,7 @@ export const transformElementOut: TransformOut<
       isNonCollapsible: isNonCollapsible.toString(),
       campaignId:
         campaignId === undefinedDropdownValue ? undefined : campaignId,
+      tagId,
     },
   };
 };

--- a/src/renderers/react/customFieldViewComponents/CustomDropdownView.tsx
+++ b/src/renderers/react/customFieldViewComponents/CustomDropdownView.tsx
@@ -9,6 +9,7 @@ type CustomDropdownViewProps = {
   options?: Options;
   label: string;
   display?: "inline" | "block";
+  onChange?: (event: string) => void;
 };
 
 export const CustomDropdownView = ({
@@ -16,6 +17,7 @@ export const CustomDropdownView = ({
   options,
   label,
   display = "block",
+  onChange,
 }: CustomDropdownViewProps) => {
   const [selectedElement, setSelectedElement] = useCustomFieldState(field);
   return (
@@ -25,6 +27,7 @@ export const CustomDropdownView = ({
       selected={selectedElement}
       label={label}
       onChange={(event) => {
+        if (onChange) onChange(event.target.value);
         setSelectedElement(event.target.value);
       }}
       error={field.errors.map((e) => e.error).join(", ")}


### PR DESCRIPTION
Paired on this work with @jonathonherbert & @rebecca-thompson 

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR adds a new field `tagId` for the Callout element. This fields doesn't exist in view and is only added for the purpose of data. The field will be populated by value when the user chooses a callout from the drop down. 

This PR also removes the `applyTag` & `onRemove` handlers from the `Callout` element. These handlers were being used in composer client to add/remove the relevant callout tag to the furniture. 

The approach of adding/removing the tags on the client was found to be flaky and unreliable, so we decided to take a different approach by updating the tags server side when saving the updated content to database.  The composer PR can be found here https://github.com/guardian/flexible-content/pull/4287

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This was tested locally with composer.
