### PR TITLE
feat: Update cartoon data transformer

### DIFF
--- a/demo/helpers.ts
+++ b/demo/helpers.ts
@@ -216,6 +216,5 @@ export const getImageFromMediaPayload = (
     width: +mainAsset.fields.width,
     height: +mainAsset.fields.height,
     mediaId: mediaPayload.mediaId,
-    mediaApiUri: mediaPayload.mediaApiUri,
   };
 };

--- a/demo/helpers.ts
+++ b/demo/helpers.ts
@@ -5,7 +5,7 @@ import type { Asset } from "../src/elements/helpers/defaultTransform";
 import type { SetMedia } from "../src/elements/helpers/types/Media";
 
 type GridAsset = {
-  mimeType: string;
+  mimeType: string; // e.g. ("image/jpeg", "image/png" or "image/svg+xml")
   dimensions: { width: number; height: number };
   secureUrl: string;
 };

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -30,7 +30,6 @@ import {
   transformElementOut,
   undefinedDropdownValue,
 } from "../src";
-import { getImageFromMediaPayload } from "../src/elements/cartoon/CartoonForm";
 import type { MediaPayload } from "../src/elements/helpers/types/Media";
 import {
   createParsers,
@@ -41,6 +40,7 @@ import { testDecorationPlugin } from "../src/plugin/helpers/test";
 import { CollabServer, EditorConnection } from "./collab/CollabServer";
 import { createSelectionCollabPlugin } from "./collab/SelectionPlugin";
 import {
+  getImageFromMediaPayload,
   onCropCartoon,
   onCropImage,
   onDemoCropImage,

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -41,6 +41,7 @@ import { testDecorationPlugin } from "../src/plugin/helpers/test";
 import { CollabServer, EditorConnection } from "./collab/CollabServer";
 import { createSelectionCollabPlugin } from "./collab/SelectionPlugin";
 import {
+  onCropCartoon,
   onCropImage,
   onDemoCropImage,
   onSelectImage,
@@ -212,7 +213,7 @@ const {
     vine: deprecatedElement,
     instagram: deprecatedElement,
     comment: commentElement,
-    cartoon: createCartoonElement(onCropImage, createCaptionPlugins),
+    cartoon: createCartoonElement(onCropCartoon, createCaptionPlugins),
     tweet: createTweetElement({
       checkThirdPartyTracking: mockThirdPartyTracking,
       createCaptionPlugins,

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -30,6 +30,7 @@ import {
   transformElementOut,
   undefinedDropdownValue,
 } from "../src";
+import { getImageFromMediaPayload } from "../src/elements/cartoon/CartoonForm";
 import type { MediaPayload } from "../src/elements/helpers/types/Media";
 import {
   createParsers,
@@ -454,19 +455,17 @@ const createEditor = (server: CollabServer) => {
   cartoonElementButton.id = cartoonElementName;
   cartoonElementButton.addEventListener("click", () => {
     const setMedia = (mediaPayload: MediaPayload) => {
-      const {
-        photographer,
-        mediaId,
-        mediaApiUri,
-        assets,
-        suppliersReference,
-        caption,
-        source,
-      } = mediaPayload;
+      const { photographer, caption, source } = mediaPayload;
+
+      const imageToInsert = getImageFromMediaPayload(mediaPayload);
+
+      // TODO: handle this error
+      if (!imageToInsert) return;
+
       insertElement({
         elementName: cartoonElementName,
         values: {
-          desktopImages: [{ assets, suppliersReference, mediaId, mediaApiUri }],
+          largeImages: [imageToInsert],
           credit: photographer,
           source,
           caption,

--- a/src/elements/cartoon/CartoonForm.tsx
+++ b/src/elements/cartoon/CartoonForm.tsx
@@ -35,8 +35,8 @@ export const getImageFromMediaPayload = (
   return {
     mimeType: mainAsset.mimeType,
     file: mainAsset.url,
-    width: mainAsset.fields.width,
-    height: mainAsset.fields.height,
+    width: +mainAsset.fields.width,
+    height: +mainAsset.fields.height,
     mediaId: mediaPayload.mediaId,
     mediaApiUri: mediaPayload.mediaApiUri,
   };

--- a/src/elements/cartoon/CartoonForm.tsx
+++ b/src/elements/cartoon/CartoonForm.tsx
@@ -18,29 +18,9 @@ import { Tooltip } from "../../editorial-source-components/Tooltip";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
-import type {
-  CartoonImageSelector,
-  MediaPayload,
-} from "../helpers/types/Media";
+import type { CartoonImageSelector } from "../helpers/types/Media";
 import type { Image } from "./cartoonDataTransformer";
 import { cartoonFields } from "./CartoonSpec";
-
-export const getImageFromMediaPayload = (
-  mediaPayload: MediaPayload
-): Image | undefined => {
-  const mainAsset = mediaPayload.assets.find((asset) => asset.fields.isMaster);
-
-  if (!mainAsset) return undefined;
-
-  return {
-    mimeType: mainAsset.mimeType,
-    file: mainAsset.url,
-    width: +mainAsset.fields.width,
-    height: +mainAsset.fields.height,
-    mediaId: mediaPayload.mediaId,
-    mediaApiUri: mediaPayload.mediaApiUri,
-  };
-};
 
 export const createCartoonElement = (
   cartoonImageSelector: CartoonImageSelector,

--- a/src/elements/cartoon/CartoonForm.tsx
+++ b/src/elements/cartoon/CartoonForm.tsx
@@ -18,7 +18,10 @@ import { Tooltip } from "../../editorial-source-components/Tooltip";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
-import type { ImageSelector, MediaPayload } from "../helpers/types/Media";
+import type {
+  CartoonImageSelector,
+  MediaPayload,
+} from "../helpers/types/Media";
 import type { Image } from "./cartoonDataTransformer";
 import { cartoonFields } from "./CartoonSpec";
 
@@ -40,22 +43,17 @@ export const getImageFromMediaPayload = (
 };
 
 export const createCartoonElement = (
-  imageSelector: ImageSelector,
+  cartoonImageSelector: CartoonImageSelector,
   createCaptionPlugins: (schema: Schema) => Plugin[]
 ) => {
   return createReactElementSpec(
-    cartoonFields(imageSelector, createCaptionPlugins),
+    cartoonFields(cartoonImageSelector, createCaptionPlugins),
     ({ fields }) => {
       const addImageAtIndex = (
-        mediaPayload: MediaPayload,
+        imageToInsert: Image,
         images: Image[],
         index?: number
       ) => {
-        const imageToInsert = getImageFromMediaPayload(mediaPayload);
-
-        // TODO: handle this error
-        if (!imageToInsert) return images;
-
         if (index !== undefined && index > -1 && index < images.length) {
           return images.map((image, i) => {
             if (i === index) {
@@ -76,11 +74,11 @@ export const createCartoonElement = (
             images={fields.largeImages.value}
             alt={fields.alt.value}
             addImage={(mediaId?: string, index?: number) => {
-              fields.largeImages.description.props.imageSelector(
-                (mediaPayload: MediaPayload) =>
+              fields.largeImages.description.props.cartoonImageSelector(
+                (imageToInsert: Image) =>
                   fields.largeImages.update(
                     addImageAtIndex(
-                      mediaPayload,
+                      imageToInsert,
                       fields.largeImages.value,
                       index
                     )
@@ -101,11 +99,11 @@ export const createCartoonElement = (
             images={fields.smallImages.value}
             alt={fields.alt.value}
             addImage={(mediaId?: string, index?: number) => {
-              fields.smallImages.description.props.imageSelector(
-                (mediaPayload: MediaPayload) =>
+              fields.smallImages.description.props.cartoonImageSelector(
+                (imageToInsert: Image) =>
                   fields.smallImages.update(
                     addImageAtIndex(
-                      mediaPayload,
+                      imageToInsert,
                       fields.smallImages.value,
                       index
                     )

--- a/src/elements/cartoon/CartoonSpec.tsx
+++ b/src/elements/cartoon/CartoonSpec.tsx
@@ -9,22 +9,25 @@ import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
 import { useTyperighterAttrs } from "../helpers/typerighter";
-import type { ImageSelector, MainImageData } from "../helpers/types/Media";
+import type { ImageSelector } from "../helpers/types/Media";
 import { minAssetValidation } from "../image/ImageElement";
+import type { Image } from "./cartoonDataTransformer";
 
 export const cartoonFields = (
   imageSelector: ImageSelector,
   createCaptionPlugins: (schema: Schema) => Plugin[]
 ) => {
   return {
-    desktopImages: createCustomField<
-      MainImageData[],
-      { imageSelector: ImageSelector }
-    >([], { imageSelector }, [minAssetValidation]),
-    mobileImages: createCustomField<
-      MainImageData[],
-      { imageSelector: ImageSelector }
-    >([], { imageSelector }, [minAssetValidation]),
+    largeImages: createCustomField<Image[], { imageSelector: ImageSelector }>(
+      [],
+      { imageSelector },
+      [minAssetValidation]
+    ),
+    smallImages: createCustomField<Image[], { imageSelector: ImageSelector }>(
+      [],
+      { imageSelector },
+      [minAssetValidation]
+    ),
     caption: createFlatRichTextField({
       createPlugins: createCaptionPlugins,
       marks: "em strong link strike",

--- a/src/elements/cartoon/CartoonSpec.tsx
+++ b/src/elements/cartoon/CartoonSpec.tsx
@@ -9,25 +9,23 @@ import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
 import { useTyperighterAttrs } from "../helpers/typerighter";
-import type { ImageSelector } from "../helpers/types/Media";
+import type { CartoonImageSelector } from "../helpers/types/Media";
 import { minAssetValidation } from "../image/ImageElement";
 import type { Image } from "./cartoonDataTransformer";
 
 export const cartoonFields = (
-  imageSelector: ImageSelector,
+  cartoonImageSelector: CartoonImageSelector,
   createCaptionPlugins: (schema: Schema) => Plugin[]
 ) => {
   return {
-    largeImages: createCustomField<Image[], { imageSelector: ImageSelector }>(
-      [],
-      { imageSelector },
-      [minAssetValidation]
-    ),
-    smallImages: createCustomField<Image[], { imageSelector: ImageSelector }>(
-      [],
-      { imageSelector },
-      [minAssetValidation]
-    ),
+    largeImages: createCustomField<
+      Image[],
+      { cartoonImageSelector: CartoonImageSelector }
+    >([], { cartoonImageSelector }, [minAssetValidation]),
+    smallImages: createCustomField<
+      Image[],
+      { cartoonImageSelector: CartoonImageSelector }
+    >([], { cartoonImageSelector }, [minAssetValidation]),
     caption: createFlatRichTextField({
       createPlugins: createCaptionPlugins,
       marks: "em strong link strike",

--- a/src/elements/cartoon/__tests__/cartoonDataTransformer.spec.ts
+++ b/src/elements/cartoon/__tests__/cartoonDataTransformer.spec.ts
@@ -20,6 +20,7 @@ describe("cartoon element transform", () => {
         fields: {
           credit: "Oliva Hemingway",
           caption: "Photo of a dog",
+          alt: "Photo of a dog",
           source: "PA",
           variants: [
             {
@@ -53,7 +54,9 @@ describe("cartoon element transform", () => {
         role: "none-selected",
         credit: "Oliva Hemingway",
         source: "PA",
+        caption: "Photo of a dog",
         alt: "Photo of a dog",
+        displayCredit: false,
         largeImages: [
           {
             mimeType: "image/jpeg",

--- a/src/elements/cartoon/__tests__/cartoonDataTransformer.spec.ts
+++ b/src/elements/cartoon/__tests__/cartoonDataTransformer.spec.ts
@@ -31,6 +31,7 @@ describe("cartoon element transform", () => {
                   file: "https://media.guim.co.uk/large.jpg",
                   width: 200,
                   height: 200,
+                  mediaId: "123",
                 },
               ],
             },
@@ -42,6 +43,7 @@ describe("cartoon element transform", () => {
                   file: "https://media.guim.co.uk/small.jpg",
                   width: 100,
                   height: 100,
+                  mediaId: "456",
                 },
               ],
             },
@@ -63,6 +65,7 @@ describe("cartoon element transform", () => {
             file: "https://media.guim.co.uk/large.jpg",
             width: 200,
             height: 200,
+            mediaId: "123",
           },
         ],
         smallImages: [
@@ -71,6 +74,7 @@ describe("cartoon element transform", () => {
             file: "https://media.guim.co.uk/small.jpg",
             width: 100,
             height: 100,
+            mediaId: "456",
           },
         ],
       });
@@ -100,6 +104,7 @@ describe("cartoon element transform", () => {
               file: "https://media.guim.co.uk/large.jpg",
               width: 200,
               height: 200,
+              mediaId: "123",
             },
           ],
           smallImages: [
@@ -108,6 +113,7 @@ describe("cartoon element transform", () => {
               file: "https://media.guim.co.uk/small.jpg",
               width: 100,
               height: 100,
+              mediaId: "456",
             },
           ],
         };
@@ -129,6 +135,7 @@ describe("cartoon element transform", () => {
                     file: "https://media.guim.co.uk/small.jpg",
                     width: 100,
                     height: 100,
+                    mediaId: "456",
                   },
                 ],
               },
@@ -140,6 +147,7 @@ describe("cartoon element transform", () => {
                     file: "https://media.guim.co.uk/large.jpg",
                     width: 200,
                     height: 200,
+                    mediaId: "123",
                   },
                 ],
               },

--- a/src/elements/cartoon/__tests__/cartoonDataTransformer.spec.ts
+++ b/src/elements/cartoon/__tests__/cartoonDataTransformer.spec.ts
@@ -1,0 +1,150 @@
+import type { Element } from "../cartoonDataTransformer";
+import { transformElement } from "../cartoonDataTransformer";
+
+describe("cartoon element transform", () => {
+  describe("transformIn", () => {
+    it("should not allow elements which are the wrong type", () => {
+      // @ts-expect-error -- we should not be able to transform a malformed element
+      expect(() => transformElement.in({})).toThrow;
+      expect(() =>
+        transformElement.in({
+          assets: [],
+          // @ts-expect-error -- we should not be able to transform a malformed element
+          fields: { nonExistantField: "123" },
+        })
+      ).toThrow;
+    });
+    it("should transform elements correctly", () => {
+      const element: Element = {
+        elementType: "cartoon",
+        fields: {
+          credit: "Oliva Hemingway",
+          caption: "Photo of a dog",
+          source: "PA",
+          variants: [
+            {
+              viewportSize: "large",
+              images: [
+                {
+                  mimeType: "image/jpeg",
+                  file: "https://media.guim.co.uk/large.jpg",
+                  width: 200,
+                  height: 200,
+                },
+              ],
+            },
+            {
+              viewportSize: "small",
+              images: [
+                {
+                  mimeType: "image/jpeg",
+                  file: "https://media.guim.co.uk/small.jpg",
+                  width: 100,
+                  height: 100,
+                },
+              ],
+            },
+          ],
+        },
+        assets: [],
+      };
+
+      expect(transformElement.in(element)).toEqual({
+        role: "none-selected",
+        credit: "Oliva Hemingway",
+        source: "PA",
+        alt: "Photo of a dog",
+        largeImages: [
+          {
+            mimeType: "image/jpeg",
+            file: "https://media.guim.co.uk/large.jpg",
+            width: 200,
+            height: 200,
+          },
+        ],
+        smallImages: [
+          {
+            mimeType: "image/jpeg",
+            file: "https://media.guim.co.uk/small.jpg",
+            width: 100,
+            height: 100,
+          },
+        ],
+      });
+    });
+    describe("transformOut", () => {
+      it("should not allow elements which are the wrong type", () => {
+        // @ts-expect-error -- we should not be able to transform a malformed element
+        expect(() => transformElement.out({})).toThrow;
+        expect(() =>
+          transformElement.out({
+            // @ts-expect-error -- we should not be able to transform a malformed element
+            nonExistantField: "123",
+          })
+        ).toThrow;
+      });
+      it("should transform elements out correctly", () => {
+        const element = {
+          role: "none-selected",
+          credit: "Oliva Hemingway",
+          source: "PA",
+          alt: "Photo of a dog",
+          displayCredit: true,
+          caption: "Photo of a dog",
+          largeImages: [
+            {
+              mimeType: "image/jpeg",
+              file: "https://media.guim.co.uk/large.jpg",
+              width: 200,
+              height: 200,
+            },
+          ],
+          smallImages: [
+            {
+              mimeType: "image/jpeg",
+              file: "https://media.guim.co.uk/small.jpg",
+              width: 100,
+              height: 100,
+            },
+          ],
+        };
+
+        expect(transformElement.out(element)).toEqual({
+          elementType: "cartoon",
+          fields: {
+            alt: "Photo of a dog",
+            caption: "Photo of a dog",
+            source: "PA",
+            credit: "Oliva Hemingway",
+            displayCredit: "true",
+            variants: [
+              {
+                viewportSize: "small",
+                images: [
+                  {
+                    mimeType: "image/jpeg",
+                    file: "https://media.guim.co.uk/small.jpg",
+                    width: 100,
+                    height: 100,
+                  },
+                ],
+              },
+              {
+                viewportSize: "large",
+                images: [
+                  {
+                    mimeType: "image/jpeg",
+                    file: "https://media.guim.co.uk/large.jpg",
+                    width: 200,
+                    height: 200,
+                  },
+                ],
+              },
+            ],
+          },
+          assets: [],
+        });
+      });
+    });
+  });
+});

--- a/src/elements/cartoon/cartoonDataTransformer.ts
+++ b/src/elements/cartoon/cartoonDataTransformer.ts
@@ -25,6 +25,7 @@ type Fields = {
   role?: string;
   credit?: string;
   caption?: string;
+  alt?: string;
   source?: string;
   displayCredit?: string;
 };
@@ -39,7 +40,7 @@ export const transformElementIn: TransformIn<
   Element,
   ReturnType<typeof cartoonFields>
 > = ({ fields }) => {
-  const { role, credit, caption, source, variants } = fields;
+  const { role, variants, displayCredit, ...rest } = fields;
 
   const getImages = (viewportSize: ViewportSize): Image[] => {
     const variant = variants.find(
@@ -53,11 +54,10 @@ export const transformElementIn: TransformIn<
 
   return {
     role: role ?? undefinedDropdownValue,
-    credit,
-    source,
-    caption,
+    displayCredit: displayCredit === "true",
     largeImages: getImages("large"),
     smallImages: getImages("small"),
+    ...rest,
   };
 };
 

--- a/src/elements/cartoon/cartoonDataTransformer.ts
+++ b/src/elements/cartoon/cartoonDataTransformer.ts
@@ -12,7 +12,6 @@ export type Image = {
   width: number;
   height: number;
   mediaId?: string;
-  mediaApiUri?: string;
 };
 
 type Variant = {

--- a/src/elements/cartoon/cartoonDataTransformer.ts
+++ b/src/elements/cartoon/cartoonDataTransformer.ts
@@ -1,52 +1,63 @@
-import type { Breakpoint } from "@guardian/src-foundations";
 import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
 import type { Asset } from "../helpers/defaultTransform";
-import type { MainImageData } from "../helpers/types/Media";
 import type { TransformIn, TransformOut } from "../helpers/types/Transform";
 import type { cartoonFields } from "./CartoonSpec";
 
+type ViewportSize = "small" | "medium" | "large"; // This used to be called "breakpoint"
+
+export type Image = {
+  mimeType: string; // e.g. ("image/jpeg", "image/png" or "image/svg+xml")
+  file: string;
+  width: number | string;
+  height: number | string;
+  mediaId?: string;
+  mediaApiUri?: string;
+};
+
+type Variant = {
+  viewportSize: ViewportSize;
+  images: Image[];
+};
+
+type Fields = {
+  variants: Variant[];
+  role?: string;
+  credit?: string;
+  caption?: string;
+  source?: string;
+  displayCredit?: string;
+};
+
 export type Element = {
   elementType: string;
-  fields: Record<string, string | undefined>;
+  fields: Fields;
   assets: Asset[];
-  elements?: Element[];
 };
 
 export const transformElementIn: TransformIn<
   Element,
   ReturnType<typeof cartoonFields>
-> = ({ fields, elements }) => {
-  const { role, photographer, caption, source } = fields;
+> = ({ fields }) => {
+  const { role, credit, caption, source, variants } = fields;
 
-  const getImages = (breakpoint: Breakpoint): MainImageData[] => {
-    if (Array.isArray(elements)) {
-      return elements
-        .filter(
-          (element) =>
-            element.elementType === "image" &&
-            element.fields.breakpoint === breakpoint
-        )
-        .map((element) => {
-          return {
-            mediaId: element.fields.mediaId,
-            mediaApiUri: element.fields.mediaApiUri,
-            assets: element.assets,
-            caption: element.fields.caption,
-          };
-        });
-    } else {
-      return [];
-    }
+  const getImages = (viewportSize: ViewportSize): Image[] => {
+    const variant = variants.find(
+      (variant) => variant.viewportSize === viewportSize
+    );
+
+    if (!variant) return [];
+
+    return variant.images;
   };
 
   return {
     role: role ?? undefinedDropdownValue,
-    credit: photographer,
+    credit,
     source,
-    alt: caption,
-    desktopImages: getImages("desktop"),
-    mobileImages: getImages("mobile"),
+    caption,
+    largeImages: getImages("large"),
+    smallImages: getImages("small"),
   };
 };
 
@@ -54,41 +65,29 @@ export const transformElementOut: TransformOut<
   Element,
   ReturnType<typeof cartoonFields>
 > = ({
-  desktopImages,
-  mobileImages,
+  largeImages,
+  smallImages,
   displayCredit,
   role,
   ...rest
 }: FieldNameToValueMap<ReturnType<typeof cartoonFields>>): Element => {
-  const getElementFromImage = (
-    image: MainImageData,
-    breakpoint: Breakpoint
-  ) => {
-    const { assets, ...rest } = image;
-    return {
-      elementType: "image",
-      fields: {
-        breakpoint,
-        ...rest,
-      },
-      assets,
-    };
-  };
-
-  const elements = mobileImages
-    .map((image) => getElementFromImage(image, "mobile"))
-    .concat(
-      desktopImages.map((image) => getElementFromImage(image, "desktop"))
-    );
-
   return {
     elementType: "cartoon",
     fields: {
+      variants: [
+        {
+          viewportSize: "small",
+          images: smallImages,
+        },
+        {
+          viewportSize: "large",
+          images: largeImages,
+        },
+      ],
       displayCredit: displayCredit.toString(),
       role: role === undefinedDropdownValue ? undefined : role,
       ...rest,
     },
-    elements,
     assets: [],
   };
 };

--- a/src/elements/cartoon/cartoonDataTransformer.ts
+++ b/src/elements/cartoon/cartoonDataTransformer.ts
@@ -9,8 +9,8 @@ type ViewportSize = "small" | "medium" | "large"; // This used to be called "bre
 export type Image = {
   mimeType: string; // e.g. ("image/jpeg", "image/png" or "image/svg+xml")
   file: string;
-  width: number | string;
-  height: number | string;
+  width: number;
+  height: number;
   mediaId?: string;
   mediaApiUri?: string;
 };

--- a/src/elements/helpers/defaultTransform.ts
+++ b/src/elements/helpers/defaultTransform.ts
@@ -5,7 +5,7 @@ import type { TransformIn, TransformOut } from "./types/Transform";
 
 export type Asset = {
   assetType: string;
-  mimeType: string;
+  mimeType: string; // e.g. ("image/jpeg", "image/png" or "image/svg+xml")
   url: string;
   fields: {
     width: number | string;

--- a/src/elements/helpers/types/Media.ts
+++ b/src/elements/helpers/types/Media.ts
@@ -1,6 +1,7 @@
 import type { Schema } from "prosemirror-model";
 import type { Plugin } from "prosemirror-state";
 import type { Options } from "../../../plugin/fieldViews/DropdownFieldView";
+import type { Image } from "../../cartoon/cartoonDataTransformer";
 import type { Asset } from "../defaultTransform";
 
 export type MediaPayload = {
@@ -30,3 +31,9 @@ export type ImageElementOptions = {
   createCaptionPlugins?: (schema: Schema) => Plugin[];
   additionalRoleOptions: Options;
 };
+
+export type SetImage = (image: Image) => void;
+export type CartoonImageSelector = (
+  setImage: SetImage,
+  mediaId?: string
+) => void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,4 +27,4 @@ export { fieldGroupName, isProseMirrorElement } from "./plugin/nodeSpec";
 export type { Options } from "./plugin/fieldViews/DropdownFieldView";
 export { createCartoonElement } from "./elements/cartoon/CartoonForm";
 export { undefinedDropdownValue } from "./plugin/helpers/constants";
-export { SetMedia } from "./elements/helpers/types/Media";
+export type { SetImage, SetMedia } from "./elements/helpers/types/Media";


### PR DESCRIPTION
## What does this change?

While testing the Cartoon element in Composer, images were temporarily added as a top level field called `elements`.

This PR moves these elements into the `fields` field. It also defines a type for `fields` based on the one from the ticket.

## How can we measure success?

It's hard to measure success at the moment but this change should move us closer to how the data will actually be modelled.

## Have we considered potential risks?

There should be no risk as the cartoon element is not currently used anywhere.

## Screenshot

![Screenshot 2023-04-26 at 14 37 39](https://user-images.githubusercontent.com/7423751/234593277-4823fb03-8afa-40d6-8dd9-7635e90a991c.png)
