### PR TITLE
Enforce repeater has minChildren nodes in schema

### DIFF
--- a/.changeset/beige-fireants-rush.md
+++ b/.changeset/beige-fireants-rush.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-elements": patch
+---
+
+Enforce repeater has minChildren nodes in schema

--- a/src/plugin/__tests__/nodeSpec.spec.ts
+++ b/src/plugin/__tests__/nodeSpec.spec.ts
@@ -223,7 +223,7 @@ describe("nodeSpec generation", () => {
         expect(
           nodeSpec["exampleElement__exampleRepeater__parent"]
         ).toMatchObject({
-          content: "exampleElement__exampleRepeater__child*",
+          content: "exampleElement__exampleRepeater__child{0,}",
         });
 
         expect(
@@ -253,10 +253,42 @@ describe("nodeSpec generation", () => {
         expect(
           nodeSpec["exampleElement__nestedRepeaterField__parent"]
         ).toMatchObject({
-          content: "exampleElement__nestedRepeaterField__child*",
+          content: "exampleElement__nestedRepeaterField__child{0,}",
         });
         expect(
           nodeSpec["exampleElement__nestedRepeaterField__child"]
+        ).toMatchObject({
+          content: "exampleElement__exampleField",
+        });
+        expect(nodeSpec["exampleElement__exampleField"]).toBeTruthy();
+      });
+
+      it("should generate NodeSpecs for repeater fields, which have a minChildren of 1", () => {
+        const nodeSpec = getNodeSpecForField(
+          "exampleElement",
+          "exampleRepeater",
+          createRepeaterField({
+            repeaterWithAtLeastOneChild: createRepeaterField(
+              {
+                exampleField: createTextField(),
+              },
+              1
+            ),
+          })
+        );
+
+        expect(
+          nodeSpec["exampleElement__exampleRepeater__child"]
+        ).toMatchObject({
+          content: "exampleElement__repeaterWithAtLeastOneChild__parent",
+        });
+        expect(
+          nodeSpec["exampleElement__repeaterWithAtLeastOneChild__parent"]
+        ).toMatchObject({
+          content: "exampleElement__repeaterWithAtLeastOneChild__child{1,}",
+        });
+        expect(
+          nodeSpec["exampleElement__repeaterWithAtLeastOneChild__child"]
         ).toMatchObject({
           content: "exampleElement__exampleField",
         });

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -211,7 +211,7 @@ export const getNodeSpecForField = (
       return {
         [parentNodeName]: {
           group: fieldGroupName,
-          content: `${childNodeName}*`,
+          content: `${childNodeName}{${field.minChildren},}`,
           toDOM: getDefaultToDOMForRepeaterNode(parentNodeName),
           parseDOM: getDefaultParseDOMForLeafNode(parentNodeName),
           attrs: { ...useTyperighterAttrs },
@@ -222,7 +222,9 @@ export const getNodeSpecForField = (
           toDOM: getDefaultToDOMForRepeaterNode(childNodeName),
           parseDOM: getDefaultParseDOMForRepeaterChildNode(childNodeName),
           attrs: {
-            [RepeaterFieldMapIDKey]: {},
+            [RepeaterFieldMapIDKey]: {
+              default: getRepeaterID(),
+            },
             ...useTyperighterAttrs,
           },
         },


### PR DESCRIPTION
Worked on with @rhystmills.

This fixes a bug where you can 'delete' an element that requires one child, putting it in a broken state.

## How to test
Publish the ProseMirror library locally and test in a consumer (e.g. Composer) where there is a repeater element with a `minChildren` property ≥ 1 (e.g. Key Takeaways). 

You should be able to delete the element (by hitting CMD + A and backspace, _not_ the controls as these are disabled).
 
Deleting the element will wipe all its content but crucially keep a repeater with one empty child.

The document should save as normal and fire no error messages.
