### PR TITLE
make `minChildren` a property of the repeater itself (for greater encapsulation)

### DIFF
--- a/src/elements/alt-style/AltStyleElementForm.tsx
+++ b/src/elements/alt-style/AltStyleElementForm.tsx
@@ -59,7 +59,7 @@ export const altStyleElement = createReactElementSpec({
           <LeftRepeaterActionControls
             removeChildAt={() => fields.repeater.view.removeChildAt(index)}
             numberOfChildNodes={children.length}
-            minChildren={1}
+            minChildren={fields.repeater.view.minChildren}
           />
           {/*Use field index as key to avoid React render conflicts*/}
           <RepeaterChild>

--- a/src/elements/alt-style/AltStyleElementSpec.tsx
+++ b/src/elements/alt-style/AltStyleElementSpec.tsx
@@ -5,18 +5,21 @@ import { required } from "../../plugin/helpers/validation";
 import { useTyperighterAttrs } from "../helpers/typerighter";
 
 export const altStyleFields = {
-  repeater: createRepeaterField({
-    title: createTextField({
-      rows: 1,
-      isResizeable: false,
-      validators: [required("Title is required")],
-    }),
-    content: createNestedElementField({
-      placeholder: "Don't show description",
-      content: "block*",
-      marks: "em strong link",
-      attrs: useTyperighterAttrs,
-      minRows: 6,
-    }),
-  }),
+  repeater: createRepeaterField(
+    {
+      title: createTextField({
+        rows: 1,
+        isResizeable: false,
+        validators: [required("Title is required")],
+      }),
+      content: createNestedElementField({
+        placeholder: "Don't show description",
+        content: "block*",
+        marks: "em strong link",
+        attrs: useTyperighterAttrs,
+        minRows: 6,
+      }),
+    },
+    1
+  ),
 };

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -266,6 +266,7 @@ describe("buildElementPlugin", () => {
           fields: {
             field1: { type: "richText" },
           },
+          minChildren: 0,
         },
       });
       const {
@@ -312,8 +313,10 @@ describe("buildElementPlugin", () => {
               fields: {
                 field1: { type: "richText" },
               },
+              minChildren: 0,
             },
           },
+          minChildren: 0,
         },
       });
       const {
@@ -435,6 +438,7 @@ describe("buildElementPlugin", () => {
           fields: {
             field1: { type: "nestedElement", content: "block+" },
           },
+          minChildren: 0,
         },
       });
       const {
@@ -500,6 +504,7 @@ describe("buildElementPlugin", () => {
           fields: {
             field1: { type: "nestedElement", content: "block+" },
           },
+          minChildren: 0,
         },
       });
       const {
@@ -566,6 +571,7 @@ describe("buildElementPlugin", () => {
           fields: {
             field1: { type: "nestedElement", content: "block+" },
           },
+          minChildren: 0,
         },
       });
       const {
@@ -736,6 +742,7 @@ describe("buildElementPlugin", () => {
         fields: {
           field4: { type: "richText" },
         },
+        minChildren: 0,
       },
     });
 

--- a/src/plugin/__tests__/nodeSpec.spec.ts
+++ b/src/plugin/__tests__/nodeSpec.spec.ts
@@ -54,6 +54,7 @@ describe("nodeSpec generation", () => {
         fields: {
           field1: { type: "richText" },
         },
+        minChildren: 0,
       },
     });
     const nodeSpec = getNodeSpecFromFieldDescriptions(

--- a/src/plugin/fieldViews/RepeaterFieldView.ts
+++ b/src/plugin/fieldViews/RepeaterFieldView.ts
@@ -16,10 +16,12 @@ export const getRepeaterChildNameFromParent = (nodeName: string) =>
   nodeName.replace("__parent", "__child");
 
 export const createRepeaterField = <FDesc extends FieldDescriptions<string>>(
-  fields: FDesc
+  fields: FDesc,
+  minChildren = 0
 ) => ({
   type: repeaterFieldType,
   fields,
+  minChildren,
 });
 
 export interface RepeaterFieldDescription<
@@ -27,6 +29,7 @@ export interface RepeaterFieldDescription<
 > extends BaseFieldDescription<unknown> {
   type: typeof repeaterFieldType;
   fields: FDesc;
+  minChildren: number;
 }
 
 /**
@@ -44,7 +47,8 @@ export class RepeaterFieldView extends FieldView<unknown> {
     public getPos: () => number,
     // The outer editor instance. Updated from within this class when nodes are added or removed.
     private outerView: EditorView,
-    private fieldName: string
+    private fieldName: string,
+    public minChildren: number
   ) {
     super();
   }
@@ -129,7 +133,7 @@ export class RepeaterFieldView extends FieldView<unknown> {
    * Remove a child from this repeater at the given index.
    * Do not remove if we are at the minimum threshold for number of children.
    */
-  public removeChildAt(index: number, minChildren = 0) {
+  public removeChildAt(index: number) {
     if (index < 0 || index >= this.node.childCount) {
       console.error(
         `Cannot remove at index ${index}: index out of range. Must be between 0 and ${
@@ -138,7 +142,7 @@ export class RepeaterFieldView extends FieldView<unknown> {
       );
       return;
     }
-    if (this.node.childCount === minChildren) {
+    if (this.node.childCount === this.minChildren) {
       return;
     }
     const tr = this.outerView.state.tr;

--- a/src/plugin/fieldViews/__tests__/RepeaterFieldView.spec.ts
+++ b/src/plugin/fieldViews/__tests__/RepeaterFieldView.spec.ts
@@ -62,12 +62,14 @@ describe("RepeaterFieldView", () => {
   });
 
   it("should do nothing if removing a repeater child when we are at the minimum threshold for number of children", () => {
+    const minChildren = 1;
     testRepeaterMutation(
       ["Content 1"],
       (repeaterFieldView) => {
-        repeaterFieldView.removeChildAt(0, 1);
+        repeaterFieldView.removeChildAt(0);
       },
-      [`paragraph("Content 1")`]
+      [`paragraph("Content 1")`],
+      minChildren
     );
   });
 
@@ -123,7 +125,8 @@ describe("RepeaterFieldView", () => {
 const testRepeaterMutation = (
   initialContent: string[],
   mutation: (repeaterFieldView: RepeaterFieldView) => void,
-  expectedFinalContent: string[]
+  expectedFinalContent: string[],
+  minChildren = 0
 ) => {
   const nestedTestElement = createNoopElement({
     nestedField: {
@@ -137,6 +140,7 @@ const testRepeaterMutation = (
       fields: {
         field1: { type: "richText" },
       },
+      minChildren: 0,
     },
   });
   const { view, insertElement } = createEditorWithElements({
@@ -161,7 +165,8 @@ const testRepeaterMutation = (
     0,
     () => 0,
     view,
-    "testRepeater"
+    "testRepeater",
+    minChildren
   );
 
   mutation(repeaterFieldView);

--- a/src/plugin/helpers/fieldView.ts
+++ b/src/plugin/helpers/fieldView.ts
@@ -141,6 +141,13 @@ export const getElementFieldViewFromType = (
         field.options
       );
     case "repeater":
-      return new RepeaterFieldView(node, offset, getPos, view, fieldName);
+      return new RepeaterFieldView(
+        node,
+        offset,
+        getPos,
+        view,
+        fieldName,
+        field.minChildren
+      );
   }
 };


### PR DESCRIPTION
Small tweak to #334 to make the `minChildren` an actual property of the repeater itself rather than an input/argument to `removeChildAt` function to reduce the possibility of misuse/bugs (greater encapsulation in other words).