### PR TITLE
Fix bug with text element serialisation in nestedElement fields

### DIFF
--- a/.changeset/twenty-pans-own.md
+++ b/.changeset/twenty-pans-own.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-elements": patch
+---
+
+Fix bug with text element serialisation in nestedElement field

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -437,7 +437,7 @@ const createNestedElementNode = (
           values,
         };
 
-        if (elementName === "textElement") {
+        if (elementName === "text") {
           const emptyTextElementNode = schema.nodes["textElement"].create({
             flexElement: null,
           });


### PR DESCRIPTION
## What does this change?
Text elements weren't saving and loading in flexible-content due to an inconsistency with naming. In flexible-content they have the `elementType` "text" but their internal `elementName` in prosemirror is "textElement".

This PR makes sure we recognise these nodes when we initialise the editor, and convert them to a "textElement".

## How to test
I've tested this functionality locally.

Use this library in `flexible-content` using this branch and https://github.com/guardian/flexible-content/pull/4566

