### PR TITLE
feat: Stop adding the thumbnail role to all image elements

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -143,6 +143,7 @@ const additionalRoleOptions = [
   { text: "supporting", value: "supporting" },
   { text: "showcase", value: "showcase" },
   { text: "immersive", value: "immersive" },
+  { text: "thumbnail", value: "thumbnail" },
 ];
 
 const {

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -158,8 +158,6 @@ export const createImageElement = (options: ImageElementOptions) => {
   return { element, updateAdditionalRoleOptions };
 };
 
-const thumbnailOnlyOptions = [thumbnailOption];
-
 const RoleOptionsDropdown = ({
   field,
   mainImage,
@@ -171,13 +169,15 @@ const RoleOptionsDropdown = ({
 }) => {
   // We memoise these options to ensure that this array does not change identity
   // and re-trigger useEffect unless our additionalRoleOptions have changed.
-  const allOptions = useMemo(
-    () => [...additionalRoleOptions, thumbnailOption],
-    [additionalRoleOptions]
-  );
+  const allOptions = useMemo(() => additionalRoleOptions, [
+    additionalRoleOptions,
+  ]);
 
+  // if the image is very small and the element supports thumbnails, only allow the thumbnail role in the drop-down
   const roleOptions = minAssetValidation(mainImage, "").length
-    ? thumbnailOnlyOptions
+    ? allOptions.some((value) => value.text === "thumbnail")
+      ? [thumbnailOption]
+      : allOptions
     : allOptions;
 
   /**

--- a/src/elements/image/imageElementValidation.ts
+++ b/src/elements/image/imageElementValidation.ts
@@ -54,7 +54,8 @@ export const largestAssetMinDimension = (minSize: number): FieldValidator => (
     ) {
       return [
         {
-          error: "Warning: Small image, only thumbnail available",
+          error:
+            "Warning: Small image. Image should be greater than 460 x 460px for uses other than a thumbnail",
           message:
             "Image should be greater than 460 x 460px for uses other than a thumbnail.",
           level: "WARN",


### PR DESCRIPTION
## What does this change?
The image element currently derives its weighting drop down options (also referred to as 'role' in some places) from two places:

1. hard-coded values in the React component (thumbnail)
2. values that are passed in when the element is created - such as [here](https://github.com/guardian/flexible-content/blob/main/composer/src/js/prosemirror-setup/helpers/image-element.ts)

Up to this point, having the thumbnail weighting automatically added hasn't been a problem as all image elements allow for an image to be a thumbnail, however... the Picture content editor does not currently permit this weighting, so we need to move thumbnail from a hard-coded value and start passing it in along with the other weighting options.

## How to test
This has been tested locally by running `yarn yalc` and importing the local build into flexible-content. You should see the thumbnail option continue to appear in the image element in the article editor.

## Images
<img width="273" alt="Screenshot 2023-06-27 at 17 46 10" src="https://github.com/guardian/prosemirror-elements/assets/33927854/744e16bd-3c2c-4868-a30e-62cd6d8a8cad">
