### PR TITLE
Display element controls vertically when elements are nested

### DIFF
--- a/demo/style.css
+++ b/demo/style.css
@@ -756,7 +756,7 @@ img.ProseMirror-separator {
 
 /* Prosemirror instances nested within elements */
 .ProseMirror .ProseMirror {
-  padding: 4px 8px;
+  padding: 4px 6px;
 }
 
 .ProseMirror-selectednode {

--- a/src/plugin/fieldViews/NestedElementFieldView.ts
+++ b/src/plugin/fieldViews/NestedElementFieldView.ts
@@ -137,7 +137,12 @@ export class NestedElementFieldView extends ProseMirrorFieldView {
       });
     }
     this.fieldViewElement.classList.add(
-      "ProseMirrorElements__NestedElementField"
+      "ProseMirrorElements__NestedElementField",
+      /*
+        This shorthand class is used to style the nested element.
+        It's easier to read and reason about than the longer class name.
+       */
+      "nested"
     );
   }
 }

--- a/src/renderers/react/AltStyleElementWrapper.tsx
+++ b/src/renderers/react/AltStyleElementWrapper.tsx
@@ -43,10 +43,7 @@ export const AltStyleElementWrapper: React.FunctionComponent<ElementWrapperProps
   children,
 }) => {
   return (
-    <AltStyleContainer
-      className="ProsemirrorElement__wrapper"
-      data-cy={elementWrapperTestId}
-    >
+    <AltStyleContainer className="wrapper" data-cy={elementWrapperTestId}>
       <AltStylePanel isSelected={isSelected}>
         {isSelected && <Overlay />}
         {children}

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -14,13 +14,19 @@ export const Container = styled("div")`
 
 export const Body = styled("div")`
   display: flex;
-  :hover,
-  :focus-within {
-    .actions {
-      opacity: 1;
-    }
-  }
   min-height: 134px;
+  &:not(:hover) .actions,
+  &:not(:focus-within) .actions,
+  .nested &:not(:hover) .actions,
+  .nested &:not(:focus-within) .actions {
+    opacity: 0;
+  }
+  &:hover .actions,
+  &:focus-within .actions,
+  .nested &:hover .actions,
+  .nested &:focus-within .actions {
+    opacity: 1;
+  }
 `;
 
 const Panel = styled("div")<{

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -3,13 +3,13 @@ import { space } from "@guardian/src-foundations";
 import { neutral } from "@guardian/src-foundations/palette";
 import type { ReactElement } from "react";
 import React, { useContext, useState } from "react";
-import { actionSpacing } from "../../plugin/helpers/constants";
 import type { CommandCreator } from "../../plugin/types/Commands";
 import { TelemetryContext } from "./TelemetryContext";
 import { LeftActionControls, RightActionControls } from "./WrapperControls";
 
 export const Container = styled("div")`
-  margin: ${space[3]}px -${actionSpacing}px;
+  margin: ${space[3]}px 0;
+  position: relative;
 `;
 
 export const Body = styled("div")`

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -15,17 +15,31 @@ export const Container = styled("div")`
 export const Body = styled("div")`
   display: flex;
   min-height: 134px;
-  &:not(:hover) .actions,
-  &:not(:focus-within) .actions,
-  .nested &:not(:hover) .actions,
-  .nested &:not(:focus-within) .actions {
+  .wrapper:not(:hover) .actions,
+  .wrapper:not(:focus-within) .actions,
+  .nested .wrapper:not(:hover) .actions,
+  .nested .wrapper:not(:focus-within) .actions {
     opacity: 0;
   }
-  &:hover .actions,
-  &:focus-within .actions,
-  .nested &:hover .actions,
-  .nested &:focus-within .actions {
+  .wrapper:hover .actions,
+  .wrapper:focus-within .actions,
+  .nested .wrapper:hover .actions,
+  .nested .wrapper:focus-within .actions {
     opacity: 1;
+    // z-index: 11 is required to make sure the controls are on top of other ProseMirror styles
+    z-index: 11;
+  }
+  // If nested element's controls are visible, hide parent's controls
+  :has(.nested .wrapper:hover) {
+    .actions {
+      opacity: 0;
+    }
+    .nested .wrapper:hover .actions,
+    .nested .wrapper:focus-within .actions {
+      opacity: 1;
+      // z-index: 12 is required to make sure the nested element's controls are on top of the parent's controls
+      z-index: 12;
+    }
   }
 `;
 
@@ -87,10 +101,7 @@ export const ElementWrapper: React.FunctionComponent<ElementWrapperProps> = ({
   const sendTelemetryEvent = useContext(TelemetryContext);
 
   return (
-    <Container
-      className="ProsemirrorElement__wrapper"
-      data-cy={elementWrapperTestId}
-    >
+    <Container className="wrapper" data-cy={elementWrapperTestId}>
       <Body>
         <LeftActionControls
           select={select}

--- a/src/renderers/react/WrapperControls.tsx
+++ b/src/renderers/react/WrapperControls.tsx
@@ -132,7 +132,6 @@ const Actions = styled("div")`
   flex-direction: column;
   align-items: center;
   width: ${actionSpacing}px;
-  z-index: 11;
   transition: opacity 0.2s;
 `;
 

--- a/src/renderers/react/WrapperControls.tsx
+++ b/src/renderers/react/WrapperControls.tsx
@@ -95,22 +95,6 @@ const SeriousButton = styled(Button)<{ activated?: boolean }>`
   }
 `;
 
-const Actions = styled("div")`
-  display: flex;
-  flex-direction: column;
-  opacity: 0;
-  transition: opacity 0.2s;
-`;
-
-const LeftActions = styled(Actions)`
-  justify-content: space-between;
-  position: relative;
-`;
-
-const RightActions = styled(Actions)`
-  right: -${buttonWidth + 1}px;
-`;
-
 const Tooltip = styled("div")`
   background-color: ${neutral[97]};
   color: ${neutral[0]};
@@ -160,40 +144,44 @@ export const LeftActionControls = ({
 }: LeftActionProps) => {
   return (
     <LeftActions className="actions">
-      <SeriousButton
-        type="button"
-        data-cy={selectTestId}
-        disabled={!select(false)}
-        onClick={() => {
-          sendTelemetryEvent?.(CommandTelemetryType.PMESelectButtonPressed);
-          select(true);
-        }}
-        aria-label="Select element"
-      >
-        <SvgHighlightAlt />
-      </SeriousButton>
-      <SeriousButton
-        type="button"
-        activated={closeClickedOnce}
-        data-cy={removeTestId}
-        disabled={!remove(false)}
-        onClick={() => {
-          if (closeClickedOnce) {
-            sendTelemetryEvent?.(CommandTelemetryType.PMERemoveButtonPressed);
-            remove(true);
-            onRemove?.();
-          } else {
-            setCloseClickedOnce(true);
-            setTimeout(() => {
-              setCloseClickedOnce(false);
-            }, 5000);
-          }
-        }}
-        aria-label="Delete element"
-      >
-        <SvgBin />
-        {closeClickedOnce && <Tooltip>Click again to confirm</Tooltip>}
-      </SeriousButton>
+      <TopActions>
+        <SeriousButton
+          type="button"
+          data-cy={selectTestId}
+          disabled={!select(false)}
+          onClick={() => {
+            sendTelemetryEvent?.(CommandTelemetryType.PMESelectButtonPressed);
+            select(true);
+          }}
+          aria-label="Select element"
+        >
+          <SvgHighlightAlt />
+        </SeriousButton>
+      </TopActions>
+      <BottomActions>
+        <SeriousButton
+          type="button"
+          activated={closeClickedOnce}
+          data-cy={removeTestId}
+          disabled={!remove(false)}
+          onClick={() => {
+            if (closeClickedOnce) {
+              sendTelemetryEvent?.(CommandTelemetryType.PMERemoveButtonPressed);
+              remove(true);
+              onRemove?.();
+            } else {
+              setCloseClickedOnce(true);
+              setTimeout(() => {
+                setCloseClickedOnce(false);
+              }, 5000);
+            }
+          }}
+          aria-label="Delete element"
+        >
+          <SvgBin />
+          {closeClickedOnce && <Tooltip>Click again to confirm</Tooltip>}
+        </SeriousButton>
+      </BottomActions>
     </LeftActions>
   );
 };
@@ -215,76 +203,80 @@ export const RightActionControls = ({
 }: RightActionProps) => {
   return (
     <RightActions className="actions">
-      <Button
-        type="button"
-        data-cy={moveTopTestId}
-        disabled={!moveTop(false)}
-        onClick={() => {
-          sendTelemetryEvent?.(CommandTelemetryType.PMEUpButtonPressed, {
-            jump: true,
-          });
-          moveTop(true);
-        }}
-        aria-label="Move element to top"
-      >
-        <div
-          css={css`
-            transform: rotate(270deg) translate(1px, 1px);
-          `}
+      <TopActions>
+        <Button
+          type="button"
+          data-cy={moveTopTestId}
+          disabled={!moveTop(false)}
+          onClick={() => {
+            sendTelemetryEvent?.(CommandTelemetryType.PMEUpButtonPressed, {
+              jump: true,
+            });
+            moveTop(true);
+          }}
+          aria-label="Move element to top"
         >
-          <SvgChevronRightDouble />
-        </div>
-      </Button>
-      <Button
-        type="button"
-        data-cy={moveUpTestId}
-        expanded
-        disabled={!moveUp(false)}
-        onClick={() => {
-          sendTelemetryEvent?.(CommandTelemetryType.PMEUpButtonPressed, {
-            jump: false,
-          });
-          moveUp(true);
-        }}
-        aria-label="Move element up"
-      >
-        <SvgArrowUpStraight />
-      </Button>
-      <Button
-        type="button"
-        data-cy={moveDownTestId}
-        expanded
-        disabled={!moveDown(false)}
-        onClick={() => {
-          sendTelemetryEvent?.(CommandTelemetryType.PMEDownButtonPressed, {
-            jump: false,
-          });
-          moveDown(true);
-        }}
-        aria-label="Move element down"
-      >
-        <SvgArrowDownStraight />
-      </Button>
-      <Button
-        type="button"
-        data-cy={moveBottomTestId}
-        disabled={!moveBottom(false)}
-        onClick={() => {
-          sendTelemetryEvent?.(CommandTelemetryType.PMEDownButtonPressed, {
-            jump: true,
-          });
-          moveBottom(true);
-        }}
-        aria-label="Move element to bottom"
-      >
-        <div
-          css={css`
-            transform: rotate(90deg) translate(-2px, 2px);
-          `}
+          <div
+            css={css`
+              transform: rotate(270deg) translate(1px, 1px);
+            `}
+          >
+            <SvgChevronRightDouble />
+          </div>
+        </Button>
+        <Button
+          type="button"
+          data-cy={moveUpTestId}
+          expanded
+          disabled={!moveUp(false)}
+          onClick={() => {
+            sendTelemetryEvent?.(CommandTelemetryType.PMEUpButtonPressed, {
+              jump: false,
+            });
+            moveUp(true);
+          }}
+          aria-label="Move element up"
         >
-          <SvgChevronRightDouble />
-        </div>
-      </Button>
+          <SvgArrowUpStraight />
+        </Button>
+      </TopActions>
+      <BottomActions>
+        <Button
+          type="button"
+          data-cy={moveDownTestId}
+          expanded
+          disabled={!moveDown(false)}
+          onClick={() => {
+            sendTelemetryEvent?.(CommandTelemetryType.PMEDownButtonPressed, {
+              jump: false,
+            });
+            moveDown(true);
+          }}
+          aria-label="Move element down"
+        >
+          <SvgArrowDownStraight />
+        </Button>
+        <Button
+          type="button"
+          data-cy={moveBottomTestId}
+          disabled={!moveBottom(false)}
+          onClick={() => {
+            sendTelemetryEvent?.(CommandTelemetryType.PMEDownButtonPressed, {
+              jump: true,
+            });
+            moveBottom(true);
+          }}
+          aria-label="Move element to bottom"
+        >
+          <div
+            css={css`
+              transform: rotate(90deg) translate(-2px, 2px);
+            `}
+          >
+            <SvgChevronRightDouble />
+          </div>
+        </Button>
+      </BottomActions>
     </RightActions>
   );
 };
@@ -303,32 +295,39 @@ export type RightRepeaterActionProps = {
   index: number;
 };
 
-const LeftRepeaterActions = styled(Actions)`
+const Actions = styled("div")`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: ${actionSpacing}px;
+`;
+
+const LeftActions = styled(Actions)`
   height: 100%;
   justify-content: space-between;
   position: absolute;
   left: -${actionSpacing}px;
 `;
 
-const RightRepeaterActions = styled(Actions)`
+const RightActions = styled(Actions)`
   height: 100%;
   justify-content: space-between;
+  position: absolute;
+  right: -${actionSpacing}px;
 `;
 
-const RepeaterActions = styled("div")`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`;
-
-const TopRepeaterActions = styled(RepeaterActions)`
+const TopActions = styled(Actions)`
   position: absolute;
   top: 0;
+  height: 50%;
+  justify-content: flex-start;
 `;
 
-const BottomRepeaterActions = styled(RepeaterActions)`
+const BottomActions = styled(Actions)`
   position: absolute;
   bottom: 0;
+  height: 50%;
+  justify-content: flex-end;
 `;
 
 export const LeftRepeaterActionControls = ({
@@ -339,8 +338,8 @@ export const LeftRepeaterActionControls = ({
   const [closeClickedOnce, setCloseClickedOnce] = useState(false);
 
   return (
-    <LeftRepeaterActions className="actions">
-      <BottomRepeaterActions>
+    <LeftActions className="actions">
+      <BottomActions>
         <SeriousButton
           type="button"
           activated={closeClickedOnce}
@@ -361,8 +360,8 @@ export const LeftRepeaterActionControls = ({
           <SvgBin />
           {closeClickedOnce && <Tooltip>Click again to confirm</Tooltip>}
         </SeriousButton>
-      </BottomRepeaterActions>
-    </LeftRepeaterActions>
+      </BottomActions>
+    </LeftActions>
   );
 };
 
@@ -374,8 +373,8 @@ export const RightRepeaterActionControls = ({
   index,
 }: RightRepeaterActionProps) => {
   return (
-    <RightRepeaterActions className="actions">
-      <TopRepeaterActions>
+    <RightActions className="actions">
+      <TopActions>
         <Button
           type="button"
           data-cy={moveChildUpTestId}
@@ -394,8 +393,8 @@ export const RightRepeaterActionControls = ({
         >
           <SvgArrowDownStraight />
         </Button>
-      </TopRepeaterActions>
-      <BottomRepeaterActions>
+      </TopActions>
+      <BottomActions>
         <Button
           type="button"
           data-cy={addChildTestId}
@@ -404,7 +403,7 @@ export const RightRepeaterActionControls = ({
         >
           +
         </Button>
-      </BottomRepeaterActions>
-    </RightRepeaterActions>
+      </BottomActions>
+    </RightActions>
   );
 };

--- a/src/renderers/react/WrapperControls.tsx
+++ b/src/renderers/react/WrapperControls.tsx
@@ -32,15 +32,14 @@ const Button = styled("button")<{ expanded?: boolean }>`
   appearance: none;
   background: ${neutral[93]};
   border: none;
-  border-top: 1px solid ${neutral[100]};
   color: ${neutral[0]};
   cursor: pointer;
   flex-grow: ${({ expanded }) => (expanded ? "1" : "0")};
-  ${({ expanded }) => !expanded && `height: ${buttonWidth}px;`};
   font-size: 15px;
   line-height: 1;
   padding: ${space[1]}px;
   width: ${buttonWidth}px;
+  height: ${buttonWidth}px;
   transition: background-color 0.1s;
   :focus {
     ${focusHalo};
@@ -125,6 +124,40 @@ const Tooltip = styled("div")`
   }
 `;
 
+type VerticalPosition = "top" | "bottom";
+type HorizontalPosition = "left" | "right";
+
+const Actions = styled("div")`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: ${actionSpacing}px;
+  z-index: 11;
+  transition: opacity 0.2s;
+`;
+
+const SideActions = styled(Actions)<{
+  horizontalPosition: HorizontalPosition;
+}>`
+  height: 100%;
+  position: absolute;
+  ${({ horizontalPosition }) => `${horizontalPosition}: -${actionSpacing}px`};
+  justify-content: space-between;
+`;
+
+const VerticalActions = styled("div")<{
+  verticalPosition: VerticalPosition;
+}>`
+  position: absolute;
+  ${({ verticalPosition }) => `${verticalPosition}: 0`};
+  display: flex;
+  flex-direction: ${({ verticalPosition }) =>
+    verticalPosition === "top" ? "column" : "column-reverse"};
+  align-items: center;
+  width: ${actionSpacing}px;
+  height: 50%;
+`;
+
 export type LeftActionProps = {
   select: (run?: boolean) => true | void;
   remove: (run?: boolean) => true | void;
@@ -141,50 +174,48 @@ export const LeftActionControls = ({
   closeClickedOnce,
   setCloseClickedOnce,
   sendTelemetryEvent,
-}: LeftActionProps) => {
-  return (
-    <LeftActions className="actions">
-      <TopActions>
-        <SeriousButton
-          type="button"
-          data-cy={selectTestId}
-          disabled={!select(false)}
-          onClick={() => {
-            sendTelemetryEvent?.(CommandTelemetryType.PMESelectButtonPressed);
-            select(true);
-          }}
-          aria-label="Select element"
-        >
-          <SvgHighlightAlt />
-        </SeriousButton>
-      </TopActions>
-      <BottomActions>
-        <SeriousButton
-          type="button"
-          activated={closeClickedOnce}
-          data-cy={removeTestId}
-          disabled={!remove(false)}
-          onClick={() => {
-            if (closeClickedOnce) {
-              sendTelemetryEvent?.(CommandTelemetryType.PMERemoveButtonPressed);
-              remove(true);
-              onRemove?.();
-            } else {
-              setCloseClickedOnce(true);
-              setTimeout(() => {
-                setCloseClickedOnce(false);
-              }, 5000);
-            }
-          }}
-          aria-label="Delete element"
-        >
-          <SvgBin />
-          {closeClickedOnce && <Tooltip>Click again to confirm</Tooltip>}
-        </SeriousButton>
-      </BottomActions>
-    </LeftActions>
-  );
-};
+}: LeftActionProps) => (
+  <SideActions className="actions" horizontalPosition={"left"}>
+    <VerticalActions verticalPosition={"top"}>
+      <SeriousButton
+        type="button"
+        data-cy={selectTestId}
+        disabled={!select(false)}
+        onClick={() => {
+          sendTelemetryEvent?.(CommandTelemetryType.PMESelectButtonPressed);
+          select(true);
+        }}
+        aria-label="Select element"
+      >
+        <SvgHighlightAlt />
+      </SeriousButton>
+    </VerticalActions>
+    <VerticalActions verticalPosition={"bottom"}>
+      <SeriousButton
+        type="button"
+        activated={closeClickedOnce}
+        data-cy={removeTestId}
+        disabled={!remove(false)}
+        onClick={() => {
+          if (closeClickedOnce) {
+            sendTelemetryEvent?.(CommandTelemetryType.PMERemoveButtonPressed);
+            remove(true);
+            onRemove?.();
+          } else {
+            setCloseClickedOnce(true);
+            setTimeout(() => {
+              setCloseClickedOnce(false);
+            }, 5000);
+          }
+        }}
+        aria-label="Delete element"
+      >
+        <SvgBin />
+        {closeClickedOnce && <Tooltip>Click again to confirm</Tooltip>}
+      </SeriousButton>
+    </VerticalActions>
+  </SideActions>
+);
 
 export type RightActionProps = {
   moveUp: (run?: boolean) => boolean | void;
@@ -200,86 +231,84 @@ export const RightActionControls = ({
   moveTop,
   moveBottom,
   sendTelemetryEvent,
-}: RightActionProps) => {
-  return (
-    <RightActions className="actions">
-      <TopActions>
-        <Button
-          type="button"
-          data-cy={moveTopTestId}
-          disabled={!moveTop(false)}
-          onClick={() => {
-            sendTelemetryEvent?.(CommandTelemetryType.PMEUpButtonPressed, {
-              jump: true,
-            });
-            moveTop(true);
-          }}
-          aria-label="Move element to top"
+}: RightActionProps) => (
+  <SideActions className="actions" horizontalPosition={"right"}>
+    <VerticalActions verticalPosition={"top"}>
+      <Button
+        type="button"
+        data-cy={moveTopTestId}
+        disabled={!moveTop(false)}
+        onClick={() => {
+          sendTelemetryEvent?.(CommandTelemetryType.PMEUpButtonPressed, {
+            jump: true,
+          });
+          moveTop(true);
+        }}
+        aria-label="Move element to top"
+      >
+        <div
+          css={css`
+            transform: rotate(270deg) translate(1px, 1px);
+          `}
         >
-          <div
-            css={css`
-              transform: rotate(270deg) translate(1px, 1px);
-            `}
-          >
-            <SvgChevronRightDouble />
-          </div>
-        </Button>
-        <Button
-          type="button"
-          data-cy={moveUpTestId}
-          expanded
-          disabled={!moveUp(false)}
-          onClick={() => {
-            sendTelemetryEvent?.(CommandTelemetryType.PMEUpButtonPressed, {
-              jump: false,
-            });
-            moveUp(true);
-          }}
-          aria-label="Move element up"
+          <SvgChevronRightDouble />
+        </div>
+      </Button>
+      <Button
+        type="button"
+        data-cy={moveUpTestId}
+        expanded
+        disabled={!moveUp(false)}
+        onClick={() => {
+          sendTelemetryEvent?.(CommandTelemetryType.PMEUpButtonPressed, {
+            jump: false,
+          });
+          moveUp(true);
+        }}
+        aria-label="Move element up"
+      >
+        <SvgArrowUpStraight />
+      </Button>
+    </VerticalActions>
+    <VerticalActions verticalPosition={"bottom"}>
+      <Button
+        type="button"
+        data-cy={moveBottomTestId}
+        disabled={!moveBottom(false)}
+        onClick={() => {
+          sendTelemetryEvent?.(CommandTelemetryType.PMEDownButtonPressed, {
+            jump: true,
+          });
+          moveBottom(true);
+        }}
+        aria-label="Move element to bottom"
+      >
+        <div
+          css={css`
+            transform: rotate(90deg) translate(-2px, 2px);
+          `}
         >
-          <SvgArrowUpStraight />
-        </Button>
-      </TopActions>
-      <BottomActions>
-        <Button
-          type="button"
-          data-cy={moveDownTestId}
-          expanded
-          disabled={!moveDown(false)}
-          onClick={() => {
-            sendTelemetryEvent?.(CommandTelemetryType.PMEDownButtonPressed, {
-              jump: false,
-            });
-            moveDown(true);
-          }}
-          aria-label="Move element down"
-        >
-          <SvgArrowDownStraight />
-        </Button>
-        <Button
-          type="button"
-          data-cy={moveBottomTestId}
-          disabled={!moveBottom(false)}
-          onClick={() => {
-            sendTelemetryEvent?.(CommandTelemetryType.PMEDownButtonPressed, {
-              jump: true,
-            });
-            moveBottom(true);
-          }}
-          aria-label="Move element to bottom"
-        >
-          <div
-            css={css`
-              transform: rotate(90deg) translate(-2px, 2px);
-            `}
-          >
-            <SvgChevronRightDouble />
-          </div>
-        </Button>
-      </BottomActions>
-    </RightActions>
-  );
-};
+          <SvgChevronRightDouble />
+        </div>
+      </Button>
+      <Button
+        type="button"
+        data-cy={moveDownTestId}
+        expanded
+        disabled={!moveDown(false)}
+        onClick={() => {
+          sendTelemetryEvent?.(CommandTelemetryType.PMEDownButtonPressed, {
+            jump: false,
+          });
+          moveDown(true);
+        }}
+        aria-label="Move element down"
+      >
+        <SvgArrowDownStraight />
+      </Button>
+    </VerticalActions>
+  </SideActions>
+);
 
 export type LeftRepeaterActionProps = {
   removeChildAt: MouseEventHandler<HTMLButtonElement>;
@@ -295,41 +324,6 @@ export type RightRepeaterActionProps = {
   index: number;
 };
 
-const Actions = styled("div")`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: ${actionSpacing}px;
-`;
-
-const LeftActions = styled(Actions)`
-  height: 100%;
-  justify-content: space-between;
-  position: absolute;
-  left: -${actionSpacing}px;
-`;
-
-const RightActions = styled(Actions)`
-  height: 100%;
-  justify-content: space-between;
-  position: absolute;
-  right: -${actionSpacing}px;
-`;
-
-const TopActions = styled(Actions)`
-  position: absolute;
-  top: 0;
-  height: 50%;
-  justify-content: flex-start;
-`;
-
-const BottomActions = styled(Actions)`
-  position: absolute;
-  bottom: 0;
-  height: 50%;
-  justify-content: flex-end;
-`;
-
 export const LeftRepeaterActionControls = ({
   removeChildAt,
   numberOfChildNodes,
@@ -338,8 +332,8 @@ export const LeftRepeaterActionControls = ({
   const [closeClickedOnce, setCloseClickedOnce] = useState(false);
 
   return (
-    <LeftActions className="actions">
-      <BottomActions>
+    <SideActions className="actions" horizontalPosition={"left"}>
+      <VerticalActions verticalPosition={"bottom"}>
         <SeriousButton
           type="button"
           activated={closeClickedOnce}
@@ -360,8 +354,8 @@ export const LeftRepeaterActionControls = ({
           <SvgBin />
           {closeClickedOnce && <Tooltip>Click again to confirm</Tooltip>}
         </SeriousButton>
-      </BottomActions>
-    </LeftActions>
+      </VerticalActions>
+    </SideActions>
   );
 };
 
@@ -373,8 +367,8 @@ export const RightRepeaterActionControls = ({
   index,
 }: RightRepeaterActionProps) => {
   return (
-    <RightActions className="actions">
-      <TopActions>
+    <SideActions className="actions" horizontalPosition={"right"}>
+      <VerticalActions verticalPosition={"top"}>
         <Button
           type="button"
           data-cy={moveChildUpTestId}
@@ -393,8 +387,8 @@ export const RightRepeaterActionControls = ({
         >
           <SvgArrowDownStraight />
         </Button>
-      </TopActions>
-      <BottomActions>
+      </VerticalActions>
+      <VerticalActions verticalPosition={"bottom"}>
         <Button
           type="button"
           data-cy={addChildTestId}
@@ -403,7 +397,7 @@ export const RightRepeaterActionControls = ({
         >
           +
         </Button>
-      </BottomActions>
-    </RightActions>
+      </VerticalActions>
+    </SideActions>
   );
 };


### PR DESCRIPTION
## What does this change?
When using nested elements within repeaters, we found there was often a clash between them and we were worried that users might get the two control sets confused. 

This PR displays the controls differently depending on whether the controls are nested or not:
* Regular Element => Horizontal Controls (to the sides of the element) - as before
* Nested Element => Vertical Controls (on top or on the bottom of the element) - **new**

### Before:
<img width="797" alt="image" src="https://github.com/guardian/prosemirror-elements/assets/40991816/ef27069a-9d82-4e32-92e3-b6ad91c7b24a">

### After:
https://github.com/guardian/prosemirror-elements/assets/40991816/d882c408-6eae-4422-9fe7-4509833b24e0

## How to test
See if the controls work as expected and render as before for regular elements. You might want to also test it in a consuming application (e.g. Composer) using `yalc`.

Note that using the nested controls exposes the placeholder bugs we are experiencing more keenly - but that's not in the purview of this PR.

## Notes
It could be argued this doesn't improve the situation as much as we would have hoped. The vertical spacing between elements is much larger than before (to accommodate the vertical controls).

If we had we increased this spacing just a little, without making the nested controls display vertically, we would have eliminated most of the clash between the control sets. This PR is definitely better to help distinguish between the two, but we should ask ourselves if this is worth the trade-off of increasing the vertical spacing.

I'm also open to other suggestions and ideas.
