### PR TITLE
feat: Export repeater field

### DIFF
--- a/.changeset/pretty-ducks-suffer.md
+++ b/.changeset/pretty-ducks-suffer.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-elements": minor
+---
+
+Add repeater field to package exports

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export {
   createCustomField,
 } from "./plugin/fieldViews/CustomFieldView";
 export { createFlatRichTextField } from "./plugin/fieldViews/RichTextFieldView";
+export { createRepeaterField } from "./plugin/fieldViews/RepeaterFieldView";
 
 export {
   htmlMaxLength,


### PR DESCRIPTION
## What does this change?

Exports `createRepeaterField`, which should really have been in #313. 

## How to test

You should be able to use `createRepeaterField` in consuming projects.