### PR TITLE
fix: model cartoon element booleans as booleans, not strings

### DIFF
--- a/demo/helpers.ts
+++ b/demo/helpers.ts
@@ -1,13 +1,8 @@
 import type { EditorState, Transaction } from "prosemirror-state";
 import { Plugin } from "prosemirror-state";
-import type { Image } from "../src/elements/cartoon/cartoonDataTransformer";
+import type { Image, MediaPayload, SetImage, SetMedia } from "../src";
 import type { DemoSetMedia } from "../src/elements/demo-image/DemoImageElement";
 import type { Asset } from "../src/elements/helpers/defaultTransform";
-import type {
-  MediaPayload,
-  SetImage,
-  SetMedia,
-} from "../src/elements/helpers/types/Media";
 
 type GridAsset = {
   mimeType: string; // e.g. ("image/jpeg", "image/png" or "image/svg+xml")

--- a/src/elements/cartoon/CartoonForm.tsx
+++ b/src/elements/cartoon/CartoonForm.tsx
@@ -18,8 +18,7 @@ import { Tooltip } from "../../editorial-source-components/Tooltip";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
-import type { CartoonImageSelector } from "../helpers/types/Media";
-import type { Image } from "./cartoonDataTransformer";
+import type { CartoonImageSelector, Image } from "../helpers/types/Media";
 import { cartoonFields } from "./CartoonSpec";
 
 export const createCartoonElement = (

--- a/src/elements/cartoon/CartoonSpec.tsx
+++ b/src/elements/cartoon/CartoonSpec.tsx
@@ -9,9 +9,8 @@ import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 import { htmlMaxLength, htmlRequired } from "../../plugin/helpers/validation";
 import { useTyperighterAttrs } from "../helpers/typerighter";
-import type { CartoonImageSelector } from "../helpers/types/Media";
+import type { CartoonImageSelector, Image } from "../helpers/types/Media";
 import { minAssetValidation } from "../image/ImageElement";
-import type { Image } from "./cartoonDataTransformer";
 
 export const cartoonFields = (
   cartoonImageSelector: CartoonImageSelector,

--- a/src/elements/cartoon/__tests__/cartoonDataTransformer.spec.ts
+++ b/src/elements/cartoon/__tests__/cartoonDataTransformer.spec.ts
@@ -22,6 +22,7 @@ describe("cartoon element transform", () => {
           caption: "Photo of a dog",
           alt: "Photo of a dog",
           source: "PA",
+          displayCredit: true,
           variants: [
             {
               viewportSize: "large",
@@ -58,7 +59,7 @@ describe("cartoon element transform", () => {
         source: "PA",
         caption: "Photo of a dog",
         alt: "Photo of a dog",
-        displayCredit: false,
+        displayCredit: true,
         largeImages: [
           {
             mimeType: "image/jpeg",
@@ -125,7 +126,7 @@ describe("cartoon element transform", () => {
             caption: "Photo of a dog",
             source: "PA",
             credit: "Oliva Hemingway",
-            displayCredit: "true",
+            displayCredit: true,
             variants: [
               {
                 viewportSize: "small",

--- a/src/elements/cartoon/cartoonDataTransformer.ts
+++ b/src/elements/cartoon/cartoonDataTransformer.ts
@@ -1,18 +1,11 @@
 import { undefinedDropdownValue } from "../../plugin/helpers/constants";
 import type { FieldNameToValueMap } from "../../plugin/helpers/fieldView";
 import type { Asset } from "../helpers/defaultTransform";
+import type { Image } from "../helpers/types/Media";
 import type { TransformIn, TransformOut } from "../helpers/types/Transform";
 import type { cartoonFields } from "./CartoonSpec";
 
 type ViewportSize = "small" | "medium" | "large"; // This used to be called "breakpoint"
-
-export type Image = {
-  mimeType: string; // e.g. ("image/jpeg", "image/png" or "image/svg+xml")
-  file: string;
-  width: number;
-  height: number;
-  mediaId?: string;
-};
 
 type Variant = {
   viewportSize: ViewportSize;
@@ -26,7 +19,7 @@ type Fields = {
   caption?: string;
   alt?: string;
   source?: string;
-  displayCredit?: string;
+  displayCredit?: boolean;
 };
 
 export type Element = {
@@ -39,7 +32,7 @@ export const transformElementIn: TransformIn<
   Element,
   ReturnType<typeof cartoonFields>
 > = ({ fields }) => {
-  const { role, variants, displayCredit, ...rest } = fields;
+  const { role, variants, ...rest } = fields;
 
   const getImages = (viewportSize: ViewportSize): Image[] => {
     const variant = variants.find(
@@ -53,7 +46,6 @@ export const transformElementIn: TransformIn<
 
   return {
     role: role ?? undefinedDropdownValue,
-    displayCredit: displayCredit === "true",
     largeImages: getImages("large"),
     smallImages: getImages("small"),
     ...rest,
@@ -66,7 +58,6 @@ export const transformElementOut: TransformOut<
 > = ({
   largeImages,
   smallImages,
-  displayCredit,
   role,
   ...rest
 }: FieldNameToValueMap<ReturnType<typeof cartoonFields>>): Element => {
@@ -83,7 +74,6 @@ export const transformElementOut: TransformOut<
           images: largeImages,
         },
       ],
-      displayCredit: displayCredit.toString(),
       role: role === undefinedDropdownValue ? undefined : role,
       ...rest,
     },

--- a/src/elements/helpers/types/Media.ts
+++ b/src/elements/helpers/types/Media.ts
@@ -1,7 +1,6 @@
 import type { Schema } from "prosemirror-model";
 import type { Plugin } from "prosemirror-state";
 import type { Options } from "../../../plugin/fieldViews/DropdownFieldView";
-import type { Image } from "../../cartoon/cartoonDataTransformer";
 import type { Asset } from "../defaultTransform";
 
 export type MediaPayload = {
@@ -32,7 +31,16 @@ export type ImageElementOptions = {
   additionalRoleOptions: Options;
 };
 
+export type Image = {
+  mimeType: string; // e.g. ("image/jpeg", "image/png" or "image/svg+xml")
+  file: string;
+  width: number;
+  height: number;
+  mediaId?: string;
+};
+
 export type SetImage = (image: Image) => void;
+
 export type CartoonImageSelector = (
   setImage: SetImage,
   mediaId?: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,4 +27,9 @@ export { fieldGroupName, isProseMirrorElement } from "./plugin/nodeSpec";
 export type { Options } from "./plugin/fieldViews/DropdownFieldView";
 export { createCartoonElement } from "./elements/cartoon/CartoonForm";
 export { undefinedDropdownValue } from "./plugin/helpers/constants";
-export type { SetImage, SetMedia } from "./elements/helpers/types/Media";
+export type {
+  SetImage,
+  Image,
+  SetMedia,
+  MediaPayload,
+} from "./elements/helpers/types/Media";


### PR DESCRIPTION
## What does this change?
This changes the `displayCredit` boolean values in the cartoon data transformer to be correctly modelled as a boolean, rather than a string.

It also moves the definition of the `Image` type to be co-located with the other Media type definitions and exports this type, so we can use it in flexible-content (important for getting re-crop and add image buttons working).

## How to test
This has been checked by building the libs locally using `yalc` and pulling them into the flexible-content project.
