### PR TITLE
Add minimum rows option for nestedElementField

### DIFF
--- a/src/elements/alt-style/AltStyleElementSpec.tsx
+++ b/src/elements/alt-style/AltStyleElementSpec.tsx
@@ -14,9 +14,9 @@ export const altStyleFields = {
     content: createNestedElementField({
       placeholder: "Don't show description",
       content: "block*",
-      isResizeable: true,
       marks: "em strong link",
       attrs: useTyperighterAttrs,
+      minRows: 4
     }),
   }),
 };

--- a/src/elements/alt-style/AltStyleElementSpec.tsx
+++ b/src/elements/alt-style/AltStyleElementSpec.tsx
@@ -16,7 +16,7 @@ export const altStyleFields = {
       content: "block*",
       marks: "em strong link",
       attrs: useTyperighterAttrs,
-      minRows: 4
+      minRows: 6,
     }),
   }),
 };

--- a/src/plugin/fieldViews/NestedElementFieldView.ts
+++ b/src/plugin/fieldViews/NestedElementFieldView.ts
@@ -90,7 +90,6 @@ export class NestedElementFieldView extends ProseMirrorFieldView {
     { placeholder, isResizeable, minRows }: NestedElementFieldDescription,
     // Specify plugins of which the field should have its own copy
     allowedPlugins: PluginKey[] = []
-    // Initial height of the field, in rows
   ) {
     super(
       node,

--- a/src/plugin/fieldViews/NestedElementFieldView.ts
+++ b/src/plugin/fieldViews/NestedElementFieldView.ts
@@ -4,10 +4,10 @@ import type { DecorationSource, EditorView } from "prosemirror-view";
 import type { FieldValidator } from "../elementSpec";
 import { pluginKey } from "../helpers/constants";
 import type { PlaceholderOption } from "../helpers/placeholder";
+import { waitForNextLayout } from "../helpers/util";
 import { FieldContentType } from "./FieldView";
 import type { AbstractTextFieldDescription } from "./ProseMirrorFieldView";
 import { ProseMirrorFieldView } from "./ProseMirrorFieldView";
-import { waitForNextLayout } from "../helpers/util";
 
 type NestedElementOptions = {
   absentOnEmpty?: boolean;
@@ -44,7 +44,7 @@ export const createNestedElementField = ({
   placeholder,
   isResizeable,
   allowedPlugins = [],
-  minRows
+  minRows = 4,
 }: NestedElementOptions): NestedElementFieldDescription => {
   return {
     type: NestedElementFieldView.fieldType,
@@ -56,7 +56,7 @@ export const createNestedElementField = ({
     placeholder,
     isResizeable,
     allowedPlugins,
-    minRows
+    minRows,
   };
 };
 
@@ -89,7 +89,7 @@ export class NestedElementFieldView extends ProseMirrorFieldView {
     decorations: DecorationSource,
     { placeholder, isResizeable, minRows }: NestedElementFieldDescription,
     // Specify plugins of which the field should have its own copy
-    allowedPlugins: PluginKey[] = [],
+    allowedPlugins: PluginKey[] = []
     // Initial height of the field, in rows
   ) {
     super(
@@ -104,7 +104,7 @@ export class NestedElementFieldView extends ProseMirrorFieldView {
           : [pluginKey, ...allowedPlugins].includes(plugin.spec.key)
       ),
       placeholder,
-      isResizeable,
+      isResizeable
     );
 
     if (this.innerEditorView) {
@@ -135,7 +135,7 @@ export class NestedElementFieldView extends ProseMirrorFieldView {
           }px`;
           domElement.style.minHeight = initialInputHeightPx;
         }
-      })
+      });
     }
     this.fieldViewElement.classList.add(
       "ProseMirrorElements__NestedElementField"


### PR DESCRIPTION
## What does this change?
This adds an option to specify the minimum rows for a `nestedElementField`.  This will allow us to hint to Composer users that a field is intended for multiline text. `minRows` for the `nestedElementField` applies a `min-height` style to the relevant field using a calculation based on the browser's `line-height`.

I've added this to the `NestedElementField` rather than the `ProseMirrorFieldView` it extends because we haven't got a use case for `minRows` in the `RichTextField` yet (which also extends `ProseMirrorFieldView`) - additionally, the `TextField` (which already supports rows) also includes `maxRows` and `isMultiline` which I was reluctant to add as options for all text fields. I've avoided these questions by just adding `minRows` to the place where we definitely want it.

## How to test
1. Run the `prosemirror-elements` demo (https://prosemirror-elements.local.dev-gutools.co.uk/) locally, by running `yarn start`.
2. Add the 'Alt Style' element (one of the many buttons in the demo)
3. Does the content field appear to have a min-height of around six rows?
4. Does it expand to fit the content you type if you go beyond six rows? (It should)