### PR TITLE
collapse border between adjacent alt-style fields

### DIFF
--- a/src/editorial-source-components/FieldWrapper.tsx
+++ b/src/editorial-source-components/FieldWrapper.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/react";
 import type { ValidationError } from "../plugin/elementSpec";
 import type { FieldView } from "../plugin/fieldViews/FieldView";
 import type { Field } from "../plugin/types/Element";
@@ -28,7 +29,17 @@ export const FieldWrapper = <F extends Field<FieldView<unknown>>>({
   useAlternateStyles,
   showHeading = true,
 }: Props<F>) => (
-  <div className={className}>
+  <div
+    className={className}
+    css={
+      useAlternateStyles &&
+      css`
+        &:not(:first-of-type) div {
+          border-top: none; //collapse border between adjacent alt-style fields
+        }
+      `
+    }
+  >
     {showHeading ? (
       <InputHeading
         name={field.name}

--- a/src/elements/alt-style/AltStyleElementForm.tsx
+++ b/src/elements/alt-style/AltStyleElementForm.tsx
@@ -58,7 +58,7 @@ const ChildNumber = styled("div")`
   height: ${buttonWidth}px;
   width: ${buttonWidth}px;
   top: 0;
-  left: -${actionSpacing}px;
+  left: -${actionSpacing - 1}px; // -1 ensures border of number overlaps/collapses into border of first field
   padding: 2px;
   border: 1px solid ${neutral[60]};
   position: absolute;


### PR DESCRIPTION
This double line was grating on me whilst working on something else. 
CSS is a bit fiddly given the layers of DOM between the div with the existing `border` css and the the thing which would respond to `:not(:first-of-type)` selector.

Also, nudged the alt-style `ChildNumber` over a pixel, again to avoid double/adjacent borders.

| Before | After |
| --- | --- |
| <img width="742" alt="image" src="https://github.com/guardian/prosemirror-elements/assets/19289579/dca12b18-acff-491a-9191-aedff53f11ac"> | <img width="736" alt="image" src="https://github.com/guardian/prosemirror-elements/assets/19289579/f8e83229-86c3-4eaa-850a-e04eab5eadca"> |