### PR TITLE
fix: Fix indexing of cartoon images

### DIFF
--- a/src/elements/cartoon/CartoonForm.tsx
+++ b/src/elements/cartoon/CartoonForm.tsx
@@ -193,7 +193,7 @@ const ImageSet: FunctionComponent<{
         {images.map((image, index) => (
           <ImageThumbnail
             index={index}
-            key={image.file}
+            key={`${image.file}-${index}`}
             image={image}
             alt={alt}
             recropImage={addImage}


### PR DESCRIPTION
## What does this change?

The new cartoon element has a bug the media url is used as a key for adding and removing images in the image array. This works unless multiple of the same image are added, then things start getting weird because the key is no longer unique which [react doesn't like](https://legacy.reactjs.org/docs/lists-and-keys.html).

The fix is just to append the array index to the media url to ensure uniqueness. React don't recommend doing this...

> We don’t recommend using indexes for keys if the order of items may change. This can negatively impact performance and may cause issues with component state.

...however since re-ordering isn't possible in this context, just adding and deleting, this appears to be safe. I didn't observe any new bugs or performance issues when testing.

## How to test

Follow [these instructions](https://github.com/guardian/prosemirror-elements#testing-locally-in-applications-using-prosemirror-elements) for pulling a local version of `prosemirror-elements` into composer.

You'll also need to manually uncomment a few lines in `flexible-content` to enable the element ([here](https://github.com/guardian/flexible-content/blob/main/composer/src/js/directives/controls/rich-text/button-definitions.ts#L275), [here](https://github.com/guardian/flexible-content/blob/main/composer/src/js/prosemirror-setup/helpers/elements.ts#L28) and [here](https://github.com/guardian/flexible-content/blob/main/composer/src/js/prosemirror-setup/helpers/elements.ts#L89)).

Once you've got everything setup, you should be able to create a cartoon element, and in the "Large images" (or "Small images") field, select the same crop any number of times, delete them, add them again, re-crop them, add some other crops, and have nothing weird happen along the way.

## How can we measure success?

No weirdness when selecting the same crop twice and then attempting further actions.

## Have we considered potential risks?

No risks I can think of. Certainly no immediate ones as the cartoon element is not currently used.

## Images

### Before

![before](https://github.com/guardian/prosemirror-elements/assets/7423751/024db28a-2b83-4ce2-b186-dcf497627ae4)

### After

![after](https://github.com/guardian/prosemirror-elements/assets/7423751/43b024d2-3252-401b-8b6d-52e72b2ef651)
