### PR TITLE
fix: formatting of cross to remove images in cartoon element

### DIFF
--- a/src/elements/cartoon/CartoonForm.tsx
+++ b/src/elements/cartoon/CartoonForm.tsx
@@ -261,6 +261,7 @@ const ImageThumbnail: FunctionComponent<{
   return (
     <div>
       <div css={imageThumbnailStyle}>
+        <img src={image.file} alt={alt}></img>
         {!required && (
           <button
             css={removeImageButton}
@@ -271,7 +272,6 @@ const ImageThumbnail: FunctionComponent<{
             <SvgCrossRound />
           </button>
         )}
-        <img src={image.file} alt={alt}></img>
       </div>
       {required && (
         <Button


### PR DESCRIPTION
## What does this change?
Adds the remove image cross after the image rather than before. This prevents images of certain dimensions from masking the cross.

| Before      | After      |
| ----------- | ---------- |
| <img width="168" alt="Screenshot 2023-08-15 at 09 50 46" src="https://github.com/guardian/prosemirror-elements/assets/33927854/ca946591-ece6-4f5e-aadc-78e3c74831bf"> | <img width="168" alt="Screenshot 2023-08-15 at 09 50 28" src="https://github.com/guardian/prosemirror-elements/assets/33927854/bb7ae64c-4443-4c08-a4a0-041c73a5be41"> |

## How to test
You should be able to run the demo and add/remove images from the cartoon element with no trouble.
