### PR TITLE
feat: Update Node to correct type

### DIFF
--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -346,10 +346,9 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
   private getNodeFromValue(htmlContent: string) {
     const element = document.createElement("div");
     element.innerHTML = htmlContent;
-    const content = this.parser.parse(element);
-    return this.node.type.create(
-      { type: this.node.attrs.type as string },
-      content
-    );
+    const topNode = this.node.type.create({
+      type: this.node.attrs.type as string,
+    });
+    return this.parser.parse(element, { topNode });
   }
 }

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -346,9 +346,6 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
   private getNodeFromValue(htmlContent: string) {
     const element = document.createElement("div");
     element.innerHTML = htmlContent;
-    const topNode = this.node.type.create({
-      type: this.node.attrs.type as string,
-    });
-    return this.parser.parse(element, { topNode });
+    return this.parser.parse(element, { topNode: this.node });
   }
 }


### PR DESCRIPTION
## What does this change?
The `getNodeFromValue` function is called whenever we call `update` on a field from within one of our element forms. For example, the button to populate the alt text from the caption in `ImageElementForm.tsx`:

```
                      <Button
                        priority="secondary"
                        size="xsmall"
                        iconSide="left"
                        onClick={() => {
                          sendTelemetryEvent?.(
                            ImageElementTelemetryType.CopyFromCaptionButtonPressed
                          );
                          fields.alt.update(fields.caption.value);
                        }}
                      >
                        Copy from caption
                      </Button>
```

The problem with the way `getNodeFromValue` is currently implemented is the default behaviour is to parse the html into the default top node type (usually `doc`).

In the Picture content editor in flexible content, we have restricted the doc to have 0 or 1 elements of type image, so when it tries to parse text into the doc, it fails.

This can be fixed by creating a topNode of the correct type and setting this in the parse options. It should be achieving the same thing without the intermediary step of creating a doc Node.

## How to test
Check any fields that are updated using `.update`. These are usually fields that are populated from other fields or that respond to some other event happening in the UI (such as role options changing if a very small image is selected on recrop). The elements that currently use this are the Image, Cartoon and Callout elements, which have all been tested locally