### PR TITLE
Add more control over repeater child nodes

### DIFF
--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -113,8 +113,9 @@ export const addImageElement = (values: Record<string, unknown> = {}) => {
   });
 };
 
-export const clickButton = (id: string) =>
-  cy.get(`button${selectDataCy(id)}`).click();
+export const getButton = (id: string) => cy.get(`button${selectDataCy(id)}`);
+
+export const clickButton = (id: string) => getButton(id).click();
 
 export const assertEditorFocus = (shouldBeFocused: boolean) => {
   cy.window().then((win: WindowType) => {

--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -113,6 +113,16 @@ export const addImageElement = (values: Record<string, unknown> = {}) => {
   });
 };
 
+export const addAltStyleElement = (values: Record<string, unknown> = {}) => {
+  cy.window().then((win: WindowType) => {
+    const { view, insertElement } = win.PM_ELEMENTS;
+    insertElement({ elementName: "alt-style", values })(
+      view.state,
+      view.dispatch
+    );
+  });
+};
+
 export const getButton = (id: string) => cy.get(`button${selectDataCy(id)}`);
 
 export const clickButton = (id: string) => getButton(id).click();

--- a/cypress/tests/AltStylesElement.cy.ts
+++ b/cypress/tests/AltStylesElement.cy.ts
@@ -1,11 +1,14 @@
 import { sampleAltStylesElement } from "../../demo/sampleElements";
 import {
   addChildTestId,
+  moveChildDownTestId,
+  moveChildUpTestId,
   removeChildTestId,
 } from "../../src/renderers/react/WrapperControls";
 import {
   addAltStyleElement,
   getButton,
+  getElementRichTextField,
   selectDataCy,
   visitRoot,
 } from "../helpers/editor";
@@ -13,25 +16,85 @@ import {
 describe("AltStyleElement", () => {
   beforeEach(visitRoot);
 
+  const altStyleSelector = `div${selectDataCy("AltStyleElement")}`;
+
+  it("should add repeater children", () => {
+    addAltStyleElement(sampleAltStylesElement);
+    cy.get(altStyleSelector).children().should("have.length", 1);
+    const addRepeaterButtons = getButton(addChildTestId);
+    addRepeaterButtons.click();
+    cy.get(altStyleSelector).children().should("have.length", 2);
+  });
+
   it("should remove repeater children", () => {
     addAltStyleElement(sampleAltStylesElement);
     const addRepeaterButtons = getButton(addChildTestId);
     addRepeaterButtons.click();
-    cy.get(`div${selectDataCy("AltStyleElement")}`)
-      .children()
-      .should("have.length", 2);
+    cy.get(altStyleSelector).children().should("have.length", 2);
     getButton(removeChildTestId).first().click();
-    getButton(removeChildTestId).first().click();
-    cy.get(`div${selectDataCy("AltStyleElement")}`)
-      .children()
-      .should("have.length", 1);
+    getButton(removeChildTestId).first().click(); // second click needed to confirm delete
+    cy.get(altStyleSelector).children().should("have.length", 1);
     getButton(removeChildTestId).should("be.disabled"); // because you can't delete the last one
-    // force click to bypass the disabled check
-    getButton(removeChildTestId).first().click({ force: true });
-    getButton(removeChildTestId).first().click({ force: true });
-    // still one left
-    cy.get(`div${selectDataCy("AltStyleElement")}`)
-      .children()
-      .should("have.length", 1);
+    getButton(removeChildTestId).first().click({ force: true }); // force click to bypass the disabled check
+    getButton(removeChildTestId).first().click({ force: true }); // second click needed to confirm delete
+    cy.get(altStyleSelector).children().should("have.length", 1); // still one left
+  });
+
+  const repeaterWithChildren = {
+    repeater: [
+      {
+        title: "A",
+        content: "",
+      },
+      {
+        title: "B",
+        content: "",
+      },
+      {
+        title: "C",
+        content: "",
+      },
+    ],
+  };
+
+  const assertOrderOfTitleFields = (titles: string[]) =>
+    titles.map((title, index) =>
+      getElementRichTextField("title").eq(index).should("have.text", title)
+    );
+
+  it("should move repeater child up", () => {
+    addAltStyleElement(repeaterWithChildren);
+    const moveChildUpButtons = getButton(moveChildUpTestId);
+
+    // try to move A up - should be disabled
+    moveChildUpButtons.first().should("be.disabled");
+    moveChildUpButtons.first().click({ force: true }); // force click to bypass the disabled check
+    assertOrderOfTitleFields(["A", "B", "C"]);
+
+    // try to move B up
+    getButton(moveChildUpTestId).children().eq(1).click();
+    assertOrderOfTitleFields(["B", "A", "C"]);
+
+    // try to move C up
+    getButton(moveChildUpTestId).children().eq(2).click();
+    assertOrderOfTitleFields(["B", "C", "A"]);
+  });
+
+  it("should move repeater child down", () => {
+    addAltStyleElement(repeaterWithChildren);
+    const moveChildDownButtons = getButton(moveChildDownTestId);
+
+    // try to move C down - should be disabled
+    moveChildDownButtons.last().should("be.disabled");
+    moveChildDownButtons.last().click({ force: true }); // force click to bypass the disabled check
+    assertOrderOfTitleFields(["A", "B", "C"]);
+
+    // try to move B down
+    getButton(moveChildDownTestId).children().eq(1).click();
+    assertOrderOfTitleFields(["A", "C", "B"]);
+
+    // try to move A down
+    getButton(moveChildDownTestId).children().eq(0).click();
+    assertOrderOfTitleFields(["C", "A", "B"]);
   });
 });

--- a/cypress/tests/AltStylesElement.cy.ts
+++ b/cypress/tests/AltStylesElement.cy.ts
@@ -1,0 +1,37 @@
+import { sampleAltStylesElement } from "../../demo/sampleElements";
+import {
+  addChildTestId,
+  removeChildTestId,
+} from "../../src/renderers/react/WrapperControls";
+import {
+  addAltStyleElement,
+  getButton,
+  selectDataCy,
+  visitRoot,
+} from "../helpers/editor";
+
+describe("AltStyleElement", () => {
+  beforeEach(visitRoot);
+
+  it("should remove repeater children", () => {
+    addAltStyleElement(sampleAltStylesElement);
+    const addRepeaterButtons = getButton(addChildTestId);
+    addRepeaterButtons.click();
+    cy.get(`div${selectDataCy("AltStyleElement")}`)
+      .children()
+      .should("have.length", 2);
+    getButton(removeChildTestId).first().click();
+    getButton(removeChildTestId).first().click();
+    cy.get(`div${selectDataCy("AltStyleElement")}`)
+      .children()
+      .should("have.length", 1);
+    getButton(removeChildTestId).should("be.disabled"); // because you can't delete the last one
+    // force click to bypass the disabled check
+    getButton(removeChildTestId).first().click({ force: true });
+    getButton(removeChildTestId).first().click({ force: true });
+    // still one left
+    cy.get(`div${selectDataCy("AltStyleElement")}`)
+      .children()
+      .should("have.length", 1);
+  });
+});

--- a/cypress/tests/ImageElement.cy.ts
+++ b/cypress/tests/ImageElement.cy.ts
@@ -597,19 +597,6 @@ describe("ImageElement", () => {
           })
         );
       });
-      it("should add nested repeater elements", () => {
-        addImageElement();
-        clickButton(AddRepeaterButtonId);
-        clickButton(AddNestedRepeaterButtonId);
-        getElementRichTextField("nestedRepeaterText").should("exist");
-      });
-      it("should remove nested repeater elements", () => {
-        addImageElement();
-        clickButton(AddRepeaterButtonId);
-        clickButton(AddNestedRepeaterButtonId);
-        clickButton(RemoveNestedRepeaterButtonId);
-        getElementRichTextField("nestedRepeaterText").should("not.exist");
-      });
       it("should accept values in nested repeater elements", () => {
         addImageElement();
         clickButton(AddRepeaterButtonId);

--- a/cypress/tests/ImageElement.cy.ts
+++ b/cypress/tests/ImageElement.cy.ts
@@ -578,15 +578,27 @@ describe("ImageElement", () => {
 
     describe("Repeater behaviour", () => {
       it("should add repeater elements", () => {
-        addImageElement();
-        clickButton(AddRepeaterButtonId);
-        getElementRichTextField("repeaterText").should("exist");
+        addImageElement({
+          repeater: [
+            {
+              repeaterText: "Example repeater text 1",
+            },
+          ],
+        });
+        getElementRichTextField("repeaterText").its("length").should("eq", 1);
+        const addRepeaterButtons = getButton(AddRepeaterButtonId);
+        addRepeaterButtons.first().click();
+        getElementRichTextField("repeaterText").its("length").should("eq", 2);
       });
       it("should remove repeater elements", () => {
-        addImageElement();
-        const addRepeaterButtons = getButton(AddRepeaterButtonId);
-        addRepeaterButtons.click();
-        addRepeaterButtons.first().click();
+        addImageElement({
+          repeater: [
+            {
+              repeaterText: "Example repeater text 1",
+            },
+            { repeaterText: "Example repeater text 2" },
+          ],
+        });
         getElementRichTextField("repeaterText").its("length").should("eq", 2);
         getButton(RemoveRepeaterButtonId).first().click();
         getElementRichTextField("repeaterText").its("length").should("eq", 1);
@@ -594,27 +606,55 @@ describe("ImageElement", () => {
         getElementRichTextField("repeaterText").should("not.exist");
       });
       it("should accept values in repeater elements", () => {
-        addImageElement();
-        clickButton(AddRepeaterButtonId);
+        addImageElement({
+          repeater: [
+            {
+              repeaterText: "",
+            },
+          ],
+        });
         typeIntoElementField("repeaterText", "Repeater value");
         assertDocHtml(
           getSerialisedHtml({
-            repeaterValue: [{ repeaterText: "Repeater value" }],
+            repeaterValue: [
+              {
+                repeaterText: "Repeater value",
+              },
+            ],
           })
         );
       });
       it("should add nested repeater elements", () => {
-        addImageElement();
-        clickButton(AddRepeaterButtonId);
+        addImageElement({
+          repeater: [
+            {
+              repeaterText: "Example repeater text 1",
+              nestedRepeater: [
+                { nestedRepeaterText: "Example nested repeater text 1" },
+              ],
+            },
+          ],
+        });
+        getElementRichTextField("nestedRepeaterText")
+          .its("length")
+          .should("eq", 1);
         clickButton(AddNestedRepeaterButtonId);
-        getElementRichTextField("nestedRepeaterText").should("exist");
+        getElementRichTextField("nestedRepeaterText")
+          .its("length")
+          .should("eq", 2);
       });
       it("should remove nested repeater elements", () => {
-        addImageElement();
-        clickButton(AddRepeaterButtonId);
-        const addNestedRepeaterButtons = getButton(AddNestedRepeaterButtonId);
-        addNestedRepeaterButtons.click();
-        addNestedRepeaterButtons.first().click();
+        addImageElement({
+          repeater: [
+            {
+              repeaterText: "Example repeater text 1",
+              nestedRepeater: [
+                { nestedRepeaterText: "Example nested repeater text 1" },
+                { nestedRepeaterText: "Example nested repeater text 2" },
+              ],
+            },
+          ],
+        });
         getElementRichTextField("nestedRepeaterText")
           .its("length")
           .should("eq", 2);
@@ -626,9 +666,14 @@ describe("ImageElement", () => {
         getElementRichTextField("nestedRepeaterText").should("not.exist");
       });
       it("should accept values in nested repeater elements", () => {
-        addImageElement();
-        clickButton(AddRepeaterButtonId);
-        clickButton(AddNestedRepeaterButtonId);
+        addImageElement({
+          repeater: [
+            {
+              repeaterText: "",
+              nestedRepeater: [{ nestedRepeaterText: "" }],
+            },
+          ],
+        });
         typeIntoElementField("nestedRepeaterText", "Repeater value");
         assertDocHtml(
           getSerialisedHtml({

--- a/cypress/tests/ImageElement.cy.ts
+++ b/cypress/tests/ImageElement.cy.ts
@@ -12,6 +12,7 @@ import {
   changeTestDecoString,
   clickButton,
   focusElementField,
+  getButton,
   getDocSelection,
   getElementField,
   getElementHeading,
@@ -583,9 +584,14 @@ describe("ImageElement", () => {
       });
       it("should remove repeater elements", () => {
         addImageElement();
-        clickButton(AddRepeaterButtonId);
+        const addRepeaterButtons = getButton(AddRepeaterButtonId);
+        addRepeaterButtons.click();
+        addRepeaterButtons.first().click();
+        getElementRichTextField("repeaterText").its("length").should("eq", 2);
+        getButton(RemoveRepeaterButtonId).first().click();
+        getElementRichTextField("repeaterText").its("length").should("eq", 1);
         clickButton(RemoveRepeaterButtonId);
-        getElementRichTextField("repeaterText").should("not.exist");
+        getElementRichTextField("repeaterText").its("length").should("eq", 1); // because you can't delete the last one
       });
       it("should accept values in repeater elements", () => {
         addImageElement();
@@ -596,6 +602,30 @@ describe("ImageElement", () => {
             repeaterValue: [{ repeaterText: "Repeater value" }],
           })
         );
+      });
+      it("should add nested repeater elements", () => {
+        addImageElement();
+        clickButton(AddRepeaterButtonId);
+        clickButton(AddNestedRepeaterButtonId);
+        getElementRichTextField("nestedRepeaterText").should("exist");
+      });
+      it("should remove nested repeater elements", () => {
+        addImageElement();
+        clickButton(AddRepeaterButtonId);
+        const addNestedRepeaterButtons = getButton(AddNestedRepeaterButtonId);
+        addNestedRepeaterButtons.click();
+        addNestedRepeaterButtons.first().click();
+        getElementRichTextField("nestedRepeaterText")
+          .its("length")
+          .should("eq", 2);
+        getButton(RemoveNestedRepeaterButtonId).first().click();
+        getElementRichTextField("nestedRepeaterText")
+          .its("length")
+          .should("eq", 1);
+        clickButton(RemoveNestedRepeaterButtonId);
+        getElementRichTextField("nestedRepeaterText")
+          .its("length")
+          .should("eq", 1); // because you can't delete the last one
       });
       it("should accept values in nested repeater elements", () => {
         addImageElement();

--- a/cypress/tests/ImageElement.cy.ts
+++ b/cypress/tests/ImageElement.cy.ts
@@ -591,7 +591,7 @@ describe("ImageElement", () => {
         getButton(RemoveRepeaterButtonId).first().click();
         getElementRichTextField("repeaterText").its("length").should("eq", 1);
         clickButton(RemoveRepeaterButtonId);
-        getElementRichTextField("repeaterText").its("length").should("eq", 1); // because you can't delete the last one
+        getElementRichTextField("repeaterText").should("not.exist");
       });
       it("should accept values in repeater elements", () => {
         addImageElement();
@@ -623,9 +623,7 @@ describe("ImageElement", () => {
           .its("length")
           .should("eq", 1);
         clickButton(RemoveNestedRepeaterButtonId);
-        getElementRichTextField("nestedRepeaterText")
-          .its("length")
-          .should("eq", 1); // because you can't delete the last one
+        getElementRichTextField("nestedRepeaterText").should("not.exist");
       });
       it("should accept values in nested repeater elements", () => {
         addImageElement();

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -10,7 +10,7 @@ import { schema as basicSchema, marks } from "prosemirror-schema-basic";
 import { EditorState } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import { buildElementPlugin, undefinedDropdownValue } from "../src";
-import { altStyleElement } from "../src/elements/alt-style/AltStyleElementForm";
+import { keyTakeawaysElement } from "../src/elements/alt-style/AltStyleElementForm";
 import { createCalloutElement } from "../src/elements/callout/Callout";
 import { createCartoonElement } from "../src/elements/cartoon/CartoonForm";
 import { codeElement } from "../src/elements/code/CodeElementForm";
@@ -240,7 +240,7 @@ const {
         editorLink: "https://example.com",
       })
     ),
-    "alt-style": altStyleElement,
+    "alt-style": keyTakeawaysElement,
   },
   {
     sendTelemetryEvent: (type: string, tags) =>

--- a/src/editorial-source-components/Editor.ts
+++ b/src/editorial-source-components/Editor.ts
@@ -15,7 +15,6 @@ export const Editor = styled.div<{
   .ProseMirrorElements__RichTextField,
   .ProseMirrorElements__TextField,
   .ProseMirrorElements__NestedElementField {
-    background-color: ${background.primary};
     ${inputBorder}
     &:active {
       border: 1px solid ${background.inputChecked};

--- a/src/editorial-source-components/Editor.ts
+++ b/src/editorial-source-components/Editor.ts
@@ -15,6 +15,7 @@ export const Editor = styled.div<{
   .ProseMirrorElements__RichTextField,
   .ProseMirrorElements__TextField,
   .ProseMirrorElements__NestedElementField {
+    background-color: ${background.primary};
     ${inputBorder}
     &:active {
       border: 1px solid ${background.inputChecked};

--- a/src/elements/alt-style/AltStyleElementForm.tsx
+++ b/src/elements/alt-style/AltStyleElementForm.tsx
@@ -1,12 +1,27 @@
+import styled from "@emotion/styled";
+import { neutral } from "@guardian/src-foundations";
 import React from "react";
 import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
 import { RepeaterFieldMapIDKey } from "../../plugin/helpers/constants";
 import { AltStyleElementWrapper } from "../../renderers/react/AltStyleElementWrapper";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+import { Body } from "../../renderers/react/ElementWrapper";
+import { RightRepeaterActionControls } from "../../renderers/react/WrapperControls";
 import { altStyleFields } from "./AltStyleElementSpec";
 
 export const AltStyleElementTestId = "AltStyleElement";
+
+const RepeaterBody = styled(Body)`
+  padding: 0 8px 8px 8px;
+  border: 1px solid ${neutral[60]};
+  margin-top: 8px;
+`;
+
+const RepeaterChild = styled("div")`
+  width: 100%;
+  padding-right: 8px;
+`;
 
 export const altStyleElement = createReactElementSpec({
   fieldDescriptions: altStyleFields,
@@ -15,10 +30,10 @@ export const altStyleElement = createReactElementSpec({
       data-cy={AltStyleElementTestId}
       useAlternateStyles={true}
     >
-      {fields.repeater.children.map((repeater, index) => (
-        // Use field index to avoid React render conflicts
-        <>
-          <div key={repeater[RepeaterFieldMapIDKey]}>
+      {fields.repeater.children.map((repeater, index, children) => (
+        <RepeaterBody>
+          {/*Use field index as key to avoid React render conflicts*/}
+          <RepeaterChild key={repeater[RepeaterFieldMapIDKey]}>
             <FieldWrapper
               headingLabel="Key Takeaway Title"
               field={repeater.title}
@@ -29,15 +44,13 @@ export const altStyleElement = createReactElementSpec({
               field={repeater.content}
               useAlternateStyles={true}
             />
-          </div>
-          <button onClick={() => fields.repeater.view.add(index)}>+</button>
-          <button
-            onClick={() => fields.repeater.view.remove(index)}
-            disabled={fields.repeater.children.length === 1}
-          >
-            -
-          </button>
-        </>
+          </RepeaterChild>
+          <RightRepeaterActionControls
+            add={() => fields.repeater.view.add(index)}
+            remove={() => fields.repeater.view.remove(index)}
+            numberOfChildNodes={children.length}
+          />
+        </RepeaterBody>
       ))}
     </FieldLayoutVertical>
   ),

--- a/src/elements/alt-style/AltStyleElementForm.tsx
+++ b/src/elements/alt-style/AltStyleElementForm.tsx
@@ -17,7 +17,6 @@ export const AltStyleElementTestId = "AltStyleElement";
 
 const RepeaterBody = styled(Body)`
   padding: 8px 8px 16px 8px;
-  background-color: ${neutral[97]};
   &:not(:last-child) {
     border-bottom: 1px dashed ${neutral[60]};
   }
@@ -33,7 +32,6 @@ const ChildNumber = styled("div")`
   position: absolute;
   top: 16px;
   left: 8px;
-  background-color: ${neutral[97]};
   color: ${neutral[46]};
   font-family: "Guardian Agate Sans", sans-serif;
   line-height: 1;

--- a/src/elements/alt-style/AltStyleElementForm.tsx
+++ b/src/elements/alt-style/AltStyleElementForm.tsx
@@ -60,7 +60,7 @@ export const altStyleElement = createReactElementSpec({
           <LeftRepeaterActionControls
             removeChildAt={() => fields.repeater.view.removeChildAt(index)}
             numberOfChildNodes={children.length}
-            minChildren={1}
+            minChildren={fields.repeater.view.minChildren}
           />
           <RepeaterChild>
             <FieldWrapper

--- a/src/elements/alt-style/AltStyleElementForm.tsx
+++ b/src/elements/alt-style/AltStyleElementForm.tsx
@@ -4,6 +4,11 @@ import React from "react";
 import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
 import { RepeaterFieldMapIDKey } from "../../plugin/helpers/constants";
+import type {
+  FieldDescriptions,
+  FieldNameToField,
+  RepeaterField,
+} from "../../plugin/types/Element";
 import { AltStyleElementWrapper } from "../../renderers/react/AltStyleElementWrapper";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { Body } from "../../renderers/react/ElementWrapper";
@@ -11,11 +16,11 @@ import {
   LeftRepeaterActionControls,
   RightRepeaterActionControls,
 } from "../../renderers/react/WrapperControls";
-import { altStyleFields } from "./AltStyleElementSpec";
+import { keyTakeawaysFields } from "./AltStyleElementSpec";
 
 export const AltStyleElementTestId = "AltStyleElement";
 
-const RepeaterBody = styled(Body)`
+const RepeaterChild = styled(Body)`
   padding: 8px 8px 16px 8px;
   &:not(:last-child) {
     border-bottom: 1px dashed ${neutral[60]};
@@ -23,7 +28,7 @@ const RepeaterBody = styled(Body)`
   position: relative;
 `;
 
-const RepeaterChild = styled("div")`
+const RepeatedFieldsWrapper = styled("div")`
   width: 100%;
   padding: 0 8px;
 `;
@@ -46,46 +51,71 @@ const ChildNumber = styled("div")`
   border: 1px solid ${neutral[60]};
 `;
 
-export const altStyleElement = createReactElementSpec({
-  fieldDescriptions: altStyleFields,
-  component: ({ fields }) => (
-    <FieldLayoutVertical
-      data-cy={AltStyleElementTestId}
-      useAlternateStyles={true}
-    >
-      {fields.repeater.children.map((repeater, index, children) => (
-        // Use field ID as key instead of node index to avoid React render conflicts
-        <RepeaterBody key={repeater[RepeaterFieldMapIDKey]}>
-          <ChildNumber>{index + 1}</ChildNumber>
-          <LeftRepeaterActionControls
-            removeChildAt={() => fields.repeater.view.removeChildAt(index)}
-            numberOfChildNodes={children.length}
-            minChildren={fields.repeater.view.minChildren}
-          />
-          <RepeaterChild>
-            <FieldWrapper
-              headingLabel="Key Takeaway Title"
-              field={repeater.title}
-              useAlternateStyles={true}
-            />
-            <FieldWrapper
-              headingLabel="Key Takeaway Content"
-              field={repeater.content}
-              useAlternateStyles={true}
-            />
-          </RepeaterChild>
-          <RightRepeaterActionControls
-            addChildAfter={() => fields.repeater.view.addChildAfter(index)}
-            moveChildUpOne={() => fields.repeater.view.moveChildUpOne(index)}
-            moveChildDownOne={() =>
-              fields.repeater.view.moveChildDownOne(index)
-            }
-            numberOfChildNodes={children.length}
-            index={index}
-          />
-        </RepeaterBody>
-      ))}
-    </FieldLayoutVertical>
-  ),
-  wrapperComponent: AltStyleElementWrapper,
-});
+export const createReactAltStylesElementSpec = <
+  FDesc extends FieldDescriptions<string>,
+  RepeatedFieldDescriptions extends FieldDescriptions<string>
+>(
+  fieldDescriptions: FDesc,
+  repeaterFieldExtractor: (
+    fields: FieldNameToField<FDesc>
+  ) => RepeaterField<RepeatedFieldDescriptions>,
+  renderRepeaterChild: (
+    repeaterChild: FieldNameToField<RepeatedFieldDescriptions>
+  ) => React.ReactNode
+) =>
+  createReactElementSpec({
+    fieldDescriptions,
+    component: ({ fields }) => {
+      const repeaterField = repeaterFieldExtractor(fields);
+      return (
+        <FieldLayoutVertical
+          data-cy={AltStyleElementTestId}
+          useAlternateStyles={true}
+        >
+          {repeaterField.children.map((child, index) => (
+            // Use field ID as key instead of node index to avoid React render conflicts
+            <RepeaterChild key={child[RepeaterFieldMapIDKey]}>
+              <ChildNumber>{index + 1}</ChildNumber>
+              <LeftRepeaterActionControls
+                removeChildAt={() => repeaterField.view.removeChildAt(index)}
+                numberOfChildNodes={repeaterField.children.length}
+                minChildren={repeaterField.view.minChildren}
+              />
+              <RepeatedFieldsWrapper>
+                {renderRepeaterChild(child)}
+              </RepeatedFieldsWrapper>
+              <RightRepeaterActionControls
+                addChildAfter={() => repeaterField.view.addChildAfter(index)}
+                moveChildUpOne={() => repeaterField.view.moveChildUpOne(index)}
+                moveChildDownOne={() =>
+                  repeaterField.view.moveChildDownOne(index)
+                }
+                numberOfChildNodes={repeaterField.children.length}
+                index={index}
+              />
+            </RepeaterChild>
+          ))}
+        </FieldLayoutVertical>
+      );
+    },
+    wrapperComponent: AltStyleElementWrapper,
+  });
+
+export const keyTakeawaysElement = createReactAltStylesElementSpec(
+  keyTakeawaysFields,
+  (fields) => fields.repeater,
+  (repeaterChild) => (
+    <>
+      <FieldWrapper
+        headingLabel="Key Takeaway Title"
+        field={repeaterChild.title}
+        useAlternateStyles={true}
+      />
+      <FieldWrapper
+        headingLabel="Key Takeaway Content"
+        field={repeaterChild.content}
+        useAlternateStyles={true}
+      />
+    </>
+  )
+);

--- a/src/elements/alt-style/AltStyleElementForm.tsx
+++ b/src/elements/alt-style/AltStyleElementForm.tsx
@@ -59,7 +59,7 @@ export const altStyleElement = createReactElementSpec({
         <RepeaterBody>
           <ChildNumber>{index + 1}</ChildNumber>
           <LeftRepeaterActionControls
-            remove={() => fields.repeater.view.remove(index)}
+            removeChildAt={() => fields.repeater.view.removeChildAt(index)}
             numberOfChildNodes={children.length}
           />
           {/*Use field index as key to avoid React render conflicts*/}
@@ -76,9 +76,11 @@ export const altStyleElement = createReactElementSpec({
             />
           </RepeaterChild>
           <RightRepeaterActionControls
-            add={() => fields.repeater.view.add(index)}
-            moveUp={() => fields.repeater.view.moveUp(index)}
-            moveDown={() => fields.repeater.view.moveDown(index)}
+            addChildAfter={() => fields.repeater.view.addChildAfter(index)}
+            moveChildUpOne={() => fields.repeater.view.moveChildUpOne(index)}
+            moveChildDownOne={() =>
+              fields.repeater.view.moveChildDownOne(index)
+            }
             numberOfChildNodes={children.length}
             index={index}
           />

--- a/src/elements/alt-style/AltStyleElementForm.tsx
+++ b/src/elements/alt-style/AltStyleElementForm.tsx
@@ -61,6 +61,7 @@ export const altStyleElement = createReactElementSpec({
           <LeftRepeaterActionControls
             removeChildAt={() => fields.repeater.view.removeChildAt(index)}
             numberOfChildNodes={children.length}
+            minChildren={1}
           />
           {/*Use field index as key to avoid React render conflicts*/}
           <RepeaterChild key={repeater[RepeaterFieldMapIDKey]}>

--- a/src/elements/alt-style/AltStyleElementForm.tsx
+++ b/src/elements/alt-style/AltStyleElementForm.tsx
@@ -54,15 +54,15 @@ export const altStyleElement = createReactElementSpec({
       useAlternateStyles={true}
     >
       {fields.repeater.children.map((repeater, index, children) => (
-        <RepeaterBody>
+        // Use field ID as key instead of node index to avoid React render conflicts
+        <RepeaterBody key={repeater[RepeaterFieldMapIDKey]}>
           <ChildNumber>{index + 1}</ChildNumber>
           <LeftRepeaterActionControls
             removeChildAt={() => fields.repeater.view.removeChildAt(index)}
             numberOfChildNodes={children.length}
             minChildren={1}
           />
-          {/*Use field index as key to avoid React render conflicts*/}
-          <RepeaterChild key={repeater[RepeaterFieldMapIDKey]}>
+          <RepeaterChild>
             <FieldWrapper
               headingLabel="Key Takeaway Title"
               field={repeater.title}

--- a/src/elements/alt-style/AltStyleElementForm.tsx
+++ b/src/elements/alt-style/AltStyleElementForm.tsx
@@ -48,7 +48,10 @@ export const altStyleElement = createReactElementSpec({
           <RightRepeaterActionControls
             add={() => fields.repeater.view.add(index)}
             remove={() => fields.repeater.view.remove(index)}
+            moveUp={() => fields.repeater.view.moveUp(index)}
+            moveDown={() => fields.repeater.view.moveDown(index)}
             numberOfChildNodes={children.length}
+            index={index}
           />
         </RepeaterBody>
       ))}

--- a/src/elements/alt-style/AltStyleElementForm.tsx
+++ b/src/elements/alt-style/AltStyleElementForm.tsx
@@ -7,20 +7,45 @@ import { RepeaterFieldMapIDKey } from "../../plugin/helpers/constants";
 import { AltStyleElementWrapper } from "../../renderers/react/AltStyleElementWrapper";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { Body } from "../../renderers/react/ElementWrapper";
-import { RightRepeaterActionControls } from "../../renderers/react/WrapperControls";
+import {
+  LeftRepeaterActionControls,
+  RightRepeaterActionControls,
+} from "../../renderers/react/WrapperControls";
 import { altStyleFields } from "./AltStyleElementSpec";
 
 export const AltStyleElementTestId = "AltStyleElement";
 
 const RepeaterBody = styled(Body)`
-  padding: 0 8px 8px 8px;
-  border: 1px solid ${neutral[60]};
-  margin-top: 8px;
+  padding: 8px 8px 16px 8px;
+  background-color: ${neutral[97]};
+  &:not(:last-child) {
+    border-bottom: 1px dashed ${neutral[60]};
+  }
+  position: relative;
 `;
 
 const RepeaterChild = styled("div")`
   width: 100%;
-  padding-right: 8px;
+  padding: 0 8px;
+`;
+
+const ChildNumber = styled("div")`
+  position: absolute;
+  top: 16px;
+  left: 8px;
+  background-color: ${neutral[97]};
+  color: ${neutral[46]};
+  font-family: "Guardian Agate Sans", sans-serif;
+  line-height: 1;
+  font-weight: 700;
+  font-size: 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 24px;
+  padding: 2px;
+  width: 24px;
+  border: 1px solid ${neutral[60]};
 `;
 
 export const altStyleElement = createReactElementSpec({
@@ -32,6 +57,11 @@ export const altStyleElement = createReactElementSpec({
     >
       {fields.repeater.children.map((repeater, index, children) => (
         <RepeaterBody>
+          <ChildNumber>{index + 1}</ChildNumber>
+          <LeftRepeaterActionControls
+            remove={() => fields.repeater.view.remove(index)}
+            numberOfChildNodes={children.length}
+          />
           {/*Use field index as key to avoid React render conflicts*/}
           <RepeaterChild key={repeater[RepeaterFieldMapIDKey]}>
             <FieldWrapper
@@ -47,7 +77,6 @@ export const altStyleElement = createReactElementSpec({
           </RepeaterChild>
           <RightRepeaterActionControls
             add={() => fields.repeater.view.add(index)}
-            remove={() => fields.repeater.view.remove(index)}
             moveUp={() => fields.repeater.view.moveUp(index)}
             moveDown={() => fields.repeater.view.moveDown(index)}
             numberOfChildNodes={children.length}

--- a/src/elements/alt-style/AltStyleElementForm.tsx
+++ b/src/elements/alt-style/AltStyleElementForm.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import { RepeaterFieldMapIDKey } from "../../plugin/helpers/constants";
 import { AltStyleElementWrapper } from "../../renderers/react/AltStyleElementWrapper";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { altStyleFields } from "./AltStyleElementSpec";
@@ -15,20 +16,29 @@ export const altStyleElement = createReactElementSpec({
       useAlternateStyles={true}
     >
       {fields.repeater.children.map((repeater, index) => (
-        <div key={index}>
-          <FieldWrapper
-            headingLabel="Key Takeaway Title"
-            field={repeater.title}
-            useAlternateStyles={true}
-          />
-          <FieldWrapper
-            headingLabel="Key Takeaway Content"
-            field={repeater.content}
-            useAlternateStyles={true}
-          />
-        </div>
+        // Use field index to avoid React render conflicts
+        <>
+          <div key={repeater[RepeaterFieldMapIDKey]}>
+            <FieldWrapper
+              headingLabel="Key Takeaway Title"
+              field={repeater.title}
+              useAlternateStyles={true}
+            />
+            <FieldWrapper
+              headingLabel="Key Takeaway Content"
+              field={repeater.content}
+              useAlternateStyles={true}
+            />
+          </div>
+          <button onClick={() => fields.repeater.view.add(index)}>+</button>
+          <button
+            onClick={() => fields.repeater.view.remove(index)}
+            disabled={fields.repeater.children.length === 1}
+          >
+            -
+          </button>
+        </>
       ))}
-      <button onClick={() => fields.repeater.view.add()}>+</button>
     </FieldLayoutVertical>
   ),
   wrapperComponent: AltStyleElementWrapper,

--- a/src/elements/alt-style/AltStyleElementSpec.tsx
+++ b/src/elements/alt-style/AltStyleElementSpec.tsx
@@ -5,18 +5,21 @@ import { required } from "../../plugin/helpers/validation";
 import { useTyperighterAttrs } from "../helpers/typerighter";
 
 export const altStyleFields = {
-  repeater: createRepeaterField({
-    title: createTextField({
-      rows: 1,
-      isResizeable: false,
-      validators: [required("Title is required")],
-    }),
-    content: createNestedElementField({
-      placeholder: "Don't show description",
-      content: "block*",
-      marks: "em strong link",
-      attrs: useTyperighterAttrs,
-      minRows: 6,
-    }),
-  }),
+  repeater: createRepeaterField(
+    {
+      title: createTextField({
+        rows: 1,
+        isResizeable: false,
+        validators: [required("Title is required")],
+      }),
+      content: createNestedElementField({
+        placeholder: "Don't show description",
+        content: "block*",
+        marks: "em strong link",
+        attrs: useTyperighterAttrs,
+        minRows: 6,
+      }),
+    },
+    1
+  ),
 };

--- a/src/elements/alt-style/AltStyleElementSpec.tsx
+++ b/src/elements/alt-style/AltStyleElementSpec.tsx
@@ -4,7 +4,7 @@ import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { required } from "../../plugin/helpers/validation";
 import { useTyperighterAttrs } from "../helpers/typerighter";
 
-export const altStyleFields = {
+export const keyTakeawaysFields = {
   repeater: createRepeaterField(
     {
       title: createTextField({

--- a/src/elements/demo-image/DemoImageElementForm.tsx
+++ b/src/elements/demo-image/DemoImageElementForm.tsx
@@ -60,7 +60,7 @@ export const createDemoImageElement = (
                 headingContent={
                   <button
                     data-cy={RemoveRepeaterButtonId}
-                    onClick={() => fields.repeater.view.remove(index)}
+                    onClick={() => fields.repeater.view.removeChildAt(index)}
                   >
                     -
                   </button>
@@ -77,7 +77,7 @@ export const createDemoImageElement = (
                           <button
                             data-cy={RemoveNestedRepeaterButtonId}
                             onClick={() =>
-                              repeater.nestedRepeater.view.remove(index)
+                              repeater.nestedRepeater.view.removeChildAt(index)
                             }
                           >
                             -
@@ -91,7 +91,7 @@ export const createDemoImageElement = (
               </ul>
               <button
                 data-cy={AddNestedRepeaterButtonId}
-                onClick={() => repeater.nestedRepeater.view.add()}
+                onClick={() => repeater.nestedRepeater.view.addChildAfter()}
               >
                 +
               </button>
@@ -99,7 +99,7 @@ export const createDemoImageElement = (
           ))}
           <button
             data-cy={AddRepeaterButtonId}
-            onClick={() => fields.repeater.view.add()}
+            onClick={() => fields.repeater.view.addChildAfter()}
           >
             +
           </button>

--- a/src/elements/demo-image/DemoImageElementForm.tsx
+++ b/src/elements/demo-image/DemoImageElementForm.tsx
@@ -58,12 +58,20 @@ export const createDemoImageElement = (
               <FieldWrapper
                 headingLabel="Repeater text"
                 headingContent={
-                  <button
-                    data-cy={RemoveRepeaterButtonId}
-                    onClick={() => fields.repeater.view.removeChildAt(index)}
-                  >
-                    -
-                  </button>
+                  <>
+                    <button
+                      data-cy={RemoveRepeaterButtonId}
+                      onClick={() => fields.repeater.view.removeChildAt(index)}
+                    >
+                      -
+                    </button>
+                    <button
+                      data-cy={AddRepeaterButtonId}
+                      onClick={() => fields.repeater.view.addChildAfter(index)}
+                    >
+                      +
+                    </button>
+                  </>
                 }
                 field={repeater.repeaterText}
               />
@@ -74,14 +82,28 @@ export const createDemoImageElement = (
                       <FieldWrapper
                         headingLabel="Nested repeater text"
                         headingContent={
-                          <button
-                            data-cy={RemoveNestedRepeaterButtonId}
-                            onClick={() =>
-                              repeater.nestedRepeater.view.removeChildAt(index)
-                            }
-                          >
-                            -
-                          </button>
+                          <>
+                            <button
+                              data-cy={RemoveNestedRepeaterButtonId}
+                              onClick={() =>
+                                repeater.nestedRepeater.view.removeChildAt(
+                                  index
+                                )
+                              }
+                            >
+                              -
+                            </button>
+                            <button
+                              data-cy={AddNestedRepeaterButtonId}
+                              onClick={() =>
+                                repeater.nestedRepeater.view.addChildAfter(
+                                  index
+                                )
+                              }
+                            >
+                              +
+                            </button>
+                          </>
                         }
                         field={nestedRepeater.nestedRepeaterText}
                       />
@@ -89,20 +111,8 @@ export const createDemoImageElement = (
                   )
                 )}
               </ul>
-              <button
-                data-cy={AddNestedRepeaterButtonId}
-                onClick={() => repeater.nestedRepeater.view.addChildAfter()}
-              >
-                +
-              </button>
             </li>
           ))}
-          <button
-            data-cy={AddRepeaterButtonId}
-            onClick={() => fields.repeater.view.addChildAfter()}
-          >
-            +
-          </button>
         </ul>
       </FieldLayoutVertical>
     ),

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,10 +34,10 @@ export { createStore } from "./renderers/react/store";
 export { TelemetryContext } from "./renderers/react/TelemetryContext";
 export { useCustomFieldState } from "./renderers/react/useCustomFieldViewState";
 export { createReactElementSpec } from "./renderers/react/createReactElementSpec";
+export { createReactAltStylesElementSpec } from "./elements/alt-style/AltStyleElementForm";
 export { CustomCheckboxView } from "./renderers/react/customFieldViewComponents/CustomCheckboxView";
 export { CustomDropdownView } from "./renderers/react/customFieldViewComponents/CustomDropdownView";
 export { FieldComponent } from "./renderers/react/FieldComponent";
-export { AltStyleElementWrapper } from "./renderers/react/AltStyleElementWrapper";
 export {
   INNER_EDITOR_FOCUS,
   INNER_EDITOR_BLUR,

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -266,6 +266,7 @@ describe("buildElementPlugin", () => {
           fields: {
             field1: { type: "richText" },
           },
+          minChildren: 0,
         },
       });
       const {
@@ -312,8 +313,10 @@ describe("buildElementPlugin", () => {
               fields: {
                 field1: { type: "richText" },
               },
+              minChildren: 0,
             },
           },
+          minChildren: 0,
         },
       });
       const {
@@ -435,6 +438,7 @@ describe("buildElementPlugin", () => {
           fields: {
             field1: { type: "nestedElement", content: "block+" },
           },
+          minChildren: 0,
         },
       });
       const {
@@ -500,6 +504,7 @@ describe("buildElementPlugin", () => {
           fields: {
             field1: { type: "nestedElement", content: "block+" },
           },
+          minChildren: 0,
         },
       });
       const {
@@ -566,6 +571,7 @@ describe("buildElementPlugin", () => {
           fields: {
             field1: { type: "nestedElement", content: "block+" },
           },
+          minChildren: 0,
         },
       });
       const {
@@ -736,6 +742,7 @@ describe("buildElementPlugin", () => {
         fields: {
           field4: { type: "richText" },
         },
+        minChildren: 0,
       },
     });
 

--- a/src/plugin/__tests__/nodeSpec.spec.ts
+++ b/src/plugin/__tests__/nodeSpec.spec.ts
@@ -54,6 +54,7 @@ describe("nodeSpec generation", () => {
         fields: {
           field1: { type: "richText" },
         },
+        minChildren: 0,
       },
     });
     const nodeSpec = getNodeSpecFromFieldDescriptions(

--- a/src/plugin/fieldViews/RepeaterFieldView.ts
+++ b/src/plugin/fieldViews/RepeaterFieldView.ts
@@ -136,8 +136,9 @@ export class RepeaterFieldView extends FieldView<unknown> {
 
   /**
    * Remove a child from this repeater at the given index.
+   * Do not remove if we are at the minimum threshold for number of children.
    */
-  public removeChildAt(index: number) {
+  public removeChildAt(index: number, minChildren = 0) {
     if (index < 0 || index >= this.node.childCount) {
       console.error(
         `Cannot remove at index ${index}: index out of range. Must be between 0 and ${
@@ -146,7 +147,7 @@ export class RepeaterFieldView extends FieldView<unknown> {
       );
       return;
     }
-    if (this.node.childCount === 1) {
+    if (this.node.childCount === minChildren) {
       return;
     }
     const tr = this.outerView.state.tr;

--- a/src/plugin/fieldViews/RepeaterFieldView.ts
+++ b/src/plugin/fieldViews/RepeaterFieldView.ts
@@ -97,9 +97,7 @@ export class RepeaterFieldView extends FieldView<unknown> {
   public addChildAfter(index: number) {
     if (index < 0 || index >= this.node.childCount) {
       console.error(
-        `Cannot add at index ${index}: index out of range. Must be between 0 and ${
-          this.node.childCount - 1
-        }`
+        `Cannot add at index ${index}: index out of range. Must be between 0 and ${this.node.childCount}`
       );
       return;
     }
@@ -134,9 +132,9 @@ export class RepeaterFieldView extends FieldView<unknown> {
    * Do not remove if we are at the minimum threshold for number of children.
    */
   public removeChildAt(index: number) {
-    if (index < 0 || index >= this.node.childCount) {
+    if (index < 0 || index > this.node.childCount - 1) {
       console.error(
-        `Cannot remove at index ${index}: index out of range. Must be between 0 and ${
+        `Cannot remove at index ${index}: index out of range. Minimum 0, Maximum ${
           this.node.childCount - 1
         }`
       );
@@ -164,7 +162,7 @@ export class RepeaterFieldView extends FieldView<unknown> {
   public moveChildUpOne(index: number) {
     if (index < 1 || index > this.node.childCount - 1) {
       console.error(
-        `Cannot move index ${index} up: index out of range. Must be between 1 and ${
+        `Cannot move index ${index} up: index out of range. Minimum 1, Maximum ${
           this.node.childCount - 1
         }`
       );
@@ -192,7 +190,7 @@ export class RepeaterFieldView extends FieldView<unknown> {
   public moveChildDownOne(index: number) {
     if (index < 0 || index > this.node.childCount - 2) {
       console.error(
-        `Cannot move index ${index} down: index out of range. Must be between 0 and ${
+        `Cannot move index ${index} down: index out of range. Minimum 0, Maximum ${
           this.node.childCount - 2
         }`
       );

--- a/src/plugin/fieldViews/RepeaterFieldView.ts
+++ b/src/plugin/fieldViews/RepeaterFieldView.ts
@@ -137,6 +137,10 @@ export class RepeaterFieldView extends FieldView<unknown> {
     this.outerView.dispatch(tr);
   }
 
+  public addChildAtEnd() {
+    this.addChildAfter(this.node.childCount - 1);
+  }
+
   /**
    * Remove a child from this repeater at the given index.
    * Do not remove if we are at the minimum threshold for number of children.

--- a/src/plugin/fieldViews/RepeaterFieldView.ts
+++ b/src/plugin/fieldViews/RepeaterFieldView.ts
@@ -16,10 +16,12 @@ export const getRepeaterChildNameFromParent = (nodeName: string) =>
   nodeName.replace("__parent", "__child");
 
 export const createRepeaterField = <FDesc extends FieldDescriptions<string>>(
-  fields: FDesc
+  fields: FDesc,
+  minChildren = 0
 ) => ({
   type: repeaterFieldType,
   fields,
+  minChildren,
 });
 
 export interface RepeaterFieldDescription<
@@ -27,6 +29,7 @@ export interface RepeaterFieldDescription<
 > extends BaseFieldDescription<unknown> {
   type: typeof repeaterFieldType;
   fields: FDesc;
+  minChildren: number;
 }
 
 /**
@@ -44,7 +47,8 @@ export class RepeaterFieldView extends FieldView<unknown> {
     public getPos: () => number,
     // The outer editor instance. Updated from within this class when nodes are added or removed.
     private outerView: EditorView,
-    private fieldName: string
+    private fieldName: string,
+    public minChildren: number
   ) {
     super();
   }
@@ -129,7 +133,7 @@ export class RepeaterFieldView extends FieldView<unknown> {
    * Remove a child from this repeater at the given index.
    * Do not remove if we are at the minimum threshold for number of children.
    */
-  public removeChildAt(index: number, minChildren = 0) {
+  public removeChildAt(index: number) {
     if (index < 0 || index >= this.node.childCount) {
       console.error(
         `Cannot remove at index ${index}: index out of range. Must be between 0 and ${
@@ -138,7 +142,7 @@ export class RepeaterFieldView extends FieldView<unknown> {
       );
       return;
     }
-    if (this.node.childCount === minChildren) {
+    if (this.node.childCount === this.minChildren) {
       return;
     }
     const tr = this.outerView.state.tr;

--- a/src/plugin/fieldViews/RepeaterFieldView.ts
+++ b/src/plugin/fieldViews/RepeaterFieldView.ts
@@ -90,13 +90,10 @@ export class RepeaterFieldView extends FieldView<unknown> {
    * Add a new child from this repeater at the given index.
    * If no index is supplied, add to the end of the repeater.
    */
-  public addChildAfter(maybeIndex?: number) {
-    if (
-      maybeIndex !== undefined &&
-      (maybeIndex < 0 || maybeIndex >= this.node.childCount)
-    ) {
+  public addChildAfter(index: number) {
+    if (index < 0 || index >= this.node.childCount) {
       console.error(
-        `Cannot add at index ${maybeIndex}: index out of range. Must be between 0 and ${
+        `Cannot add at index ${index}: index out of range. Must be between 0 and ${
           this.node.childCount - 1
         }`
       );
@@ -115,21 +112,15 @@ export class RepeaterFieldView extends FieldView<unknown> {
       );
       return;
     }
-    let positionToAddFrom;
-    if (maybeIndex === undefined) {
-      // If no index, add to end of repeater node
-      positionToAddFrom = this.getPos() + this.offset + this.node.nodeSize;
-    } else {
-      const nodeToAddFrom = this.node.child(maybeIndex);
-      // If index supplied, add from child at given index
-      const startOfNodeToAddFrom = this.getStartOfChildNode(
-        this.node,
-        maybeIndex,
-        this.getPos(),
-        this.offset
-      );
-      positionToAddFrom = startOfNodeToAddFrom + nodeToAddFrom.nodeSize;
-    }
+    const nodeToAddFrom = this.node.child(index);
+    // If index supplied, add from child at given index
+    const startOfNodeToAddFrom = this.getStartOfChildNode(
+      this.node,
+      index,
+      this.getPos(),
+      this.offset
+    );
+    const positionToAddFrom = startOfNodeToAddFrom + nodeToAddFrom.nodeSize;
     tr.insert(positionToAddFrom, newNode);
     this.outerView.dispatch(tr);
   }

--- a/src/plugin/fieldViews/RepeaterFieldView.ts
+++ b/src/plugin/fieldViews/RepeaterFieldView.ts
@@ -90,7 +90,18 @@ export class RepeaterFieldView extends FieldView<unknown> {
    * Add a new child from this repeater at the given index.
    * If no index is supplied, add to the end of the repeater.
    */
-  public add(index?: number) {
+  public addChildAfter(maybeIndex?: number) {
+    if (
+      maybeIndex !== undefined &&
+      (maybeIndex < 0 || maybeIndex >= this.node.childCount)
+    ) {
+      console.error(
+        `Cannot add at index ${maybeIndex}: index out of range. Must be between 0 and ${
+          this.node.childCount - 1
+        }`
+      );
+      return;
+    }
     const tr = this.outerView.state.tr;
     const repeaterChildNodeName = getRepeaterChildNameFromParent(
       this.node.type.name
@@ -105,15 +116,15 @@ export class RepeaterFieldView extends FieldView<unknown> {
       return;
     }
     let positionToAddFrom;
-    if (index === undefined) {
+    if (maybeIndex === undefined) {
       // If no index, add to end of repeater node
       positionToAddFrom = this.getPos() + this.offset + this.node.nodeSize;
     } else {
-      const nodeToAddFrom = this.node.child(index);
+      const nodeToAddFrom = this.node.child(maybeIndex);
       // If index supplied, add from child at given index
       const startOfNodeToAddFrom = this.getStartOfChildNode(
         this.node,
-        index,
+        maybeIndex,
         this.getPos(),
         this.offset
       );
@@ -126,7 +137,18 @@ export class RepeaterFieldView extends FieldView<unknown> {
   /**
    * Remove a child from this repeater at the given index.
    */
-  public remove(index: number) {
+  public removeChildAt(index: number) {
+    if (index < 0 || index >= this.node.childCount) {
+      console.error(
+        `Cannot remove at index ${index}: index out of range. Must be between 0 and ${
+          this.node.childCount - 1
+        }`
+      );
+      return;
+    }
+    if (this.node.childCount === 1) {
+      return;
+    }
     const tr = this.outerView.state.tr;
     const nodeToRemove = this.node.child(index);
     const startOfNodeToRemove = this.getStartOfChildNode(
@@ -140,8 +162,13 @@ export class RepeaterFieldView extends FieldView<unknown> {
     this.outerView.dispatch(tr);
   }
 
-  public moveUp(index: number) {
-    if (index <= 0) {
+  public moveChildUpOne(index: number) {
+    if (index < 1 || index > this.node.childCount - 1) {
+      console.error(
+        `Cannot move index ${index} up: index out of range. Must be between 1 and ${
+          this.node.childCount - 1
+        }`
+      );
       return;
     }
 
@@ -160,8 +187,13 @@ export class RepeaterFieldView extends FieldView<unknown> {
     this.outerView.dispatch(tr);
   }
 
-  public moveDown(index: number) {
-    if (index >= this.node.childCount - 1) {
+  public moveChildDownOne(index: number) {
+    if (index < 0 || index > this.node.childCount - 2) {
+      console.error(
+        `Cannot move index ${index} down: index out of range. Must be between 0 and ${
+          this.node.childCount - 2
+        }`
+      );
       return;
     }
 

--- a/src/plugin/fieldViews/RepeaterFieldView.ts
+++ b/src/plugin/fieldViews/RepeaterFieldView.ts
@@ -162,6 +162,9 @@ export class RepeaterFieldView extends FieldView<unknown> {
     this.outerView.dispatch(tr);
   }
 
+  /**
+   * Move the child at the given index up one.
+   */
   public moveChildUpOne(index: number) {
     if (index < 1 || index > this.node.childCount - 1) {
       console.error(
@@ -187,6 +190,9 @@ export class RepeaterFieldView extends FieldView<unknown> {
     this.outerView.dispatch(tr);
   }
 
+  /**
+   * Move the child at the given index down one.
+   */
   public moveChildDownOne(index: number) {
     if (index < 0 || index > this.node.childCount - 2) {
       console.error(

--- a/src/plugin/fieldViews/RepeaterFieldView.ts
+++ b/src/plugin/fieldViews/RepeaterFieldView.ts
@@ -139,4 +139,44 @@ export class RepeaterFieldView extends FieldView<unknown> {
     tr.deleteRange(startOfNodeToRemove, endOfNodeToRemove);
     this.outerView.dispatch(tr);
   }
+
+  public moveUp(index: number) {
+    if (index <= 0) {
+      return;
+    }
+
+    const tr = this.outerView.state.tr;
+    const nodeToMove = this.node.child(index);
+    const startOfNodeToMove = this.getStartOfChildNode(
+      this.node,
+      index,
+      this.getPos(),
+      this.offset
+    );
+    const endOfNodeToMove = startOfNodeToMove + nodeToMove.nodeSize;
+    const previousNode = this.node.child(index - 1);
+    tr.deleteRange(startOfNodeToMove, endOfNodeToMove);
+    tr.insert(startOfNodeToMove - previousNode.nodeSize, nodeToMove);
+    this.outerView.dispatch(tr);
+  }
+
+  public moveDown(index: number) {
+    if (index >= this.node.childCount - 1) {
+      return;
+    }
+
+    const tr = this.outerView.state.tr;
+    const nodeToMove = this.node.child(index);
+    const startOfNodeToMove = this.getStartOfChildNode(
+      this.node,
+      index,
+      this.getPos(),
+      this.offset
+    );
+    const endOfNodeToMove = startOfNodeToMove + nodeToMove.nodeSize;
+    const nextNode = this.node.child(index + 1);
+    tr.insert(endOfNodeToMove + nextNode.nodeSize, nodeToMove);
+    tr.deleteRange(startOfNodeToMove, endOfNodeToMove);
+    this.outerView.dispatch(tr);
+  }
 }

--- a/src/plugin/fieldViews/__tests__/RepeaterFieldView.spec.ts
+++ b/src/plugin/fieldViews/__tests__/RepeaterFieldView.spec.ts
@@ -76,11 +76,11 @@ describe("RepeaterFieldView", () => {
     );
   });
 
-  it("should do nothing if removing a repeater child when there is only one child", () => {
+  it("should do nothing if removing a repeater child when we are at the minimum threshold for number of children", () => {
     testRepeaterMutation(
       ["Content 1"],
       (repeaterFieldView) => {
-        repeaterFieldView.removeChildAt(0);
+        repeaterFieldView.removeChildAt(0, 1);
       },
       [`paragraph("Content 1")`]
     );

--- a/src/plugin/fieldViews/__tests__/RepeaterFieldView.spec.ts
+++ b/src/plugin/fieldViews/__tests__/RepeaterFieldView.spec.ts
@@ -31,6 +31,31 @@ describe("RepeaterFieldView", () => {
     );
   });
 
+  it("should add a repeater child at the end of the repeater", () => {
+    testRepeaterMutation(
+      ["Content 1", "Content 2", "Content 3"],
+      (repeaterFieldView) => {
+        repeaterFieldView.addChildAtEnd();
+      },
+      [
+        `paragraph("Content 1")`,
+        `paragraph("Content 2")`,
+        `paragraph("Content 3")`,
+        "paragraph",
+      ]
+    );
+  });
+
+  it("should add a repeater child at the end of the repeater, even when repeater is empty", () => {
+    testRepeaterMutation(
+      [],
+      (repeaterFieldView) => {
+        repeaterFieldView.addChildAtEnd();
+      },
+      ["paragraph"]
+    );
+  });
+
   it("should add a repeater child after a valid index", () => {
     testRepeaterMutation(
       ["Content 1", "Content 2", "Content 3"],
@@ -199,13 +224,13 @@ const testRepeaterMutation = (
   const testNodeAfter = view.state.doc.firstChild as Node;
   const repeaterNodeAfter = testNodeAfter.content.firstChild as Node;
 
-  expect(repeaterNodeAfter.content.childCount).toBe(
-    expectedFinalContent.length
-  );
-
   repeaterNodeAfter.content.forEach((node, _, index) => {
     expect(node.toString()).toBe(
       `testElement__repeater1__child(testElement__field1(${expectedFinalContent[index]}))`
     );
   });
+
+  expect(repeaterNodeAfter.content.childCount).toBe(
+    expectedFinalContent.length
+  );
 };

--- a/src/plugin/fieldViews/__tests__/RepeaterFieldView.spec.ts
+++ b/src/plugin/fieldViews/__tests__/RepeaterFieldView.spec.ts
@@ -1,0 +1,196 @@
+import type { Node } from "prosemirror-model";
+import {
+  createEditorWithElements,
+  createNoopElement,
+} from "../../helpers/test";
+import { RepeaterFieldView } from "../RepeaterFieldView";
+
+describe("RepeaterFieldView", () => {
+  it("should add a repeater child after a valid index", () => {
+    testRepeaterMutation(
+      ["Content 1", "Content 2", "Content 3"],
+      (repeaterFieldView) => {
+        repeaterFieldView.addChildAfter(1);
+      },
+      [
+        `paragraph("Content 1")`,
+        `paragraph("Content 2")`,
+        "paragraph",
+        `paragraph("Content 3")`,
+      ]
+    );
+  });
+
+  it("should do nothing if adding after an invalid index", () => {
+    testRepeaterMutation(
+      ["Content 1", "Content 2", "Content 3"],
+      (repeaterFieldView) => {
+        repeaterFieldView.addChildAfter(4);
+        repeaterFieldView.addChildAfter(-1);
+      },
+      [
+        `paragraph("Content 1")`,
+        `paragraph("Content 2")`,
+        `paragraph("Content 3")`,
+      ]
+    );
+  });
+
+  it("should add a repeater child after the final index if no index is supplied", () => {
+    testRepeaterMutation(
+      ["Content 1", "Content 2", "Content 3"],
+      (repeaterFieldView) => {
+        repeaterFieldView.addChildAfter();
+      },
+      [
+        `paragraph("Content 1")`,
+        `paragraph("Content 2")`,
+        `paragraph("Content 3")`,
+        "paragraph",
+      ]
+    );
+  });
+
+  it("should remove a repeater child at a valid index", () => {
+    testRepeaterMutation(
+      ["Content 1", "Content 2", "Content 3"],
+      (repeaterFieldView) => {
+        repeaterFieldView.removeChildAt(1);
+      },
+      [`paragraph("Content 1")`, `paragraph("Content 3")`]
+    );
+  });
+
+  it("should do nothing if removing at an invalid index", () => {
+    testRepeaterMutation(
+      ["Content 1", "Content 2", "Content 3"],
+      (repeaterFieldView) => {
+        repeaterFieldView.removeChildAt(4);
+        repeaterFieldView.removeChildAt(-1);
+      },
+      [
+        `paragraph("Content 1")`,
+        `paragraph("Content 2")`,
+        `paragraph("Content 3")`,
+      ]
+    );
+  });
+
+  it("should do nothing if removing a repeater child when there is only one child", () => {
+    testRepeaterMutation(
+      ["Content 1"],
+      (repeaterFieldView) => {
+        repeaterFieldView.removeChildAt(0);
+      },
+      [`paragraph("Content 1")`]
+    );
+  });
+
+  it("should move repeater child at a valid index UP by one", () => {
+    testRepeaterMutation(
+      ["Content 1", "Content 2", "Content 3", "Content 4"],
+      (repeaterFieldView) => {
+        repeaterFieldView.moveChildUpOne(3);
+      },
+      [
+        `paragraph("Content 1")`,
+        `paragraph("Content 2")`,
+        `paragraph("Content 4")`,
+        `paragraph("Content 3")`,
+      ]
+    );
+  });
+
+  it("should move repeater child at a valid index DOWN by one", () => {
+    testRepeaterMutation(
+      ["Content 1", "Content 2", "Content 3", "Content 4"],
+      (repeaterFieldView) => {
+        repeaterFieldView.moveChildDownOne(0);
+      },
+      [
+        `paragraph("Content 2")`,
+        `paragraph("Content 1")`,
+        `paragraph("Content 3")`,
+        `paragraph("Content 4")`,
+      ]
+    );
+  });
+
+  it("should do nothing if moving a repeater child beyond the start or the end", () => {
+    testRepeaterMutation(
+      ["Content 1", "Content 2", "Content 3", "Content 4"],
+      (repeaterFieldView) => {
+        repeaterFieldView.moveChildUpOne(-1);
+        repeaterFieldView.moveChildDownOne(-1);
+        repeaterFieldView.moveChildUpOne(0);
+        repeaterFieldView.moveChildDownOne(3);
+      },
+      [
+        `paragraph("Content 1")`,
+        `paragraph("Content 2")`,
+        `paragraph("Content 3")`,
+        `paragraph("Content 4")`,
+      ]
+    );
+  });
+});
+
+const testRepeaterMutation = (
+  initialContent: string[],
+  mutation: (repeaterFieldView: RepeaterFieldView) => void,
+  expectedFinalContent: string[]
+) => {
+  const nestedTestElement = createNoopElement({
+    nestedField: {
+      type: "nestedElement",
+      content: "block+",
+    },
+  });
+  const testElement = createNoopElement({
+    repeater1: {
+      type: "repeater",
+      fields: {
+        field1: { type: "richText" },
+      },
+    },
+  });
+  const { view, insertElement } = createEditorWithElements({
+    nestedTestElement,
+    testElement,
+  });
+
+  insertElement({
+    elementName: "testElement",
+    values: {
+      repeater1: initialContent.map((content) => ({
+        field1: `<p>${content}</p>`,
+      })),
+    },
+  })(view.state, view.dispatch);
+
+  const testNodeBefore = view.state.doc.firstChild as Node;
+  const repeaterNodeBefore = testNodeBefore.content.firstChild as Node;
+
+  const repeaterFieldView = new RepeaterFieldView(
+    repeaterNodeBefore,
+    0,
+    () => 0,
+    view,
+    "testRepeater"
+  );
+
+  mutation(repeaterFieldView);
+
+  const testNodeAfter = view.state.doc.firstChild as Node;
+  const repeaterNodeAfter = testNodeAfter.content.firstChild as Node;
+
+  expect(repeaterNodeAfter.content.childCount).toBe(
+    expectedFinalContent.length
+  );
+
+  repeaterNodeAfter.content.forEach((node, _, index) => {
+    expect(node.toString()).toBe(
+      `testElement__repeater1__child(testElement__field1(${expectedFinalContent[index]}))`
+    );
+  });
+};

--- a/src/plugin/fieldViews/__tests__/RepeaterFieldView.spec.ts
+++ b/src/plugin/fieldViews/__tests__/RepeaterFieldView.spec.ts
@@ -62,12 +62,14 @@ describe("RepeaterFieldView", () => {
   });
 
   it("should do nothing if removing a repeater child when we are at the minimum threshold for number of children", () => {
+    const minChildren = 1;
     testRepeaterMutation(
       ["Content 1"],
       (repeaterFieldView) => {
-        repeaterFieldView.removeChildAt(0, 1);
+        repeaterFieldView.removeChildAt(0);
       },
-      [`paragraph("Content 1")`]
+      [`paragraph("Content 1")`],
+      minChildren
     );
   });
 
@@ -123,7 +125,8 @@ describe("RepeaterFieldView", () => {
 const testRepeaterMutation = (
   initialContent: string[],
   mutation: (repeaterFieldView: RepeaterFieldView) => void,
-  expectedFinalContent: string[]
+  expectedFinalContent: string[],
+  minChildren = 0
 ) => {
   const nestedTestElement = createNoopElement({
     nestedField: {
@@ -137,6 +140,7 @@ const testRepeaterMutation = (
       fields: {
         field1: { type: "richText" },
       },
+      minChildren: 0,
     },
   });
   const { view, insertElement } = createEditorWithElements({
@@ -161,7 +165,8 @@ const testRepeaterMutation = (
     0,
     () => 0,
     view,
-    "testRepeater"
+    "testRepeater",
+    minChildren
   );
 
   mutation(repeaterFieldView);

--- a/src/plugin/fieldViews/__tests__/RepeaterFieldView.spec.ts
+++ b/src/plugin/fieldViews/__tests__/RepeaterFieldView.spec.ts
@@ -36,21 +36,6 @@ describe("RepeaterFieldView", () => {
     );
   });
 
-  it("should add a repeater child after the final index if no index is supplied", () => {
-    testRepeaterMutation(
-      ["Content 1", "Content 2", "Content 3"],
-      (repeaterFieldView) => {
-        repeaterFieldView.addChildAfter();
-      },
-      [
-        `paragraph("Content 1")`,
-        `paragraph("Content 2")`,
-        `paragraph("Content 3")`,
-        "paragraph",
-      ]
-    );
-  });
-
   it("should remove a repeater child at a valid index", () => {
     testRepeaterMutation(
       ["Content 1", "Content 2", "Content 3"],

--- a/src/plugin/fieldViews/__tests__/RepeaterFieldView.spec.ts
+++ b/src/plugin/fieldViews/__tests__/RepeaterFieldView.spec.ts
@@ -6,6 +6,31 @@ import {
 import { RepeaterFieldView } from "../RepeaterFieldView";
 
 describe("RepeaterFieldView", () => {
+  it("should add a repeater child at the start when index is -1", () => {
+    testRepeaterMutation(
+      ["Content 1", "Content 2", "Content 3"],
+      (repeaterFieldView) => {
+        repeaterFieldView.addChildAfter(-1);
+      },
+      [
+        "paragraph",
+        `paragraph("Content 1")`,
+        `paragraph("Content 2")`,
+        `paragraph("Content 3")`,
+      ]
+    );
+  });
+
+  it("should add a repeater child when index is -1, even when repeater is empty", () => {
+    testRepeaterMutation(
+      [],
+      (repeaterFieldView) => {
+        repeaterFieldView.addChildAfter(-1);
+      },
+      ["paragraph"]
+    );
+  });
+
   it("should add a repeater child after a valid index", () => {
     testRepeaterMutation(
       ["Content 1", "Content 2", "Content 3"],
@@ -26,7 +51,7 @@ describe("RepeaterFieldView", () => {
       ["Content 1", "Content 2", "Content 3"],
       (repeaterFieldView) => {
         repeaterFieldView.addChildAfter(4);
-        repeaterFieldView.addChildAfter(-1);
+        repeaterFieldView.addChildAfter(-2);
       },
       [
         `paragraph("Content 1")`,

--- a/src/plugin/helpers/fieldView.ts
+++ b/src/plugin/helpers/fieldView.ts
@@ -141,6 +141,13 @@ export const getElementFieldViewFromType = (
         field.options
       );
     case "repeater":
-      return new RepeaterFieldView(node, offset, getPos, view, fieldName);
+      return new RepeaterFieldView(
+        node,
+        offset,
+        getPos,
+        view,
+        fieldName,
+        field.minChildren
+      );
   }
 };

--- a/src/renderers/react/AltStyleElementWrapper.tsx
+++ b/src/renderers/react/AltStyleElementWrapper.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { space } from "@guardian/src-foundations";
 import type { ReactElement } from "react";
 import type { CommandCreator } from "../../plugin/types/Commands";
-import { Body, Overlay } from "./ElementWrapper";
+import { Overlay } from "./ElementWrapper";
 
 const AltStyleContainer = styled("div")`
   margin: ${space[3]}px 0;
@@ -16,7 +16,7 @@ const AltStylePanel = styled("div")<{
   isSelected: boolean;
 }>`
   position: relative;
-  padding: 0px ${space[3]}px;
+  padding: 0 ${space[3]}px;
   flex-grow: 1;
   overflow: hidden;
   padding: ${space[3]}px;
@@ -51,12 +51,10 @@ export const AltStyleElementWrapper: React.FunctionComponent<ElementWrapperProps
       className="ProsemirrorElement__wrapper"
       data-cy={elementWrapperTestId}
     >
-      <Body>
-        <AltStylePanel isSelected={isSelected}>
-          {isSelected && <Overlay />}
-          {children}
-        </AltStylePanel>
-      </Body>
+      <AltStylePanel isSelected={isSelected}>
+        {isSelected && <Overlay />}
+        {children}
+      </AltStylePanel>
     </AltStyleContainer>
   );
 };

--- a/src/renderers/react/AltStyleElementWrapper.tsx
+++ b/src/renderers/react/AltStyleElementWrapper.tsx
@@ -1,11 +1,8 @@
 import styled from "@emotion/styled";
 import { space } from "@guardian/src-foundations";
 import type { ReactElement } from "react";
-import { useContext, useState } from "react";
 import type { CommandCreator } from "../../plugin/types/Commands";
 import { Body, Overlay } from "./ElementWrapper";
-import { TelemetryContext } from "./TelemetryContext";
-import { LeftActionControls, RightActionControls } from "./WrapperControls";
 
 const AltStyleContainer = styled("div")`
   margin: ${space[3]}px 0;
@@ -46,44 +43,19 @@ export type ElementWrapperProps = {
 export const elementWrapperTestId = "ElementWrapper";
 
 export const AltStyleElementWrapper: React.FunctionComponent<ElementWrapperProps> = ({
-  moveUp,
-  moveDown,
-  moveTop,
-  moveBottom,
-  remove,
-  select,
   isSelected,
-  onRemove,
   children,
 }) => {
-  const [closeClickedOnce, setCloseClickedOnce] = useState(false);
-  const sendTelemetryEvent = useContext(TelemetryContext);
-
   return (
     <AltStyleContainer
       className="ProsemirrorElement__wrapper"
       data-cy={elementWrapperTestId}
     >
       <Body>
-        <LeftActionControls
-          select={select}
-          remove={remove}
-          onRemove={onRemove}
-          closeClickedOnce={closeClickedOnce}
-          setCloseClickedOnce={setCloseClickedOnce}
-          sendTelemetryEvent={sendTelemetryEvent}
-        />
         <AltStylePanel isSelected={isSelected}>
           {isSelected && <Overlay />}
           {children}
         </AltStylePanel>
-        <RightActionControls
-          moveTop={moveTop}
-          moveUp={moveUp}
-          moveDown={moveDown}
-          moveBottom={moveBottom}
-          sendTelemetryEvent={sendTelemetryEvent}
-        />
       </Body>
     </AltStyleContainer>
   );

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -13,11 +13,7 @@ export const Container = styled("div")`
 
 export const Body = styled("div")`
   display: flex;
-  :hover {
-    .actions {
-      opacity: 1;
-    }
-  }
+  :hover,
   :focus-within {
     .actions {
       opacity: 1;

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -7,7 +7,7 @@ import type { CommandCreator } from "../../plugin/types/Commands";
 import { TelemetryContext } from "./TelemetryContext";
 import { LeftActionControls, RightActionControls } from "./WrapperControls";
 
-const Container = styled("div")`
+export const Container = styled("div")`
   margin: ${space[3]}px -32px;
 `;
 

--- a/src/renderers/react/WrapperControls.tsx
+++ b/src/renderers/react/WrapperControls.tsx
@@ -302,6 +302,7 @@ export const RightActionControls = ({
 export type LeftRepeaterActionProps = {
   removeChildAt: MouseEventHandler<HTMLButtonElement>;
   numberOfChildNodes: number;
+  minChildren: number;
 };
 
 export type RightRepeaterActionProps = {
@@ -325,6 +326,7 @@ const RepeaterActions = styled("div")`
 export const LeftRepeaterActionControls = ({
   removeChildAt,
   numberOfChildNodes,
+  minChildren,
 }: LeftRepeaterActionProps) => {
   const [closeClickedOnce, setCloseClickedOnce] = useState(false);
 
@@ -336,7 +338,7 @@ export const LeftRepeaterActionControls = ({
             type="button"
             activated={closeClickedOnce}
             data-cy={removeChildTestId}
-            disabled={numberOfChildNodes === 1}
+            disabled={numberOfChildNodes === minChildren}
             onClick={(e) => {
               if (closeClickedOnce) {
                 return removeChildAt(e);

--- a/src/renderers/react/WrapperControls.tsx
+++ b/src/renderers/react/WrapperControls.tsx
@@ -83,7 +83,7 @@ const SeriousButton = styled(Button)<{ activated?: boolean }>`
   svg {
     fill: ${({ activated }) => (activated ? neutral[100] : neutral[20])};
   }
-  :hover {
+  :hover:not(:disabled) {
     background-color: ${({ activated }) =>
       activated ? border.error : neutral[46]};
     svg {

--- a/src/renderers/react/WrapperControls.tsx
+++ b/src/renderers/react/WrapperControls.tsx
@@ -8,7 +8,7 @@ import {
   SvgChevronRightDouble,
 } from "@guardian/src-icons";
 import type { MouseEventHandler } from "react";
-import React from "react";
+import React, { useState } from "react";
 import { SvgBin } from "../../editorial-source-components/SvgBin";
 import { SvgHighlightAlt } from "../../editorial-source-components/SvgHighlightAlt";
 import { CommandTelemetryType } from "../../elements/helpers/types/TelemetryEvents";
@@ -43,8 +43,8 @@ const Button = styled("button")<{ expanded?: boolean }>`
   width: ${buttonWidth}px;
   transition: background-color 0.1s;
   :focus {
-    ${focusHalo}
-    z-index: 1;
+    ${focusHalo};
+    z-index: 11;
   }
 
   :first-of-type {
@@ -102,17 +102,22 @@ const Actions = styled("div")`
   transition: opacity 0.2s;
 `;
 
+const LeftActions = styled(Actions)`
+  justify-content: space-between;
+  position: relative;
+`;
+
+const LeftRepeaterActions = styled(LeftActions)`
+  height: 100%;
+  justify-content: flex-end;
+`;
+
 const RightActions = styled(Actions)`
   right: -${buttonWidth + 1}px;
 `;
 
 const RightRepeaterActions = styled(RightActions)`
   height: 100%;
-  justify-content: space-between;
-`;
-
-const LeftActions = styled(Actions)`
-  left: -${buttonWidth + 1}px;
   justify-content: space-between;
 `;
 
@@ -127,7 +132,7 @@ const Tooltip = styled("div")`
   font-family: "Guardian Agate Sans";
   font-size: 15px;
   filter: drop-shadow(0 2px 4px rgb(0 0 0 / 30%));
-  z-index: 1;
+  z-index: 11;
   width: 82px;
   padding: ${space[1]}px;
   padding-bottom: 5px;
@@ -294,9 +299,13 @@ export const RightActionControls = ({
   );
 };
 
+export type LeftRepeaterActionProps = {
+  remove: MouseEventHandler<HTMLButtonElement>;
+  numberOfChildNodes: number;
+};
+
 export type RightRepeaterActionProps = {
   add: MouseEventHandler<HTMLButtonElement>;
-  remove: MouseEventHandler<HTMLButtonElement>;
   moveUp: MouseEventHandler<HTMLButtonElement>;
   moveDown: MouseEventHandler<HTMLButtonElement>;
   numberOfChildNodes: number;
@@ -313,9 +322,44 @@ const RepeaterActions = styled("div")`
   align-items: center;
 `;
 
+export const LeftRepeaterActionControls = ({
+  remove,
+  numberOfChildNodes,
+}: LeftRepeaterActionProps) => {
+  const [closeClickedOnce, setCloseClickedOnce] = useState(false);
+
+  return (
+    <RepeaterControls>
+      <LeftRepeaterActions className="actions">
+        <RepeaterActions>
+          <SeriousButton
+            type="button"
+            activated={closeClickedOnce}
+            data-cy={removeChildTestId}
+            disabled={numberOfChildNodes === 1}
+            onClick={(e) => {
+              if (closeClickedOnce) {
+                return remove(e);
+              } else {
+                setCloseClickedOnce(true);
+                setTimeout(() => {
+                  setCloseClickedOnce(false);
+                }, 5000);
+              }
+            }}
+            aria-label="Remove repeater child"
+          >
+            <SvgBin />
+            {closeClickedOnce && <Tooltip>Click again to confirm</Tooltip>}
+          </SeriousButton>
+        </RepeaterActions>
+      </LeftRepeaterActions>
+    </RepeaterControls>
+  );
+};
+
 export const RightRepeaterActionControls = ({
   add,
-  remove,
   moveUp,
   moveDown,
   numberOfChildNodes,
@@ -352,15 +396,6 @@ export const RightRepeaterActionControls = ({
             aria-label="Add repeater child"
           >
             +
-          </Button>
-          <Button
-            type="button"
-            data-cy={removeChildTestId}
-            disabled={numberOfChildNodes === 1}
-            onClick={remove}
-            aria-label="Remove repeater child"
-          >
-            -
           </Button>
         </RepeaterActions>
       </RightRepeaterActions>

--- a/src/renderers/react/WrapperControls.tsx
+++ b/src/renderers/react/WrapperControls.tsx
@@ -7,6 +7,8 @@ import {
   SvgArrowUpStraight,
   SvgChevronRightDouble,
 } from "@guardian/src-icons";
+import type { MouseEventHandler } from "react";
+import React from "react";
 import { SvgBin } from "../../editorial-source-components/SvgBin";
 import { SvgHighlightAlt } from "../../editorial-source-components/SvgHighlightAlt";
 import { CommandTelemetryType } from "../../elements/helpers/types/TelemetryEvents";
@@ -20,12 +22,15 @@ export const moveBottomTestId = "ElementWrapper__moveBottom";
 export const moveUpTestId = "ElementWrapper__moveUp";
 export const moveDownTestId = "ElementWrapper__moveDown";
 
+export const addChildTestId = "ElementWrapper__addChild";
+export const removeChildTestId = "ElementWrapper__removeChild";
+
 const Button = styled("button")<{ expanded?: boolean }>`
   appearance: none;
   background: ${neutral[93]};
   border: none;
   border-top: 1px solid ${neutral[100]};
-  color: ${neutral[100]};
+  color: ${neutral[0]};
   cursor: pointer;
   flex-grow: ${({ expanded }) => (expanded ? "1" : "0")};
   ${({ expanded }) => !expanded && `height: ${buttonWidth}px;`};
@@ -45,6 +50,7 @@ const Button = styled("button")<{ expanded?: boolean }>`
 
   :hover {
     background: ${neutral[46]};
+    color: ${neutral[100]};
     svg {
       fill: ${neutral[100]};
     }
@@ -277,5 +283,45 @@ export const RightActionControls = ({
         </div>
       </Button>
     </RightActions>
+  );
+};
+
+export type RightRepeaterActionProps = {
+  add: MouseEventHandler<HTMLButtonElement>;
+  remove: MouseEventHandler<HTMLButtonElement>;
+  numberOfChildNodes: number;
+};
+
+const RepeaterControls = styled("div")`
+  padding-top: 8px;
+`;
+
+export const RightRepeaterActionControls = ({
+  add,
+  remove,
+  numberOfChildNodes,
+}: RightRepeaterActionProps) => {
+  return (
+    <RepeaterControls>
+      <RightActions className="actions">
+        <Button
+          type="button"
+          data-cy={addChildTestId}
+          onClick={add}
+          aria-label="Add repeater child"
+        >
+          +
+        </Button>
+        <Button
+          type="button"
+          data-cy={removeChildTestId}
+          disabled={numberOfChildNodes === 1}
+          onClick={remove}
+          aria-label="Remove repeater child"
+        >
+          -
+        </Button>
+      </RightActions>
+    </RepeaterControls>
   );
 };

--- a/src/renderers/react/WrapperControls.tsx
+++ b/src/renderers/react/WrapperControls.tsx
@@ -300,14 +300,14 @@ export const RightActionControls = ({
 };
 
 export type LeftRepeaterActionProps = {
-  remove: MouseEventHandler<HTMLButtonElement>;
+  removeChildAt: MouseEventHandler<HTMLButtonElement>;
   numberOfChildNodes: number;
 };
 
 export type RightRepeaterActionProps = {
-  add: MouseEventHandler<HTMLButtonElement>;
-  moveUp: MouseEventHandler<HTMLButtonElement>;
-  moveDown: MouseEventHandler<HTMLButtonElement>;
+  addChildAfter: MouseEventHandler<HTMLButtonElement>;
+  moveChildUpOne: MouseEventHandler<HTMLButtonElement>;
+  moveChildDownOne: MouseEventHandler<HTMLButtonElement>;
   numberOfChildNodes: number;
   index: number;
 };
@@ -323,7 +323,7 @@ const RepeaterActions = styled("div")`
 `;
 
 export const LeftRepeaterActionControls = ({
-  remove,
+  removeChildAt,
   numberOfChildNodes,
 }: LeftRepeaterActionProps) => {
   const [closeClickedOnce, setCloseClickedOnce] = useState(false);
@@ -339,7 +339,7 @@ export const LeftRepeaterActionControls = ({
             disabled={numberOfChildNodes === 1}
             onClick={(e) => {
               if (closeClickedOnce) {
-                return remove(e);
+                return removeChildAt(e);
               } else {
                 setCloseClickedOnce(true);
                 setTimeout(() => {
@@ -359,9 +359,9 @@ export const LeftRepeaterActionControls = ({
 };
 
 export const RightRepeaterActionControls = ({
-  add,
-  moveUp,
-  moveDown,
+  addChildAfter,
+  moveChildUpOne,
+  moveChildDownOne,
   numberOfChildNodes,
   index,
 }: RightRepeaterActionProps) => {
@@ -373,7 +373,7 @@ export const RightRepeaterActionControls = ({
             type="button"
             data-cy={moveChildUpTestId}
             disabled={index <= 0}
-            onClick={moveUp}
+            onClick={moveChildUpOne}
             aria-label="Move repeater child up"
           >
             <SvgArrowUpStraight />
@@ -382,7 +382,7 @@ export const RightRepeaterActionControls = ({
             type="button"
             data-cy={moveChildDownTestId}
             disabled={index >= numberOfChildNodes - 1}
-            onClick={moveDown}
+            onClick={moveChildDownOne}
             aria-label="Move repeater child down"
           >
             <SvgArrowDownStraight />
@@ -392,7 +392,7 @@ export const RightRepeaterActionControls = ({
           <Button
             type="button"
             data-cy={addChildTestId}
-            onClick={add}
+            onClick={addChildAfter}
             aria-label="Add repeater child"
           >
             +

--- a/src/renderers/react/WrapperControls.tsx
+++ b/src/renderers/react/WrapperControls.tsx
@@ -25,6 +25,9 @@ export const moveDownTestId = "ElementWrapper__moveDown";
 export const addChildTestId = "ElementWrapper__addChild";
 export const removeChildTestId = "ElementWrapper__removeChild";
 
+export const moveChildUpTestId = "ElementWrapper__moveChildUp";
+export const moveChildDownTestId = "ElementWrapper__moveChildDown";
+
 const Button = styled("button")<{ expanded?: boolean }>`
   appearance: none;
   background: ${neutral[93]};
@@ -101,6 +104,11 @@ const Actions = styled("div")`
 
 const RightActions = styled(Actions)`
   right: -${buttonWidth + 1}px;
+`;
+
+const RightRepeaterActions = styled(RightActions)`
+  height: 100%;
+  justify-content: space-between;
 `;
 
 const LeftActions = styled(Actions)`
@@ -289,39 +297,73 @@ export const RightActionControls = ({
 export type RightRepeaterActionProps = {
   add: MouseEventHandler<HTMLButtonElement>;
   remove: MouseEventHandler<HTMLButtonElement>;
+  moveUp: MouseEventHandler<HTMLButtonElement>;
+  moveDown: MouseEventHandler<HTMLButtonElement>;
   numberOfChildNodes: number;
+  index: number;
 };
 
 const RepeaterControls = styled("div")`
   padding-top: 8px;
 `;
 
+const RepeaterActions = styled("div")`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
 export const RightRepeaterActionControls = ({
   add,
   remove,
+  moveUp,
+  moveDown,
   numberOfChildNodes,
+  index,
 }: RightRepeaterActionProps) => {
   return (
     <RepeaterControls>
-      <RightActions className="actions">
-        <Button
-          type="button"
-          data-cy={addChildTestId}
-          onClick={add}
-          aria-label="Add repeater child"
-        >
-          +
-        </Button>
-        <Button
-          type="button"
-          data-cy={removeChildTestId}
-          disabled={numberOfChildNodes === 1}
-          onClick={remove}
-          aria-label="Remove repeater child"
-        >
-          -
-        </Button>
-      </RightActions>
+      <RightRepeaterActions className="actions">
+        <RepeaterActions>
+          <Button
+            type="button"
+            data-cy={moveChildUpTestId}
+            disabled={index <= 0}
+            onClick={moveUp}
+            aria-label="Move repeater child up"
+          >
+            <SvgArrowUpStraight />
+          </Button>
+          <Button
+            type="button"
+            data-cy={moveChildDownTestId}
+            disabled={index >= numberOfChildNodes - 1}
+            onClick={moveDown}
+            aria-label="Move repeater child down"
+          >
+            <SvgArrowDownStraight />
+          </Button>
+        </RepeaterActions>
+        <RepeaterActions>
+          <Button
+            type="button"
+            data-cy={addChildTestId}
+            onClick={add}
+            aria-label="Add repeater child"
+          >
+            +
+          </Button>
+          <Button
+            type="button"
+            data-cy={removeChildTestId}
+            disabled={numberOfChildNodes === 1}
+            onClick={remove}
+            aria-label="Remove repeater child"
+          >
+            -
+          </Button>
+        </RepeaterActions>
+      </RightRepeaterActions>
     </RepeaterControls>
   );
 };


### PR DESCRIPTION
Paired on with @twrichards 

## What does this change?
Previously we were able to add child nodes at the end of the repeater, and remove child nodes at a given index.

This PR allows us to add child nodes at a given index, and move child nodes up or down an index. It also refactors the remove method to have greater guards against invalid invocation (in line with the new methods), and renames the methods to be more precise.

## How to test
You can play about with these controls by creating an Alt Style element in the demo:
![image](https://github.com/guardian/prosemirror-elements/assets/40991816/7975fdca-649e-4455-bedf-84791dca6068)

Check that the controls work as expected, and are enabled / disabled in the right places.

There are also new tests for these methods which can be inspected and run to give confidence in the PR's intent.