### PR TITLE
Support Typerighter in repeater nodes by default

### DIFF
--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -1,6 +1,7 @@
 import OrderedMap from "orderedmap";
 import type { Node, NodeSpec, NodeType, Schema } from "prosemirror-model";
 import { DOMParser } from "prosemirror-model";
+import { useTyperighterAttrs } from "../elements/helpers/typerighter";
 import { FieldContentType } from "./fieldViews/FieldView";
 import type { RepeaterFieldDescription } from "./fieldViews/RepeaterFieldView";
 import {
@@ -13,7 +14,6 @@ import type { FieldNameToValueMap } from "./helpers/fieldView";
 import { fieldTypeToViewMap } from "./helpers/fieldView";
 import { getRepeaterID } from "./helpers/util";
 import type { FieldDescription, FieldDescriptions } from "./types/Element";
-import { useTyperighterAttrs } from "../elements/helpers/typerighter";
 
 // An attribute added to Element nodes to identify them as such.
 export const elementNodeAttr = "isProseMirrorElement";
@@ -214,7 +214,7 @@ export const getNodeSpecForField = (
           content: `${childNodeName}*`,
           toDOM: getDefaultToDOMForRepeaterNode(parentNodeName),
           parseDOM: getDefaultParseDOMForLeafNode(parentNodeName),
-          attrs: {...useTyperighterAttrs},
+          attrs: { ...useTyperighterAttrs },
         },
         [childNodeName]: {
           group: fieldGroupName,
@@ -223,7 +223,7 @@ export const getNodeSpecForField = (
           parseDOM: getDefaultParseDOMForRepeaterChildNode(childNodeName),
           attrs: {
             [RepeaterFieldMapIDKey]: {},
-            ...useTyperighterAttrs
+            ...useTyperighterAttrs,
           },
         },
         ...extraFields,

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -13,6 +13,7 @@ import type { FieldNameToValueMap } from "./helpers/fieldView";
 import { fieldTypeToViewMap } from "./helpers/fieldView";
 import { getRepeaterID } from "./helpers/util";
 import type { FieldDescription, FieldDescriptions } from "./types/Element";
+import { useTyperighterAttrs } from "../elements/helpers/typerighter";
 
 // An attribute added to Element nodes to identify them as such.
 export const elementNodeAttr = "isProseMirrorElement";
@@ -213,7 +214,7 @@ export const getNodeSpecForField = (
           content: `${childNodeName}*`,
           toDOM: getDefaultToDOMForRepeaterNode(parentNodeName),
           parseDOM: getDefaultParseDOMForLeafNode(parentNodeName),
-          attrs: {},
+          attrs: {...useTyperighterAttrs},
         },
         [childNodeName]: {
           group: fieldGroupName,
@@ -222,6 +223,7 @@ export const getNodeSpecForField = (
           parseDOM: getDefaultParseDOMForRepeaterChildNode(childNodeName),
           attrs: {
             [RepeaterFieldMapIDKey]: {},
+            ...useTyperighterAttrs
           },
         },
         ...extraFields,


### PR DESCRIPTION
## What does this change?
This adds typerighter support in repeater nodes by default. This means that the key takeaways element will support Typerighter.

![image](https://github.com/guardian/prosemirror-elements/assets/34686302/d14e151b-1cd4-4279-8e75-4de95cfc1541)


## How to test
1. Publish this branch locally with `yalc publish`
2. Use in the composer directory of flexible-content with `yalc add @guardian/prosemirror-elements`
3. Activate the key takeaways feature switch
4. Add some incorrect text in the content field of the key takeaways element
5. Run Typerighter (you may need to visit a CODE domain to be authorised)
6. Are the mistakes highlighted by Typerighter?