### PR TITLE
fix: Export SetMedia and don't require `isMaster` field in assets

### DIFF
--- a/src/elements/helpers/defaultTransform.ts
+++ b/src/elements/helpers/defaultTransform.ts
@@ -10,7 +10,7 @@ export type Asset = {
   fields: {
     width: number | string;
     height: number | string;
-    isMaster: boolean | undefined;
+    isMaster?: boolean | string | undefined;
   };
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,3 +27,4 @@ export { fieldGroupName, isProseMirrorElement } from "./plugin/nodeSpec";
 export type { Options } from "./plugin/fieldViews/DropdownFieldView";
 export { createCartoonElement } from "./elements/cartoon/CartoonForm";
 export { undefinedDropdownValue } from "./plugin/helpers/constants";
+export { SetMedia } from "./elements/helpers/types/Media";


### PR DESCRIPTION
## What does this change?
This introduces two small changes to facilitate this pr: https://github.com/guardian/flexible-content/pull/4333.

The first is to export the `setMedia` type, so we can use it in Composer.

The second is to make `isMaster` an optional field in the Asset type. This is due to a type mismatch in Composer which is masked when the code using it is written in Javascript, but becomes apparent when it gets migrated to Typescript. The `isMaster` field does not appear on all assets, only the one that is the master asset. For all non-master assets the flag is absent altogether, rather than being `isMaster: false | undefined`.

## How to test
You can build this library locally using `yalc` and test local Composer to see insert and recropping image elements continues to work as expected
