### PR TITLE
fix: Simplify-actions-node-version

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -13,13 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-        id: nvm
 
       - name: Use Node.js ${{ steps.nvm.outputs.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
+          node-version-file: .nvmrc
           cache: 'yarn'
 
       - name: Install dependencies
@@ -32,13 +30,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-        id: nvm
 
       - name: Use Node.js ${{ steps.nvm.outputs.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
+          node-version-file: .nvmrc
           cache: 'yarn'
 
       - name: Install dependencies
@@ -57,13 +53,11 @@ jobs:
     if: github.ref == 'refs/heads/main' ||  github.ref == 'refs/heads/beta'
     steps:
       - uses: actions/checkout@v3
-      - run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-        id: nvm
 
       - name: Use Node.js ${{ steps.nvm.outputs.NODE_VERSION }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
+          node-version-file: .nvmrc
           cache: 'yarn'
 
       - name: Install dependencies


### PR DESCRIPTION
There's a simpler way to setup node with the version specified in the .nvmrc file

## What does this change?
Rather than cat'ing a file and using the output of steps, you can just list the file in the setup-node action
Reduces the number of steps, and makes the intention clearer in the workflow file