### PR TITLE
make alt styles element (with controls) usable outside PME (e.g. in composer for 'Key Takeaways')

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -10,7 +10,7 @@ import { schema as basicSchema, marks } from "prosemirror-schema-basic";
 import { EditorState } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 import { buildElementPlugin, undefinedDropdownValue } from "../src";
-import { altStyleElement } from "../src/elements/alt-style/AltStyleElementForm";
+import { keyTakeawaysElement } from "../src/elements/alt-style/AltStyleElementForm";
 import { createCalloutElement } from "../src/elements/callout/Callout";
 import { createCartoonElement } from "../src/elements/cartoon/CartoonForm";
 import { codeElement } from "../src/elements/code/CodeElementForm";
@@ -240,7 +240,7 @@ const {
         editorLink: "https://example.com",
       })
     ),
-    "alt-style": altStyleElement,
+    "alt-style": keyTakeawaysElement,
   },
   {
     sendTelemetryEvent: (type: string, tags) =>

--- a/src/elements/alt-style/AltStyleElementForm.tsx
+++ b/src/elements/alt-style/AltStyleElementForm.tsx
@@ -4,6 +4,11 @@ import React from "react";
 import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
 import { RepeaterFieldMapIDKey } from "../../plugin/helpers/constants";
+import type {
+  FieldDescriptions,
+  FieldNameToField,
+  RepeaterField,
+} from "../../plugin/types/Element";
 import { AltStyleElementWrapper } from "../../renderers/react/AltStyleElementWrapper";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { Body } from "../../renderers/react/ElementWrapper";
@@ -11,11 +16,11 @@ import {
   LeftRepeaterActionControls,
   RightRepeaterActionControls,
 } from "../../renderers/react/WrapperControls";
-import { altStyleFields } from "./AltStyleElementSpec";
+import { keyTakeawaysFields } from "./AltStyleElementSpec";
 
 export const AltStyleElementTestId = "AltStyleElement";
 
-const RepeaterBody = styled(Body)`
+const RepeaterChild = styled(Body)`
   padding: 8px 8px 16px 8px;
   &:not(:last-child) {
     border-bottom: 1px dashed ${neutral[60]};
@@ -23,7 +28,7 @@ const RepeaterBody = styled(Body)`
   position: relative;
 `;
 
-const RepeaterChild = styled("div")`
+const RepeatedFieldsWrapper = styled("div")`
   width: 100%;
   padding: 0 8px;
 `;
@@ -46,46 +51,71 @@ const ChildNumber = styled("div")`
   border: 1px solid ${neutral[60]};
 `;
 
-export const altStyleElement = createReactElementSpec({
-  fieldDescriptions: altStyleFields,
-  component: ({ fields }) => (
-    <FieldLayoutVertical
-      data-cy={AltStyleElementTestId}
-      useAlternateStyles={true}
-    >
-      {fields.repeater.children.map((repeater, index, children) => (
-        // Use field ID as key instead of node index to avoid React render conflicts
-        <RepeaterBody key={repeater[RepeaterFieldMapIDKey]}>
-          <ChildNumber>{index + 1}</ChildNumber>
-          <LeftRepeaterActionControls
-            removeChildAt={() => fields.repeater.view.removeChildAt(index)}
-            numberOfChildNodes={children.length}
-            minChildren={fields.repeater.view.minChildren}
-          />
-          <RepeaterChild>
-            <FieldWrapper
-              headingLabel="Key Takeaway Title"
-              field={repeater.title}
-              useAlternateStyles={true}
-            />
-            <FieldWrapper
-              headingLabel="Key Takeaway Content"
-              field={repeater.content}
-              useAlternateStyles={true}
-            />
-          </RepeaterChild>
-          <RightRepeaterActionControls
-            addChildAfter={() => fields.repeater.view.addChildAfter(index)}
-            moveChildUpOne={() => fields.repeater.view.moveChildUpOne(index)}
-            moveChildDownOne={() =>
-              fields.repeater.view.moveChildDownOne(index)
-            }
-            numberOfChildNodes={children.length}
-            index={index}
-          />
-        </RepeaterBody>
-      ))}
-    </FieldLayoutVertical>
-  ),
-  wrapperComponent: AltStyleElementWrapper,
-});
+export const createReactAltStylesElementSpec = <
+  FDesc extends FieldDescriptions<string>,
+  RepeatedFieldDescriptions extends FieldDescriptions<string>
+>(
+  fieldDescriptions: FDesc,
+  repeaterFieldExtractor: (
+    fields: FieldNameToField<FDesc>
+  ) => RepeaterField<RepeatedFieldDescriptions>,
+  renderRepeaterChild: (
+    repeaterChild: FieldNameToField<RepeatedFieldDescriptions>
+  ) => React.ReactNode
+) =>
+  createReactElementSpec({
+    fieldDescriptions,
+    component: ({ fields }) => {
+      const repeaterField = repeaterFieldExtractor(fields);
+      return (
+        <FieldLayoutVertical
+          data-cy={AltStyleElementTestId}
+          useAlternateStyles={true}
+        >
+          {repeaterField.children.map((child, index) => (
+            // Use field ID as key instead of node index to avoid React render conflicts
+            <RepeaterChild key={child[RepeaterFieldMapIDKey]}>
+              <ChildNumber>{index + 1}</ChildNumber>
+              <LeftRepeaterActionControls
+                removeChildAt={() => repeaterField.view.removeChildAt(index)}
+                numberOfChildNodes={repeaterField.children.length}
+                minChildren={repeaterField.view.minChildren}
+              />
+              <RepeatedFieldsWrapper>
+                {renderRepeaterChild(child)}
+              </RepeatedFieldsWrapper>
+              <RightRepeaterActionControls
+                addChildAfter={() => repeaterField.view.addChildAfter(index)}
+                moveChildUpOne={() => repeaterField.view.moveChildUpOne(index)}
+                moveChildDownOne={() =>
+                  repeaterField.view.moveChildDownOne(index)
+                }
+                numberOfChildNodes={repeaterField.children.length}
+                index={index}
+              />
+            </RepeaterChild>
+          ))}
+        </FieldLayoutVertical>
+      );
+    },
+    wrapperComponent: AltStyleElementWrapper,
+  });
+
+export const keyTakeawaysElement = createReactAltStylesElementSpec(
+  keyTakeawaysFields,
+  (fields) => fields.repeater,
+  (repeaterChild) => (
+    <>
+      <FieldWrapper
+        headingLabel="Key Takeaway Title"
+        field={repeaterChild.title}
+        useAlternateStyles={true}
+      />
+      <FieldWrapper
+        headingLabel="Key Takeaway Content"
+        field={repeaterChild.content}
+        useAlternateStyles={true}
+      />
+    </>
+  )
+);

--- a/src/elements/alt-style/AltStyleElementSpec.tsx
+++ b/src/elements/alt-style/AltStyleElementSpec.tsx
@@ -4,7 +4,7 @@ import { createTextField } from "../../plugin/fieldViews/TextFieldView";
 import { required } from "../../plugin/helpers/validation";
 import { useTyperighterAttrs } from "../helpers/typerighter";
 
-export const altStyleFields = {
+export const keyTakeawaysFields = {
   repeater: createRepeaterField(
     {
       title: createTextField({

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,10 +34,10 @@ export { createStore } from "./renderers/react/store";
 export { TelemetryContext } from "./renderers/react/TelemetryContext";
 export { useCustomFieldState } from "./renderers/react/useCustomFieldViewState";
 export { createReactElementSpec } from "./renderers/react/createReactElementSpec";
+export { createReactAltStylesElementSpec } from "./elements/alt-style/AltStyleElementForm";
 export { CustomCheckboxView } from "./renderers/react/customFieldViewComponents/CustomCheckboxView";
 export { CustomDropdownView } from "./renderers/react/customFieldViewComponents/CustomDropdownView";
 export { FieldComponent } from "./renderers/react/FieldComponent";
-export { AltStyleElementWrapper } from "./renderers/react/AltStyleElementWrapper";
 export {
   INNER_EDITOR_FOCUS,
   INNER_EDITOR_BLUR,


### PR DESCRIPTION
Co-authored-by: @twrichards 

Add-on to be merged into https://github.com/guardian/prosemirror-elements/pull/334 to expose a generic `createReactAltStylesElementSpec` which takes `fieldDescriptions` (must have `repeater` field) and `renderRepeaterChild` function as arguments and returns an element with the surrounding add/remove/move controls, for use with 'Key Takeaways' in composer for example.