### PR TITLE
fix: Add imageType to cartoon element and rename credit to photographer

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -468,7 +468,7 @@ const createEditor = (server: CollabServer) => {
         elementName: cartoonElementName,
         values: {
           largeImages: [imageToInsert],
-          credit: photographer,
+          photographer,
           source,
           caption,
         },

--- a/src/elements/cartoon/CartoonForm.tsx
+++ b/src/elements/cartoon/CartoonForm.tsx
@@ -140,16 +140,10 @@ export const createCartoonElement = (
           />
           <Columns>
             <Column width={1 / 3}>
-              <FieldLayoutVertical>
-                <FieldWrapper
-                  field={fields.photographer}
-                  headingLabel={"Comic credit"}
-                />
-                <CustomCheckboxView
-                  field={fields.displayCredit}
-                  label="Display credit information"
-                />
-              </FieldLayoutVertical>
+              <FieldWrapper
+                field={fields.photographer}
+                headingLabel={"Comic credit"}
+              />
             </Column>
             <Column width={1 / 3}>
               <FieldWrapper field={fields.source} headingLabel={"Source"} />
@@ -160,6 +154,20 @@ export const createCartoonElement = (
                 label="Weighting"
                 display={"block"}
               />
+            </Column>
+          </Columns>
+          <Columns>
+            <Column width={2 / 3}>
+              <CustomCheckboxView
+                field={fields.displayCredit}
+                label="Display credit information"
+              />
+            </Column>
+            <Column width={1 / 3}>
+              <CustomDropdownView
+                field={fields.imageType}
+                label={"Image type"}
+              ></CustomDropdownView>
             </Column>
           </Columns>
         </FieldLayoutVertical>

--- a/src/elements/cartoon/CartoonForm.tsx
+++ b/src/elements/cartoon/CartoonForm.tsx
@@ -142,7 +142,7 @@ export const createCartoonElement = (
             <Column width={1 / 3}>
               <FieldLayoutVertical>
                 <FieldWrapper
-                  field={fields.credit}
+                  field={fields.photographer}
                   headingLabel={"Comic credit"}
                 />
                 <CustomCheckboxView

--- a/src/elements/cartoon/CartoonForm.tsx
+++ b/src/elements/cartoon/CartoonForm.tsx
@@ -49,7 +49,7 @@ export const createCartoonElement = (
       return (
         <FieldLayoutVertical>
           <ImageSet
-            label={"Large images (default)"}
+            label={"Desktop images (default)"}
             images={fields.largeImages.value}
             alt={fields.alt.value}
             addImage={(mediaId?: string, index?: number) => {
@@ -74,7 +74,7 @@ export const createCartoonElement = (
             mainMediaId={fields.largeImages.value[0]?.mediaId}
           />
           <ImageSet
-            label={"Small images"}
+            label={"Mobile images"}
             images={fields.smallImages.value}
             alt={fields.alt.value}
             addImage={(mediaId?: string, index?: number) => {
@@ -142,7 +142,7 @@ export const createCartoonElement = (
             <Column width={1 / 3}>
               <FieldWrapper
                 field={fields.photographer}
-                headingLabel={"Comic credit"}
+                headingLabel={"Byline"}
               />
             </Column>
             <Column width={1 / 3}>

--- a/src/elements/cartoon/CartoonSpec.tsx
+++ b/src/elements/cartoon/CartoonSpec.tsx
@@ -55,5 +55,10 @@ export const cartoonFields = (
       { text: "thumbnail", value: "thumbnail" },
       { text: "immersive", value: "immersive" },
     ]),
+    imageType: createCustomDropdownField("Illustration", [
+      { text: "Photograph", value: "Photograph" },
+      { text: "Illustration", value: "Illustration" },
+      { text: "Composite", value: "Composite" },
+    ]),
   };
 };

--- a/src/elements/cartoon/CartoonSpec.tsx
+++ b/src/elements/cartoon/CartoonSpec.tsx
@@ -39,7 +39,7 @@ export const cartoonFields = (
       isResizeable: true,
       attrs: useTyperighterAttrs,
     }),
-    credit: createTextField({
+    photographer: createTextField({
       validators: [htmlMaxLength(100)],
       placeholder: "Enter the artist...",
     }),

--- a/src/elements/cartoon/__tests__/cartoonDataTransformer.spec.ts
+++ b/src/elements/cartoon/__tests__/cartoonDataTransformer.spec.ts
@@ -18,7 +18,7 @@ describe("cartoon element transform", () => {
       const element: Element = {
         elementType: "cartoon",
         fields: {
-          credit: "Oliva Hemingway",
+          photographer: "Oliva Hemingway",
           caption: "Photo of a dog",
           alt: "Photo of a dog",
           source: "PA",
@@ -55,7 +55,7 @@ describe("cartoon element transform", () => {
 
       expect(transformElement.in(element)).toEqual({
         role: "none-selected",
-        credit: "Oliva Hemingway",
+        photographer: "Oliva Hemingway",
         source: "PA",
         caption: "Photo of a dog",
         alt: "Photo of a dog",
@@ -94,7 +94,7 @@ describe("cartoon element transform", () => {
       it("should transform elements out correctly", () => {
         const element = {
           role: "none-selected",
-          credit: "Oliva Hemingway",
+          photographer: "Oliva Hemingway",
           source: "PA",
           alt: "Photo of a dog",
           displayCredit: true,
@@ -125,7 +125,7 @@ describe("cartoon element transform", () => {
             alt: "Photo of a dog",
             caption: "Photo of a dog",
             source: "PA",
-            credit: "Oliva Hemingway",
+            photographer: "Oliva Hemingway",
             displayCredit: true,
             variants: [
               {

--- a/src/elements/cartoon/__tests__/cartoonDataTransformer.spec.ts
+++ b/src/elements/cartoon/__tests__/cartoonDataTransformer.spec.ts
@@ -60,6 +60,7 @@ describe("cartoon element transform", () => {
         caption: "Photo of a dog",
         alt: "Photo of a dog",
         displayCredit: true,
+        imageType: "Illustration",
         largeImages: [
           {
             mimeType: "image/jpeg",
@@ -99,6 +100,7 @@ describe("cartoon element transform", () => {
           alt: "Photo of a dog",
           displayCredit: true,
           caption: "Photo of a dog",
+          imageType: "Illustration",
           largeImages: [
             {
               mimeType: "image/jpeg",
@@ -127,6 +129,7 @@ describe("cartoon element transform", () => {
             source: "PA",
             photographer: "Oliva Hemingway",
             displayCredit: true,
+            imageType: "Illustration",
             variants: [
               {
                 viewportSize: "small",

--- a/src/elements/cartoon/cartoonDataTransformer.ts
+++ b/src/elements/cartoon/cartoonDataTransformer.ts
@@ -15,7 +15,7 @@ type Variant = {
 type Fields = {
   variants: Variant[];
   role?: string;
-  credit?: string;
+  photographer?: string;
   caption?: string;
   alt?: string;
   source?: string;

--- a/src/elements/cartoon/cartoonDataTransformer.ts
+++ b/src/elements/cartoon/cartoonDataTransformer.ts
@@ -20,6 +20,7 @@ type Fields = {
   alt?: string;
   source?: string;
   displayCredit?: boolean;
+  imageType?: string;
 };
 
 export type Element = {
@@ -32,7 +33,7 @@ export const transformElementIn: TransformIn<
   Element,
   ReturnType<typeof cartoonFields>
 > = ({ fields }) => {
-  const { role, variants, ...rest } = fields;
+  const { role, imageType, variants, ...rest } = fields;
 
   const getImages = (viewportSize: ViewportSize): Image[] => {
     const variant = variants.find(
@@ -46,6 +47,7 @@ export const transformElementIn: TransformIn<
 
   return {
     role: role ?? undefinedDropdownValue,
+    imageType: imageType ?? "Illustration",
     largeImages: getImages("large"),
     smallImages: getImages("small"),
     ...rest,


### PR DESCRIPTION
## What does this change?
This adds a new field to the Cartoon element to define the `imageType`, defaulting to Illustration if not defined.

It also renames `credit` to `photographer` in the data but not in the UI were it is labelled `byline`. This was discussed out of band and decided to change the name to align with the Image element, even though the label photographer may be less relevant in the context of a Cartoon. The idea is to eventually change this field for both elements to something more generic (such as byline as it is labeled in the Grid) and migrate existing data across. 

## How to test
Run `yarn start` to launch the local demo. The Cartoon element should continue to successfully populate the `Comic credit` field with the correct value and should have an additional drop-down field to set the image type.

## Images
<img width="626" alt="Screenshot 2023-08-08 at 14 17 35" src="https://github.com/guardian/prosemirror-elements/assets/33927854/3b59309c-2bff-45aa-bd02-3063c9d408ea">
