### PR TITLE
RFC: pipeable element transformers

### DIFF
--- a/src/elements/helpers/__tests__/transformHelpers.spec.ts
+++ b/src/elements/helpers/__tests__/transformHelpers.spec.ts
@@ -1,0 +1,96 @@
+import type { Asset } from "../defaultTransform";
+import {
+  moveAssetsAndFieldsInline,
+  pipe,
+  stringToBool,
+} from "../transformHelpers";
+
+describe("moveAssetsAndFieldsInline", () => {
+  const { in: inFn, out: outFn } = moveAssetsAndFieldsInline<{
+    assets: Asset[];
+    fields: { something: string };
+  }>();
+  it("should move assets and fields inline - in", () => {
+    const result = inFn({
+      assets: [],
+      fields: { something: "hai" },
+    });
+
+    expect(result).toEqual({ assets: [], something: "hai" });
+  });
+
+  it("should move assets and fields inline - out", () => {
+    const result = outFn({ assets: [], something: "hai" });
+
+    expect(result).toEqual({ assets: [], fields: { something: "hai" } });
+  });
+});
+
+describe("stringToBool", () => {
+  const { in: inFn, out: outFn } = stringToBool("isMandatory");
+
+  it("should transform field properties to boolean values - in", () => {
+    let result = inFn({ otherValue: "true", isMandatory: "true" });
+
+    expect(result).toEqual({ otherValue: "true", isMandatory: true });
+
+    result = inFn({ otherValue: "true", isMandatory: "false" });
+
+    expect(result).toEqual({ otherValue: "true", isMandatory: false });
+  });
+
+  it("should transform field properties to boolean values - in", () => {
+    let result = outFn({ otherValue: "true", isMandatory: true });
+
+    expect(result).toEqual({ otherValue: "true", isMandatory: "true" });
+
+    result = outFn({ otherValue: "true", isMandatory: false });
+
+    expect(result).toEqual({ otherValue: "true", isMandatory: "false" });
+  });
+});
+
+describe("pipe", () => {
+  type ExampleElement = {
+    assets: Asset[];
+    fields: { isMandatory: string; otherValue: string };
+  };
+  const {
+    in: moveAssetsIn,
+    out: moveAssetsOut,
+  } = moveAssetsAndFieldsInline<ExampleElement>();
+  const { in: mandatoryIn, out: mandatoryOut } = stringToBool("isMandatory");
+
+  it("should pipe several methods - in", () => {
+    const externalElement = {
+      assets: [],
+      fields: { otherValue: "true", isMandatory: "true" },
+    };
+
+    const composedIn = pipe(externalElement, moveAssetsIn, mandatoryIn);
+
+    expect(composedIn).toEqual({
+      assets: [],
+      otherValue: "true",
+      isMandatory: true,
+    });
+  });
+
+  it("should pipe several methods - out", () => {
+    const internalElement = {
+      otherValue: "true",
+      isMandatory: true,
+      assets: [],
+    };
+
+    const composedIn = pipe(internalElement, mandatoryOut, moveAssetsOut);
+
+    expect(composedIn).toEqual({
+      assets: [],
+      fields: {
+        otherValue: "true",
+        isMandatory: "true",
+      },
+    });
+  });
+});

--- a/src/elements/helpers/transformHelpers.ts
+++ b/src/elements/helpers/transformHelpers.ts
@@ -1,0 +1,121 @@
+import type { Asset } from "./defaultTransform";
+
+export const moveAssetsAndFieldsInline = <
+  ExternalData extends {
+    assets: Asset[];
+    fields: Record<string, unknown>;
+  }
+>() => {
+  const inFn = ({
+    assets,
+    fields,
+  }: ExternalData): { assets: Asset[] } & ExternalData["fields"] => ({
+    assets,
+    ...fields,
+  });
+
+  const outFn = ({
+    assets,
+    ...fields
+  }: ReturnType<typeof inFn>): {
+    assets: Asset[];
+    fields: ExternalData["fields"];
+  } => ({
+    assets,
+    fields: (fields as unknown) as ExternalData["fields"],
+  });
+
+  return { in: inFn, out: outFn };
+};
+
+export const stringToBool = <T extends string>(key: T) => {
+  const inFn = <Fields extends { [key in T]: string }>(
+    fields: Fields
+  ): Omit<Fields, T> & Record<T, boolean> => ({
+    ...fields,
+    [key]: fields[key] === "true",
+  });
+
+  const outFn = <Fields extends { [key in T]: boolean }>(
+    fields: Fields
+  ): Omit<Fields, T> & { [key in T]: string } => ({
+    ...fields,
+    [key]: fields[key] === true ? "true" : "false",
+  });
+
+  return { in: inFn, out: outFn };
+};
+
+/**
+ * A convenience method for "piping" a value through a series of functions,
+ * creating a "pipeline" of code. It is equivalent to a series of nested
+ * function calls, but without the need for so many brackets, and with the
+ * function names appearing in the order that they will be called. See the
+ * example for more details.
+ *
+ * It's variadic, meaning that it takes a variable number of arguments. In this
+ * case it means it can take one or more functions to "pipe" the value through.
+ *
+ * @param a A value to pass to the first function
+ * @param f The first function to pass the value to
+ * @param g The second function, which takes the result of the first, `f`
+ * @param h The third function, which takes the result of the second, `g`
+ * @example
+ * const addThree = (n: number): number => n + 3
+ * const subTwo = (n: number): number => n - 2
+ * const multFour = (n: number): number => n * 4
+ *
+ * const num = 42
+ *
+ * // The function names are written in the opposite order to the one they're
+ * // called in: <-
+ * const resultOne = multFour(subTwo(addThree(num)));
+ *
+ * // The function names are written in the order in which they're called: ->,
+ * // and the enclosing brackets are not required
+ * const resultTwo = pipe(
+ *     num,
+ *     addThree,
+ *     subTwo,
+ *     multFour,
+ * );
+ */
+export function pipe<A, B>(a: A, f: (_a: A) => B): B;
+export function pipe<A, B, C>(a: A, f: (_a: A) => B, g: (_b: B) => C): C;
+export function pipe<A, B, C, D>(
+  a: A,
+  f: (_a: A) => B,
+  g: (_b: B) => C,
+  h: (_c: C) => D
+): D;
+export function pipe<A, B, C, D>(
+  a: A,
+  f: (_a: A) => B,
+  g?: (_b: B) => C,
+  h?: (_c: C) => D
+): unknown {
+  if (g !== undefined && h !== undefined) {
+    return h(g(f(a)));
+  } else if (g !== undefined) {
+    return g(f(a));
+  }
+
+  return f(a);
+}
+
+type Transformer = { in: <A, B>(a: A) => B; out: <A, B>(a: A) => B };
+
+export const createTransformer = <
+  T extends [Head, ...Transformer[], Tail],
+  Head extends Transformer,
+  Tail extends Transformer
+>(
+  transformers: T[]
+) => ({
+  in: (
+    externalElement: Parameters<Head["in"]>[0]
+  ): ReturnType<Tail["out"]> => {},
+  out: (
+    externalElement: Parameters<Head["out"]>[0]
+  ): ReturnType<Tail["in"]> => {},
+});


### PR DESCRIPTION
## What does this change?

At the moment, we've lots of ad-hoc functions for transforming our external elements into internal elements, and vice-versa. This leads to a fair amount of repetition, as we must define input and output transformers for each element – even when they're doing very similar things! How might we DRY things up a little?

### 1. Pipeable functions that manage both `in` and `out`, producing a transformer.

One way of reducing the boilerplate we're writing, and reducing the likelihood of bugs: implement a set of transformers that we can chain into a single function to process both `in` and `out` operations.

For example, we spend ~50 lines transforming interactives, which might be expressed more concisely as

```ts
const transformer = pipe(
  moveAssetsAndFieldsInline(),
  stringToBool("isMandatory"),
  optional(["alt", "caption")
);

// Which might give us

transformer.in // ExternalElement => Element
transformer.out // Element => ExternalElement
```

We can imagine composing the rest of our transformers in a similar way.

### 2. Pipeable functions useable within `in` and `out` transformers.

Another option would be to write transformer functions as usual, but provide methods for use internally. In this case, the interactives transformer might look like: 

```ts
// I've used the existing `TransformIn` type here, but perhaps we can imagine making something a little neater
export const transformElementIn: TransformIn<
  PartialInteractiveData,
  ReturnType<typeof createInteractiveFields>
> = pipe(
  moveAssetsAndFieldsInline(),
  stringToBool("isMandatory"),
  optional(["alt", "caption")
);

export const transformElementOut: TransformOut<
  ExternalInteractiveData,
  ReturnType<typeof createInteractiveFields>
> =  pipe(
  optional(["alt", "caption")
  boolToString("isMandatory"),
  moveAssetsAndFieldsToElement(),
);
```

This results in less type complexity than 1., but does mean some repetition (`out` will always be the fns composed for `in` in reverse order.)

### Pros and cons

There are some tradeoffs that I think are the same for both 1. and 2., but differ in degree – here's a list of the ones I've thought of:

- ✅ Declarative – it's easier to see what each transformer is doing.
- ✅ More concise.
- ✅ Less likely to ship bugs when creating new transformers with these functions.
- ✅ Relatively low risk to swap, as existing transformers are well tested with fixture data.
- ❌ More complicated to write pipeline functions – the type signatures can be challenging to get right without a good knowledge of mapped types and generics.
- ❌ Debugging when things go wrong is more difficult, as the type errors are long-winded and abstract.

This has been on my mind for a while, but I'm on the fence as to whether it's worth paving this road, or how far we should go. Are devs comfortable writing transformers ad-hoc as they stand? Or did the repetition and boilerplate give them a bit of an itch?

To give an idea of the complexity, the PR contains an example implementation of a few pipeline functions, but does not yet include the code that would compose pipeline functions into the object `{ in, out }` in a single pass. 

(The `pipe` function is stolen from Dotcom 😀 )