### PR TITLE
improve triggers for CI GHA

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -6,8 +6,7 @@ on:
       - main
       - beta
   pull_request:
-    branches:
-      - "*"
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Ensured that we always build PRs, as PRs not onto main were not building, e.g. if you chaining multiple PRs together... e.g. 
![image](https://github.com/guardian/prosemirror-elements/assets/19289579/54ca0e70-cea7-4223-925a-33f8b842b019)

Also added `workflow_dispatch` to allow for manually triggered workflows, also useful.