### PR TITLE
feat: Remove unnecessary fields from cartoon form

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -11,10 +11,10 @@ import { EditorState } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import {
   buildElementPlugin,
-  cartoonElement,
   codeElement,
   commentElement,
   createCalloutElement,
+  createCartoonElement,
   createContentAtomElement,
   createDemoImageElement,
   createEmbedElement,
@@ -211,7 +211,7 @@ const {
     vine: deprecatedElement,
     instagram: deprecatedElement,
     comment: commentElement,
-    cartoon: cartoonElement(onCropImage, createCaptionPlugins),
+    cartoon: createCartoonElement(onCropImage, createCaptionPlugins),
     tweet: createTweetElement({
       checkThirdPartyTracking: mockThirdPartyTracking,
       createCaptionPlugins,

--- a/src/elements/cartoon/CartoonForm.tsx
+++ b/src/elements/cartoon/CartoonForm.tsx
@@ -144,7 +144,7 @@ export const cartoonElement = (
             }
           />
           <Columns>
-            <Column width={1 / 2}>
+            <Column width={1 / 3}>
               <FieldLayoutVertical>
                 <FieldWrapper
                   field={fields.credit}
@@ -156,28 +156,14 @@ export const cartoonElement = (
                 />
               </FieldLayoutVertical>
             </Column>
-            <Column width={1 / 2}>
+            <Column width={1 / 3}>
               <FieldWrapper field={fields.source} headingLabel={"Source"} />
             </Column>
-          </Columns>
-          <Columns>
             <Column width={1 / 3}>
               <CustomDropdownView
                 field={fields.role}
                 label="Weighting"
                 display={"block"}
-              />
-            </Column>
-            <Column width={1 / 3}>
-              <FieldWrapper
-                field={fields.verticalPadding}
-                headingLabel={"Vertical padding"}
-              />
-            </Column>
-            <Column width={1 / 3}>
-              <FieldWrapper
-                field={fields.backgroundColour}
-                headingLabel={"Background colour"}
               />
             </Column>
           </Columns>

--- a/src/elements/cartoon/CartoonForm.tsx
+++ b/src/elements/cartoon/CartoonForm.tsx
@@ -26,7 +26,7 @@ import type {
 } from "../helpers/types/Media";
 import { cartoonFields } from "./CartoonSpec";
 
-export const cartoonElement = (
+export const createCartoonElement = (
   imageSelector: ImageSelector,
   createCaptionPlugins: (schema: Schema) => Plugin[]
 ) => {

--- a/src/elements/cartoon/CartoonSpec.tsx
+++ b/src/elements/cartoon/CartoonSpec.tsx
@@ -7,12 +7,7 @@ import {
 import { createFlatRichTextField } from "../../plugin/fieldViews/RichTextFieldView";
 import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { undefinedDropdownValue } from "../../plugin/helpers/constants";
-import {
-  htmlMaxLength,
-  htmlRequired,
-  numbersOnly,
-  validHexidecimalValue,
-} from "../../plugin/helpers/validation";
+import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
 import { useTyperighterAttrs } from "../helpers/typerighter";
 import type { ImageSelector, MainImageData } from "../helpers/types/Media";
 import { minAssetValidation } from "../image/ImageElement";
@@ -60,13 +55,5 @@ export const cartoonFields = (
       { text: "thumbnail", value: "thumbnail" },
       { text: "immersive", value: "immersive" },
     ]),
-    verticalPadding: createTextField({
-      validators: [htmlMaxLength(2), numbersOnly()],
-      placeholder: "20",
-    }),
-    backgroundColour: createTextField({
-      validators: [htmlMaxLength(6), validHexidecimalValue()],
-      placeholder: "FFFFFF",
-    }),
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,5 +25,5 @@ export {
 export { useTyperighterAttr } from "./elements/helpers/typerighter";
 export { fieldGroupName, isProseMirrorElement } from "./plugin/nodeSpec";
 export type { Options } from "./plugin/fieldViews/DropdownFieldView";
-export { cartoonElement } from "./elements/cartoon/CartoonForm";
+export { createCartoonElement } from "./elements/cartoon/CartoonForm";
 export { undefinedDropdownValue } from "./plugin/helpers/constants";


### PR DESCRIPTION
## What does this change?

The Cartoon element form has two fields ("Vertical padding" and "Background colour") that were migrated across from the old Comic generator tool, but after speaking with users we're pretty sure we don't need them. This PR removes them. It also moves the "Weighting" field to the row above so it's not sitting on its own. Finally, it renames `cartoonElement` to `createCartoonElement` for the sake of consistency. 

## How to test

Run `prosemirror-elements` locally and click the "Add Cartoon" button. Note the fields are gone.

I've also updated the [testing branch](https://github.com/guardian/flexible-content/compare/bt/cartoon-element) in composer with the new name (`createCartoonElement`). ~~Annoyingly I wasn't actually able to get this working. I think my `yalc` might be broken.~~ (Update: @rebecca-thompson helped me fix this; I was running `yalc` in the parent directory by mistake)

## How can we measure success?

Mateusz looks really happy.

## Have we considered potential risks?

There is no risk as this element is not currently consumed anywhere.

## Images

| Before      | After      |
|-------------|------------|
|  ![Screenshot 2023-04-06 at 12 00 27](https://user-images.githubusercontent.com/7423751/230358803-7183e6dc-ae2e-4fea-8fa7-f34f27666098.png) | ![Screenshot 2023-04-06 at 12 00 17](https://user-images.githubusercontent.com/7423751/230358809-d4059001-5e0d-422b-8537-231545536c66.png) |

