### PR TITLE
fix: Give GH Actions the appropriate permissions to publish tags

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -50,6 +50,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [build, integration-tests]
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     if: github.ref == 'refs/heads/main' ||  github.ref == 'refs/heads/beta'
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## What does this change?
It looks like the default permissions for the `GITHUB_TOKEN` have changed underneath us, breaking the release stage of our CI pipeline. To see this in action (pun intended), you can see the permissions have changed from the last successful release and the most recent failed release:

| Original    | Current |
| -------- | ------- |
| ![Screenshot 2023-06-28 at 11 37 20](https://github.com/guardian/prosemirror-elements/assets/33927854/be5b02f7-56f3-44d3-8dcf-ebcb859a496c)  | ![Screenshot 2023-06-28 at 11 37 09](https://github.com/guardian/prosemirror-elements/assets/33927854/2f09f4ce-8fb9-4b59-89e8-da2fb2e66490)    |

The release stage of our CI pipeline is failing at the point at which is tries to publish tags to the repo. This pr gives the minimum required permissions by semantic-release to successfully release this package.

For more details on this see:

[Modifying the permissions for the Github Token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token)
[Github authentication for Semantic Release](https://github.com/semantic-release/github#github-authentication)
 
## How to test
This is a little tricky... `workflow_dispatch` is not enabled on this project which would normally allow us to run GH Actions on branches and check they work. I imagine we want to keep it this way, as this action publishes to NPM and running it on feature branches would lead to potentially unstable versions of this package being published. Effectively this means this can only really be tested once it's merged. 😬🤞

On the plus side, CI is already broken so it can't break what's not fixed.