### PR TITLE
feat: Introduce initial component for editing Recipe Element types

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -25,6 +25,7 @@ import {
   deprecatedElement,
   membershipElement,
   pullquoteElement,
+  recipeElement,
   richlinkElement,
   tableElement,
   transformElementOut,
@@ -64,6 +65,7 @@ import {
   sampleMap,
   sampleMembership,
   samplePullquote,
+  sampleRecipe,
   sampleRichLink,
   sampleTable,
   sampleTweet,
@@ -81,6 +83,7 @@ const demoImageElementName = "demo-image-element";
 const codeElementName = "code";
 const formElementName = "form";
 const pullquoteElementName = "pullquote";
+const recipeElementName = "recipe";
 const richlinkElementName = "rich-link";
 const videoElementName = "video";
 const mapElementName = "map";
@@ -105,6 +108,7 @@ type Name =
   | typeof codeElementName
   | typeof formElementName
   | typeof pullquoteElementName
+  | typeof recipeElementName
   | typeof richlinkElementName
   | typeof interactiveElementName
   | typeof videoElementName
@@ -195,6 +199,7 @@ const {
     code: codeElement,
     form: deprecatedElement,
     pullquote: pullquoteElement,
+    recipe: recipeElement,
     "rich-link": richlinkElement,
     video: createStandardElement({
       createCaptionPlugins,
@@ -411,6 +416,7 @@ const createEditor = (server: CollabServer) => {
     { label: "Form", name: formElementName, values: sampleForm },
     { label: "Vine", name: vineElementName, values: sampleVine },
     { label: "Tweet", name: tweetElementName, values: sampleTweet },
+    { label: "Recipe", name: recipeElementName, values: sampleRecipe },
     { label: "Recipe atom", name: contentAtomName, values: sampleContentAtom },
     {
       label: "Interactive atom",

--- a/demo/sampleElements.ts
+++ b/demo/sampleElements.ts
@@ -351,6 +351,10 @@ export const sampleForm = {
   data: `{"fields": {"id": "1956117", "alt": "Formstack form embed", "source": "Formstack", "viewKey": "tOfqZ3Kxj2", "iframeUrl": "https://profile.theguardian.com/form/embed/1956117-tOfqZ3Kxj2", "scriptUrl": "https://assets-secure.guim.co.uk/javascripts/vendor/formstack-interactive/0.1/boot.03e0d0dfd005f551febc8caa63566ca4.js", "scriptName": "iframe-wrapper", "signedOutAltText":"","originalUrl":"https://www.formstack.com/forms/?2353564-tOfqZ3Kxj2/","html":"<<REDACTED>>","isMandatory":false}}`,
 };
 
+export const sampleRecipe = {
+  recipeJson: "",
+};
+
 export const sampleVine = {
   type: "vine",
   data: `{"fields": {"alt":"Clinton shimmying","html":"<<REDACTED>>","title":"💃 #HillaryClinton #DebateNight #cnn","width":"600","height":"600","source":"Vine","authorUrl":"https://vine.co/u/1038266807917965312","authorName":"<<REDACTED>>","isMandatory":"true","originalUrl":"https://vine.co/v/5rz0naaaEJP"},"assets":[{"url":"https://v.cdn.vine.co/r/thumbs/FE1264FB421392386538297552896_54f5af670bb.31.0.C52609C2-9D12-40AB-BDAD-6B628DE40259.mp4.jpg?versionId=Doo_Qq2hMbJZGgI44BU5RbfRouNNZQSY","fields":{"width":"480","height":"480"},"mimeType":"image/jpeg","assetType":"image"}]}`,

--- a/src/elements/helpers/transform.ts
+++ b/src/elements/helpers/transform.ts
@@ -9,6 +9,7 @@ import { transformElement as imageElementTransform } from "../image/imageElement
 import { transformElement as interactiveElementTransform } from "../interactive/interactiveDataTransformer";
 import { transformElement as membershipElementTransform } from "../membership/membershipDataTransformer";
 import type { pullquoteFields } from "../pullquote/PullquoteSpec";
+import type { recipeFields } from "../recipe/RecipeElementSpec";
 import type { richlinkFields } from "../rich-link/RichlinkSpec";
 import { transformElement as standardElementTransform } from "../standard/standardDataTransformer";
 import type { tableFields } from "../table/TableSpec";
@@ -30,6 +31,7 @@ const transformMap = {
   "rich-link": defaultElementTransform<typeof richlinkFields>({
     isMandatory: true,
   }),
+  recipe: defaultElementTransform<typeof recipeFields>(),
   video: standardElementTransform,
   audio: standardElementTransform,
   document: standardElementTransform,

--- a/src/elements/recipe/RecipeElementForm.tsx
+++ b/src/elements/recipe/RecipeElementForm.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
+import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+import { recipeFields } from "./RecipeElementSpec";
+
+export const RecipeElementTestId = "RecipeElement";
+
+export const recipeElement = createReactElementSpec(
+  recipeFields,
+  ({ fields }) => (
+    <FieldLayoutVertical data-cy={RecipeElementTestId}>
+      <FieldWrapper headingLabel="Recipe" field={fields.recipeJson} />
+    </FieldLayoutVertical>
+  )
+);

--- a/src/elements/recipe/RecipeElementSpec.tsx
+++ b/src/elements/recipe/RecipeElementSpec.tsx
@@ -1,0 +1,12 @@
+import { createTextField } from "../../plugin/fieldViews/TextFieldView";
+import { required } from "../../plugin/helpers/validation";
+
+export const recipeFields = {
+  recipeJson: createTextField({
+    rows: 4,
+    isResizeable: true,
+    isCode: true,
+    validators: [required("empty recipe field")],
+    absentOnEmpty: true,
+  }),
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export { createCalloutElement } from "./elements/callout/Callout";
 export { codeElement } from "./elements/code/CodeElementForm";
 export { createImageElement } from "./elements/image/ImageElementForm";
 export { createStandardElement } from "./elements/standard/StandardForm";
+export { recipeElement } from "./elements/recipe/RecipeElementForm";
 export { richlinkElement } from "./elements/rich-link/RichlinkForm";
 export { createInteractiveElement } from "./elements/interactive/InteractiveForm";
 export { tableElement } from "./elements/table/TableForm";


### PR DESCRIPTION
Introducing an initial component for editing of Recipe type Elements using a prosemirror component.

Naive just edit the recipeJson in a text area developer UX.

Installing this component behind a Composer feature flag allows us to demo the end to end work flow for these elements.
This is independent of the larger refactor #313 to pull these components into Composer.

<img width="774" alt="Screenshot 2023-10-04 at 15 02 16" src="https://github.com/guardian/prosemirror-elements/assets/150238/c1b8940b-4317-4f1f-8093-ae1c01ff85b3">

## What does this change?

Introduce a new component and adds it to the demo page.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

The recipe component is available to Composer, allowing changes to these elements to be round tripped through Composer.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [ ] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [ ] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
