### PR TITLE
feat: Export element helpers, but not elements

### DIFF
--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -6,7 +6,7 @@ import {
   trimHtml,
 } from "../../src/plugin/helpers/test";
 import { elementWrapperTestId } from "../../src/renderers/react/ElementWrapper";
-import { getFieldViewTestId } from "../../src/renderers/react/FieldView";
+import { getFieldViewTestId } from "../../src/renderers/react/FieldComponent";
 
 export const visitRoot = () =>
   cy.visit("/", {

--- a/demo/helpers.ts
+++ b/demo/helpers.ts
@@ -1,8 +1,13 @@
 import type { EditorState, Transaction } from "prosemirror-state";
 import { Plugin } from "prosemirror-state";
-import type { Image, MediaPayload, SetImage, SetMedia } from "../src";
 import type { DemoSetMedia } from "../src/elements/demo-image/DemoImageElement";
 import type { Asset } from "../src/elements/helpers/defaultTransform";
+import type {
+  Image,
+  MediaPayload,
+  SetImage,
+  SetMedia,
+} from "../src/elements/helpers/types/Media";
 
 type GridAsset = {
   mimeType: string; // e.g. ("image/jpeg", "image/png" or "image/svg+xml")

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -9,29 +9,26 @@ import { Schema } from "prosemirror-model";
 import { schema as basicSchema, marks } from "prosemirror-schema-basic";
 import { EditorState } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
-import {
-  buildElementPlugin,
-  codeElement,
-  commentElement,
-  createCalloutElement,
-  createCartoonElement,
-  createContentAtomElement,
-  createDemoImageElement,
-  createEmbedElement,
-  createImageElement,
-  createInteractiveElement,
-  createStandardElement,
-  createTweetElement,
-  deprecatedElement,
-  membershipElement,
-  pullquoteElement,
-  recipeElement,
-  richlinkElement,
-  tableElement,
-  transformElementOut,
-  undefinedDropdownValue,
-} from "../src";
+import { buildElementPlugin, undefinedDropdownValue } from "../src";
+import { createCalloutElement } from "../src/elements/callout/Callout";
+import { createCartoonElement } from "../src/elements/cartoon/CartoonForm";
+import { codeElement } from "../src/elements/code/CodeElementForm";
+import { commentElement } from "../src/elements/comment/CommentForm";
+import { createContentAtomElement } from "../src/elements/content-atom/ContentAtomForm";
+import { createDemoImageElement } from "../src/elements/demo-image/DemoImageElementForm";
+import { deprecatedElement } from "../src/elements/deprecated/DeprecatedForm";
+import { createEmbedElement } from "../src/elements/embed/EmbedForm";
+import { transformElementOut } from "../src/elements/helpers/transform";
 import type { MediaPayload } from "../src/elements/helpers/types/Media";
+import { createImageElement } from "../src/elements/image/ImageElementForm";
+import { createInteractiveElement } from "../src/elements/interactive/InteractiveForm";
+import { membershipElement } from "../src/elements/membership/MembershipForm";
+import { pullquoteElement } from "../src/elements/pullquote/PullquoteForm";
+import { recipeElement } from "../src/elements/recipe/RecipeElementForm";
+import { richlinkElement } from "../src/elements/rich-link/RichlinkForm";
+import { createStandardElement } from "../src/elements/standard/StandardForm";
+import { tableElement } from "../src/elements/table/TableForm";
+import { createTweetElement } from "../src/elements/tweet/TweetForm";
 import {
   createParsers,
   docToHtml,

--- a/src/editorial-source-components/FieldWrapper.tsx
+++ b/src/editorial-source-components/FieldWrapper.tsx
@@ -1,7 +1,7 @@
 import type { ValidationError } from "../plugin/elementSpec";
-import type { FieldView as TFieldView } from "../plugin/fieldViews/FieldView";
+import type { FieldView } from "../plugin/fieldViews/FieldView";
 import type { Field } from "../plugin/types/Element";
-import { FieldView } from "../renderers/react/FieldView";
+import { FieldComponent } from "../renderers/react/FieldComponent";
 import { InputHeading } from "./InputHeading";
 
 type Props<F> = {
@@ -15,7 +15,7 @@ type Props<F> = {
   headingDirection?: "row" | "column";
 };
 
-export const FieldWrapper = <F extends Field<TFieldView<unknown>>>({
+export const FieldWrapper = <F extends Field<FieldView<unknown>>>({
   field,
   errors,
   headingLabel,
@@ -34,6 +34,6 @@ export const FieldWrapper = <F extends Field<TFieldView<unknown>>>({
       errors={(errors ? errors : field.errors).map((e) => e.error)}
       headingDirection={headingDirection}
     />
-    <FieldView field={field} hasValidationErrors={!!field.errors.length} />
+    <FieldComponent field={field} hasValidationErrors={!!field.errors.length} />
   </div>
 );

--- a/src/elements/callout/Callout.tsx
+++ b/src/elements/callout/Callout.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import { neutral, space } from "@guardian/src-foundations";
 import { textSans } from "@guardian/src-foundations/typography";
 import React, { useEffect, useState } from "react";
-import { createCheckBox } from "../../plugin/fieldViews/CheckboxFieldView";
+import { createCheckBoxField } from "../../plugin/fieldViews/CheckboxFieldView";
 import {
   createCustomDropdownField,
   createCustomField,
@@ -42,15 +42,15 @@ export const calloutFields = {
   ),
   isNonCollapsible: createCustomField(false, true),
   tagId: createTextField(),
-  useDefaultPrompt: createCheckBox(true),
+  useDefaultPrompt: createCheckBoxField(true),
   overridePrompt: createTextField({
     placeholder: "Don't show prompt",
   }),
-  useDefaultTitle: createCheckBox(true),
+  useDefaultTitle: createCheckBoxField(true),
   overrideTitle: createTextField({
     placeholder: "Don't show title",
   }),
-  useDefaultDescription: createCheckBox(true),
+  useDefaultDescription: createCheckBoxField(true),
   overrideDescription: createRichTextField({
     placeholder: "Don't show description",
     isResizeable: true,

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -1,5 +1,5 @@
 import { exampleSetup } from "prosemirror-example-setup";
-import { createCheckBox } from "../../plugin/fieldViews/CheckboxFieldView";
+import { createCheckBoxField } from "../../plugin/fieldViews/CheckboxFieldView";
 import {
   createCustomDropdownField,
   createCustomField,
@@ -79,7 +79,7 @@ export const createImageFields = (
         onCropImage,
       }
     ),
-    useSrc: createCheckBox(false),
+    useSrc: createCheckBoxField(false),
     optionDropdown: createDropDownField(
       [
         { text: "Option 1", value: "opt1" },

--- a/src/elements/demo-image/DemoImageElementForm.tsx
+++ b/src/elements/demo-image/DemoImageElementForm.tsx
@@ -4,7 +4,7 @@ import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
 import type { CustomField } from "../../plugin/types/Element";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
-import { getFieldViewTestId } from "../../renderers/react/FieldView";
+import { getFieldViewTestId } from "../../renderers/react/FieldComponent";
 import { useCustomFieldState } from "../../renderers/react/useCustomFieldViewState";
 import { createImageFields } from "./DemoImageElement";
 import type { DemoSetMedia } from "./DemoImageElement";

--- a/src/elements/helpers/__tests__/transformFixtures.spec.ts
+++ b/src/elements/helpers/__tests__/transformFixtures.spec.ts
@@ -1,19 +1,17 @@
 import { flow, noop, omit } from "lodash";
-import {
-  buildElementPlugin,
-  commentElement,
-  createContentAtomElement,
-  createEmbedElement,
-  createImageElement,
-  createInteractiveElement,
-  createStandardElement,
-  createTweetElement,
-  deprecatedElement,
-  membershipElement,
-  pullquoteElement,
-  richlinkElement,
-  tableElement,
-} from "../../..";
+import { buildElementPlugin } from "../../..";
+import { commentElement } from "../../comment/CommentForm";
+import { createContentAtomElement } from "../../content-atom/ContentAtomForm";
+import { deprecatedElement } from "../../deprecated/DeprecatedForm";
+import { createEmbedElement } from "../../embed/EmbedForm";
+import { createImageElement } from "../../image/ImageElementForm";
+import { createInteractiveElement } from "../../interactive/InteractiveForm";
+import { membershipElement } from "../../membership/MembershipForm";
+import { pullquoteElement } from "../../pullquote/PullquoteForm";
+import { richlinkElement } from "../../rich-link/RichlinkForm";
+import { createStandardElement } from "../../standard/StandardForm";
+import { tableElement } from "../../table/TableForm";
+import { createTweetElement } from "../../tweet/TweetForm";
 import { createTestSchema } from "../test";
 import { transformElementIn, transformElementOut } from "../transform";
 import { allElementFixtures } from "./fixtures";

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,21 +6,32 @@ export type {
 } from "./plugin/types/Element";
 export { buildElementPlugin } from "./plugin/element";
 export { fieldGroupName, isProseMirrorElement } from "./plugin/nodeSpec";
+export type { CustomField, Field } from "./plugin/types/Element";
+
 export type { Options } from "./plugin/fieldViews/DropdownFieldView";
 export type { FieldView } from "./plugin/fieldViews/FieldView";
-export type { CustomField, Field } from "./plugin/types/Element";
-export { createStore } from "./renderers/react/store";
-export { TelemetryContext } from "./renderers/react/TelemetryContext";
-export { useCustomFieldState } from "./renderers/react/useCustomFieldViewState";
+export { createTextField } from "./plugin/fieldViews/TextFieldView";
+export { createRichTextField } from "./plugin/fieldViews/RichTextFieldView";
+export { createCheckBoxField } from "./plugin/fieldViews/CheckboxFieldView";
 export {
   createCustomDropdownField,
   createCustomField,
 } from "./plugin/fieldViews/CustomFieldView";
 export { createFlatRichTextField } from "./plugin/fieldViews/RichTextFieldView";
-export { createTextField } from "./plugin/fieldViews/TextFieldView";
-export { htmlMaxLength, htmlRequired } from "./plugin/helpers/validation";
-export { createReactElementSpec } from "./renderers/react/createReactElementSpec";
-export { CustomDropdownView } from "./renderers/react/customFieldViewComponents/CustomDropdownView";
-export { maxLength, required } from "./plugin/helpers/validation";
+
+export {
+  htmlMaxLength,
+  htmlRequired,
+  maxLength,
+  required,
+  dropDownRequired,
+} from "./plugin/helpers/validation";
 export { undefinedDropdownValue } from "./plugin/helpers/constants";
+
+export { createStore } from "./renderers/react/store";
+export { TelemetryContext } from "./renderers/react/TelemetryContext";
+export { useCustomFieldState } from "./renderers/react/useCustomFieldViewState";
+export { createReactElementSpec } from "./renderers/react/createReactElementSpec";
 export { CustomCheckboxView } from "./renderers/react/customFieldViewComponents/CustomCheckboxView";
+export { CustomDropdownView } from "./renderers/react/customFieldViewComponents/CustomDropdownView";
+export { FieldComponent } from "./renderers/react/FieldComponent";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export type { FieldValidator } from "./plugin/elementSpec";
+export type { FieldValidator, ValidationError } from "./plugin/elementSpec";
 export type { FieldNameToValueMap } from "./plugin/helpers/fieldView";
 export type {
   FieldDescriptions,
@@ -7,7 +7,7 @@ export type {
 export { buildElementPlugin } from "./plugin/element";
 export { fieldGroupName, isProseMirrorElement } from "./plugin/nodeSpec";
 export type { Options } from "./plugin/fieldViews/DropdownFieldView";
-export type { FieldView as TFieldView } from "./plugin/fieldViews/FieldView";
+export type { FieldView } from "./plugin/fieldViews/FieldView";
 export type { CustomField, Field } from "./plugin/types/Element";
 export { createStore } from "./renderers/react/store";
 export { TelemetryContext } from "./renderers/react/TelemetryContext";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,36 +1,26 @@
-export { buildElementPlugin } from "./plugin/element";
-export { createDemoImageElement } from "./elements/demo-image/DemoImageElementForm";
-export { createEmbedElement } from "./elements/embed/EmbedForm";
+export type { FieldValidator } from "./plugin/elementSpec";
+export type { FieldNameToValueMap } from "./plugin/helpers/fieldView";
 export type {
-  YoutubeUrl,
-  TwitterUrl,
-} from "./elements/embed/embedComponents/embedUtils";
-export { pullquoteElement } from "./elements/pullquote/PullquoteForm";
-export { createCalloutElement } from "./elements/callout/Callout";
-export { codeElement } from "./elements/code/CodeElementForm";
-export { createImageElement } from "./elements/image/ImageElementForm";
-export { createStandardElement } from "./elements/standard/StandardForm";
-export { recipeElement } from "./elements/recipe/RecipeElementForm";
-export { richlinkElement } from "./elements/rich-link/RichlinkForm";
-export { createInteractiveElement } from "./elements/interactive/InteractiveForm";
-export { tableElement } from "./elements/table/TableForm";
-export { deprecatedElement } from "./elements/deprecated/DeprecatedForm";
-export { createTweetElement } from "./elements/tweet/TweetForm";
-export { commentElement } from "./elements/comment/CommentForm";
-export { membershipElement } from "./elements/membership/MembershipForm";
-export { createContentAtomElement } from "./elements/content-atom/ContentAtomForm";
-export {
-  transformElementIn,
-  transformElementOut,
-} from "./elements/helpers/transform";
-export { useTyperighterAttr } from "./elements/helpers/typerighter";
+  FieldDescriptions,
+  FieldNameToField,
+} from "./plugin/types/Element";
+export { buildElementPlugin } from "./plugin/element";
 export { fieldGroupName, isProseMirrorElement } from "./plugin/nodeSpec";
 export type { Options } from "./plugin/fieldViews/DropdownFieldView";
-export { createCartoonElement } from "./elements/cartoon/CartoonForm";
+export type { FieldView as TFieldView } from "./plugin/fieldViews/FieldView";
+export type { CustomField, Field } from "./plugin/types/Element";
+export { createStore } from "./renderers/react/store";
+export { TelemetryContext } from "./renderers/react/TelemetryContext";
+export { useCustomFieldState } from "./renderers/react/useCustomFieldViewState";
+export {
+  createCustomDropdownField,
+  createCustomField,
+} from "./plugin/fieldViews/CustomFieldView";
+export { createFlatRichTextField } from "./plugin/fieldViews/RichTextFieldView";
+export { createTextField } from "./plugin/fieldViews/TextFieldView";
+export { htmlMaxLength, htmlRequired } from "./plugin/helpers/validation";
+export { createReactElementSpec } from "./renderers/react/createReactElementSpec";
+export { CustomDropdownView } from "./renderers/react/customFieldViewComponents/CustomDropdownView";
+export { maxLength, required } from "./plugin/helpers/validation";
 export { undefinedDropdownValue } from "./plugin/helpers/constants";
-export type {
-  SetImage,
-  Image,
-  SetMedia,
-  MediaPayload,
-} from "./elements/helpers/types/Media";
+export { CustomCheckboxView } from "./renderers/react/customFieldViewComponents/CustomCheckboxView";

--- a/src/plugin/fieldViews/CheckboxFieldView.ts
+++ b/src/plugin/fieldViews/CheckboxFieldView.ts
@@ -11,7 +11,7 @@ export interface CheckboxFieldDescription
   type: typeof CheckboxFieldView.fieldType;
 }
 
-export const createCheckBox = (
+export const createCheckBoxField = (
   defaultValue: boolean,
   validators?: FieldValidator[]
 ): CheckboxFieldDescription => ({

--- a/src/renderers/react/FieldComponent.tsx
+++ b/src/renderers/react/FieldComponent.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import { Editor } from "../../editorial-source-components/Editor";
-import type { FieldView as TFieldView } from "../../plugin/fieldViews/FieldView";
+import type { FieldView } from "../../plugin/fieldViews/FieldView";
 import type { Field } from "../../plugin/types/Element";
 
 type Props<F extends Field<unknown>> = {
@@ -10,7 +10,7 @@ type Props<F extends Field<unknown>> = {
 
 export const getFieldViewTestId = (name: string) => `FieldView-${name}`;
 
-export const FieldView = <F extends Field<TFieldView<unknown>>>({
+export const FieldComponent = <F extends Field<FieldView<unknown>>>({
   field,
   hasValidationErrors,
 }: Props<F>) => {

--- a/src/renderers/react/customFieldViewComponents/CustomCheckboxView.tsx
+++ b/src/renderers/react/customFieldViewComponents/CustomCheckboxView.tsx
@@ -1,6 +1,6 @@
 import { CustomCheckbox } from "../../../editorial-source-components/CustomCheckbox";
 import type { CustomField } from "../../../plugin/types/Element";
-import { getFieldViewTestId } from "../FieldView";
+import { getFieldViewTestId } from "../FieldComponent";
 import { useCustomFieldState } from "../useCustomFieldViewState";
 
 type CustomCheckboxViewProps = {

--- a/src/renderers/react/customFieldViewComponents/CustomDropdownView.tsx
+++ b/src/renderers/react/customFieldViewComponents/CustomDropdownView.tsx
@@ -1,7 +1,7 @@
 import { CustomDropdown } from "../../../editorial-source-components/CustomDropdown";
 import type { Options } from "../../../plugin/fieldViews/DropdownFieldView";
 import type { CustomField } from "../../../plugin/types/Element";
-import { getFieldViewTestId } from "../FieldView";
+import { getFieldViewTestId } from "../FieldComponent";
 import { useCustomFieldState } from "../useCustomFieldViewState";
 
 type CustomDropdownViewProps = {


### PR DESCRIPTION
## What does this change?

Exports the necessary helpers to create elements with `prosemirror-elements` – but not the library elements themselves.

We think it's better to define these closer to our CMS to improve the feedback loop when we're iterating on element structure and UI changes.

What we do with the elements as they stand in the repo can be addressed in a follow-up PR. I'd be tempted to keep a few definitions around as they're useful in the sandbox – but we might clearly label them to make it clear they're not used in production. (Not that they could be, as they are no longer exported?)

## How to test

- The automated tests should pass.
- Take a look at the new exports in [index.ts](https://github.com/guardian/prosemirror-elements/blob/f095a75916f5a5cb153c3b20de14674c3012fafb/demo/index.ts) – all make sense?
- Take a look at the [companion PR](https://github.com/guardian/flexible-content/pull/4410) in Composer. Following the instructions for element testing in local applications in the README, import a local build of this branch into Composer's branch (`jsh/elements-in-composer`). Does the application work as intended?

Happy to pair on the above!