### PR TITLE
Widen alt style element

### DIFF
--- a/.changeset/odd-garlics-live.md
+++ b/.changeset/odd-garlics-live.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-elements": minor
+---
+
+Widen alt style element

--- a/demo/style.css
+++ b/demo/style.css
@@ -485,7 +485,7 @@ img.ProseMirror-separator {
 }
 
 .ProseMirror {
-  padding: 4px 8px 4px 14px;
+  padding: 4px 8px;
   line-height: 1.2;
   outline: none;
 }

--- a/src/editorial-source-components/FieldWrapper.tsx
+++ b/src/editorial-source-components/FieldWrapper.tsx
@@ -8,12 +8,13 @@ type Props<F> = {
   field: F;
   // If provided, these errors override the errors in the field.
   errors?: ValidationError[];
-  headingLabel: React.ReactNode;
+  headingLabel?: React.ReactNode;
   headingContent?: React.ReactNode;
   description?: React.ReactNode;
   className?: string;
   headingDirection?: "row" | "column";
   useAlternateStyles?: boolean;
+  showHeading?: boolean;
 };
 
 export const FieldWrapper = <F extends Field<FieldView<unknown>>>({
@@ -25,18 +26,21 @@ export const FieldWrapper = <F extends Field<FieldView<unknown>>>({
   className,
   headingDirection,
   useAlternateStyles,
+  showHeading = true,
 }: Props<F>) => (
   <div className={className}>
-    <InputHeading
-      name={field.name}
-      fieldId={field.view.getId()}
-      headingLabel={headingLabel}
-      headingContent={headingContent}
-      description={description}
-      errors={(errors ? errors : field.errors).map((e) => e.error)}
-      headingDirection={headingDirection}
-      useAlternateStyles={useAlternateStyles}
-    />
+    {showHeading ? (
+      <InputHeading
+        name={field.name}
+        fieldId={field.view.getId()}
+        headingLabel={headingLabel}
+        headingContent={headingContent}
+        description={description}
+        errors={(errors ? errors : field.errors).map((e) => e.error)}
+        headingDirection={headingDirection}
+        useAlternateStyles={useAlternateStyles}
+      />
+    ) : null}
     <FieldComponent
       field={field}
       hasValidationErrors={!!field.errors.length}

--- a/src/elements/alt-style/AltStyleElementForm.tsx
+++ b/src/elements/alt-style/AltStyleElementForm.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { neutral } from "@guardian/src-foundations";
+import { neutral, space } from "@guardian/src-foundations";
 import React from "react";
 import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
@@ -21,22 +21,20 @@ import { keyTakeawaysFields } from "./AltStyleElementSpec";
 export const AltStyleElementTestId = "AltStyleElement";
 
 const RepeaterChild = styled(Body)`
-  padding: 8px 8px 16px 8px;
-  &:not(:last-child) {
-    border-bottom: 1px dashed ${neutral[60]};
+  &:first-child {
+    margin-top: ${space[3]}px;
   }
+  margin-bottom: ${space[3]}px;
   position: relative;
 `;
 
 const RepeatedFieldsWrapper = styled("div")`
   width: 100%;
-  padding: 0 8px;
 `;
 
 const ChildNumber = styled("div")`
-  position: absolute;
-  top: 16px;
-  left: 8px;
+  box-sizing: border-box;
+  background-color: ${neutral[100]};
   color: ${neutral[46]};
   font-family: "Guardian Agate Sans", sans-serif;
   line-height: 1;
@@ -45,10 +43,13 @@ const ChildNumber = styled("div")`
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 24px;
+  height: 32px;
   padding: 2px;
-  width: 24px;
+  width: 32px;
   border: 1px solid ${neutral[60]};
+  position: absolute;
+  top: 0;
+  left: -32px;
 `;
 
 export const createReactAltStylesElementSpec = <

--- a/src/elements/alt-style/AltStyleElementForm.tsx
+++ b/src/elements/alt-style/AltStyleElementForm.tsx
@@ -108,13 +108,13 @@ export const keyTakeawaysElement = createReactAltStylesElementSpec(
   (repeaterChild) => (
     <>
       <FieldWrapper
-        headingLabel="Key Takeaway Title"
         field={repeaterChild.title}
+        showHeading={false}
         useAlternateStyles={true}
       />
       <FieldWrapper
-        headingLabel="Key Takeaway Content"
         field={repeaterChild.content}
+        showHeading={false}
         useAlternateStyles={true}
       />
     </>

--- a/src/elements/alt-style/AltStyleElementForm.tsx
+++ b/src/elements/alt-style/AltStyleElementForm.tsx
@@ -3,7 +3,11 @@ import { neutral, space } from "@guardian/src-foundations";
 import React from "react";
 import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
-import { RepeaterFieldMapIDKey } from "../../plugin/helpers/constants";
+import {
+  actionSpacing,
+  buttonWidth,
+  RepeaterFieldMapIDKey,
+} from "../../plugin/helpers/constants";
 import type {
   FieldDescriptions,
   FieldNameToField,
@@ -43,13 +47,13 @@ const ChildNumber = styled("div")`
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 32px;
+  height: ${buttonWidth}px;
+  width: ${buttonWidth}px;
+  top: 0;
+  left: -${actionSpacing}px;
   padding: 2px;
-  width: 32px;
   border: 1px solid ${neutral[60]};
   position: absolute;
-  top: 0;
-  left: -32px;
 `;
 
 export const createReactAltStylesElementSpec = <

--- a/src/elements/alt-style/AltStyleElementSpec.tsx
+++ b/src/elements/alt-style/AltStyleElementSpec.tsx
@@ -13,6 +13,7 @@ export const keyTakeawaysFields = {
         validators: [required("Title is required")],
       }),
       content: createNestedElementField({
+        isResizeable: false,
         placeholder: "Don't show description",
         content: "block*",
         marks: "em strong link",

--- a/src/plugin/helpers/constants.ts
+++ b/src/plugin/helpers/constants.ts
@@ -10,3 +10,6 @@ export const RepeaterFieldMapIDKey = "__ID";
 export const undefinedDropdownValue = "none-selected";
 
 export const pluginKey = new PluginKey("prosemirror_elements");
+
+export const buttonWidth = 32;
+export const actionSpacing = buttonWidth;

--- a/src/renderers/react/AltStyleElementWrapper.tsx
+++ b/src/renderers/react/AltStyleElementWrapper.tsx
@@ -5,21 +5,17 @@ import type { CommandCreator } from "../../plugin/types/Commands";
 import { Overlay } from "./ElementWrapper";
 
 const AltStyleContainer = styled("div")`
-  margin: ${space[3]}px 0;
   padding-bottom: 8px;
   border-top: 1px dashed #ddd;
   border-bottom: 1px dashed #ddd;
-  margin: ${space[3]}px -20px;
+  margin: ${space[3]}px -10px;
 `;
 
 const AltStylePanel = styled("div")<{
   isSelected: boolean;
 }>`
   position: relative;
-  padding: 0 ${space[3]}px;
   flex-grow: 1;
-  overflow: hidden;
-  padding: ${space[3]}px;
 
   * {
     ::selection {

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -3,12 +3,13 @@ import { space } from "@guardian/src-foundations";
 import { neutral } from "@guardian/src-foundations/palette";
 import type { ReactElement } from "react";
 import React, { useContext, useState } from "react";
+import { actionSpacing } from "../../plugin/helpers/constants";
 import type { CommandCreator } from "../../plugin/types/Commands";
 import { TelemetryContext } from "./TelemetryContext";
 import { LeftActionControls, RightActionControls } from "./WrapperControls";
 
 export const Container = styled("div")`
-  margin: ${space[3]}px -32px;
+  margin: ${space[3]}px -${actionSpacing}px;
 `;
 
 export const Body = styled("div")`

--- a/src/renderers/react/WrapperControls.tsx
+++ b/src/renderers/react/WrapperControls.tsx
@@ -107,18 +107,8 @@ const LeftActions = styled(Actions)`
   position: relative;
 `;
 
-const LeftRepeaterActions = styled(LeftActions)`
-  height: 100%;
-  justify-content: flex-end;
-`;
-
 const RightActions = styled(Actions)`
   right: -${buttonWidth + 1}px;
-`;
-
-const RightRepeaterActions = styled(RightActions)`
-  height: 100%;
-  justify-content: space-between;
 `;
 
 const Tooltip = styled("div")`
@@ -313,14 +303,32 @@ export type RightRepeaterActionProps = {
   index: number;
 };
 
-const RepeaterControls = styled("div")`
-  padding-top: 8px;
+const LeftRepeaterActions = styled(Actions)`
+  height: 100%;
+  justify-content: space-between;
+  position: absolute;
+  left: -32px;
+`;
+
+const RightRepeaterActions = styled(Actions)`
+  height: 100%;
+  justify-content: space-between;
 `;
 
 const RepeaterActions = styled("div")`
   display: flex;
   flex-direction: column;
   align-items: center;
+`;
+
+const TopRepeaterActions = styled(RepeaterActions)`
+  position: absolute;
+  top: 0;
+`;
+
+const BottomRepeaterActions = styled(RepeaterActions)`
+  position: absolute;
+  bottom: 0;
 `;
 
 export const LeftRepeaterActionControls = ({
@@ -331,32 +339,30 @@ export const LeftRepeaterActionControls = ({
   const [closeClickedOnce, setCloseClickedOnce] = useState(false);
 
   return (
-    <RepeaterControls>
-      <LeftRepeaterActions className="actions">
-        <RepeaterActions>
-          <SeriousButton
-            type="button"
-            activated={closeClickedOnce}
-            data-cy={removeChildTestId}
-            disabled={numberOfChildNodes === minChildren}
-            onClick={(e) => {
-              if (closeClickedOnce) {
-                return removeChildAt(e);
-              } else {
-                setCloseClickedOnce(true);
-                setTimeout(() => {
-                  setCloseClickedOnce(false);
-                }, 5000);
-              }
-            }}
-            aria-label="Remove repeater child"
-          >
-            <SvgBin />
-            {closeClickedOnce && <Tooltip>Click again to confirm</Tooltip>}
-          </SeriousButton>
-        </RepeaterActions>
-      </LeftRepeaterActions>
-    </RepeaterControls>
+    <LeftRepeaterActions className="actions">
+      <BottomRepeaterActions>
+        <SeriousButton
+          type="button"
+          activated={closeClickedOnce}
+          data-cy={removeChildTestId}
+          disabled={numberOfChildNodes === minChildren}
+          onClick={(e) => {
+            if (closeClickedOnce) {
+              return removeChildAt(e);
+            } else {
+              setCloseClickedOnce(true);
+              setTimeout(() => {
+                setCloseClickedOnce(false);
+              }, 5000);
+            }
+          }}
+          aria-label="Remove repeater child"
+        >
+          <SvgBin />
+          {closeClickedOnce && <Tooltip>Click again to confirm</Tooltip>}
+        </SeriousButton>
+      </BottomRepeaterActions>
+    </LeftRepeaterActions>
   );
 };
 
@@ -368,39 +374,37 @@ export const RightRepeaterActionControls = ({
   index,
 }: RightRepeaterActionProps) => {
   return (
-    <RepeaterControls>
-      <RightRepeaterActions className="actions">
-        <RepeaterActions>
-          <Button
-            type="button"
-            data-cy={moveChildUpTestId}
-            disabled={index <= 0}
-            onClick={moveChildUpOne}
-            aria-label="Move repeater child up"
-          >
-            <SvgArrowUpStraight />
-          </Button>
-          <Button
-            type="button"
-            data-cy={moveChildDownTestId}
-            disabled={index >= numberOfChildNodes - 1}
-            onClick={moveChildDownOne}
-            aria-label="Move repeater child down"
-          >
-            <SvgArrowDownStraight />
-          </Button>
-        </RepeaterActions>
-        <RepeaterActions>
-          <Button
-            type="button"
-            data-cy={addChildTestId}
-            onClick={addChildAfter}
-            aria-label="Add repeater child"
-          >
-            +
-          </Button>
-        </RepeaterActions>
-      </RightRepeaterActions>
-    </RepeaterControls>
+    <RightRepeaterActions className="actions">
+      <TopRepeaterActions>
+        <Button
+          type="button"
+          data-cy={moveChildUpTestId}
+          disabled={index <= 0}
+          onClick={moveChildUpOne}
+          aria-label="Move repeater child up"
+        >
+          <SvgArrowUpStraight />
+        </Button>
+        <Button
+          type="button"
+          data-cy={moveChildDownTestId}
+          disabled={index >= numberOfChildNodes - 1}
+          onClick={moveChildDownOne}
+          aria-label="Move repeater child down"
+        >
+          <SvgArrowDownStraight />
+        </Button>
+      </TopRepeaterActions>
+      <BottomRepeaterActions>
+        <Button
+          type="button"
+          data-cy={addChildTestId}
+          onClick={addChildAfter}
+          aria-label="Add repeater child"
+        >
+          +
+        </Button>
+      </BottomRepeaterActions>
+    </RightRepeaterActions>
   );
 };

--- a/src/renderers/react/WrapperControls.tsx
+++ b/src/renderers/react/WrapperControls.tsx
@@ -13,8 +13,8 @@ import { SvgBin } from "../../editorial-source-components/SvgBin";
 import { SvgHighlightAlt } from "../../editorial-source-components/SvgHighlightAlt";
 import { CommandTelemetryType } from "../../elements/helpers/types/TelemetryEvents";
 import type { SendTelemetryEvent } from "../../elements/helpers/types/TelemetryEvents";
+import { actionSpacing, buttonWidth } from "../../plugin/helpers/constants";
 
-const buttonWidth = 32;
 export const removeTestId = "ElementWrapper__remove";
 export const selectTestId = "ElementWrapper__select";
 export const moveTopTestId = "ElementWrapper__moveTop";
@@ -307,7 +307,7 @@ const LeftRepeaterActions = styled(Actions)`
   height: 100%;
   justify-content: space-between;
   position: absolute;
-  left: -32px;
+  left: -${actionSpacing}px;
 `;
 
 const RightRepeaterActions = styled(Actions)`


### PR DESCRIPTION
## What does this change?
Before:
<img width="866" alt="image" src="https://github.com/guardian/prosemirror-elements/assets/40991816/c04a7bc2-9157-4dce-9a3a-0e2dee1c9306">

After:
<img width="866" alt="image" src="https://github.com/guardian/prosemirror-elements/assets/40991816/33c0bac5-57ef-4c75-9aba-f7581dbf7a49">

We want more real estate for this type of element as it is closer to a document level item than an element level item. It also helps us deal with fitting our nested elements inside this element.

We now omit the headings for these fields because we want it to look closer to a document. We should consider adding better placeholders for these fields in a future PR (not trivial because placeholder logic is a bit of a muddle).


