### PR TITLE
feat: Hide the title for standalone callouts as this will never be shown

### DIFF
--- a/src/elements/callout/CalloutTable.tsx
+++ b/src/elements/callout/CalloutTable.tsx
@@ -70,6 +70,9 @@ const bodyStyle = css`
 const strongStyle = css`
   font-weight: 700;
 `;
+const italicStyle = css`
+  font-style: italic;
+`;
 
 const rightHeaderStyle = css`
   float: right;
@@ -202,41 +205,48 @@ export const CalloutTable = ({
             }
           />
         )}
-
-        {useDefaultTitle.value ? (
+        {isNonCollapsible.value && (
           <div>
             <span css={strongStyle}>Callout Title: </span>
-            <span>{defaultTitle}</span>
-            <span css={rightHeaderStyle}>
-              <Button
-                priority="subdued"
-                onClick={() => useDefaultTitle.update(false)}
-                size="xsmall"
-                cssOverrides={headerButtonStyle}
-              >
-                Edit title
-              </Button>
+            <span css={italicStyle}>
+              (n/a - always hidden on stand alone callouts)
             </span>
           </div>
-        ) : (
-          <FieldWrapper
-            className="callout-field"
-            field={overrideTitle}
-            headingLabel="Callout Title"
-            headingDirection="column"
-            headingContent={
-              <Button
-                priority="subdued"
-                onClick={() => useDefaultTitle.update(true)}
-                size="xsmall"
-                cssOverrides={headerButtonStyle}
-              >
-                Reset title
-              </Button>
-            }
-          />
         )}
-
+        {!isNonCollapsible.value &&
+          (useDefaultTitle.value ? (
+            <div>
+              <span css={strongStyle}>Callout Title: </span>
+              <span>{defaultTitle}</span>
+              <span css={rightHeaderStyle}>
+                <Button
+                  priority="subdued"
+                  onClick={() => useDefaultTitle.update(false)}
+                  size="xsmall"
+                  cssOverrides={headerButtonStyle}
+                >
+                  Edit title
+                </Button>
+              </span>
+            </div>
+          ) : (
+            <FieldWrapper
+              className="callout-field"
+              field={overrideTitle}
+              headingLabel="Callout Title"
+              headingDirection="column"
+              headingContent={
+                <Button
+                  priority="subdued"
+                  onClick={() => useDefaultTitle.update(true)}
+                  size="xsmall"
+                  cssOverrides={headerButtonStyle}
+                >
+                  Reset title
+                </Button>
+              }
+            />
+          ))}
         {useDefaultDescription.value ? (
           <>
             <div>

--- a/src/elements/callout/CalloutTable.tsx
+++ b/src/elements/callout/CalloutTable.tsx
@@ -209,7 +209,7 @@ export const CalloutTable = ({
           <div>
             <span css={strongStyle}>Callout Title: </span>
             <span css={italicStyle}>
-              (n/a - always hidden on stand alone callouts)
+              (n/a - always hidden on standalone callouts)
             </span>
           </div>
         )}
@@ -291,7 +291,7 @@ export const CalloutTable = ({
       </div>
       <CustomCheckboxView
         field={isNonCollapsible}
-        label="Tick for stand alone callouts only"
+        label="Tick for standalone callouts only"
       />
     </div>
   );


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This updates the callout element, so that the callout title is not editable when the standalone checkbox is checked.
This is because the title is always hidden in the front end, and is confusing to let editorial update something that won't be shown.

Also updates stand alone -> standalone


## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
| Change | Before | After |
|--------|--------|--------|
| Standalone callout (title hidden) | <img width="848" alt="image" src="https://github.com/guardian/prosemirror-elements/assets/26366706/3a8c6897-7249-4280-923e-5f7d8e37c78e"> | <img width="986" alt="image" src="https://github.com/guardian/prosemirror-elements/assets/26366706/99b4f61d-abcc-4224-9ff8-8b6b4022013e">|
| Not standalone callout (text change only) | <img width="848" alt="image" src="https://github.com/guardian/prosemirror-elements/assets/26366706/955dfe20-799a-41f9-a156-a0a7721a4f7f"> | <img width="986" alt="image" src="https://github.com/guardian/prosemirror-elements/assets/26366706/7c41bb0c-4467-4563-addf-45da180f87eb"> | 

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [x] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [x] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [x] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [x] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [x] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
