### PR TITLE
Remove style that hasn't been applied due to typo

### DIFF
--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -43,7 +43,6 @@ const Panel = styled("div")<{ isSelected: boolean }>`
   flex-grow: 1;
   overflow: hidden;
   padding: ${space[3]}px;
-  position: relative;
 
   * {
     ::selection {

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -43,7 +43,7 @@ const Panel = styled("div")<{ isSelected: boolean }>`
   flex-grow: 1;
   overflow: hidden;
   padding: ${space[3]}px;
-  postion: relative;
+  position: relative;
 
   * {
     ::selection {


### PR DESCRIPTION
~Ameliorate erratum~

Actually the styles have been working fine all this time so probably better just to remove the style that hasn't been applied rather than cause unintended side-effects by fixing the typo.