### PR TITLE
Only show controls on hover or focus

### DIFF
--- a/.changeset/dull-rings-clean.md
+++ b/.changeset/dull-rings-clean.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-elements": patch
+---
+
+Only show element controls on hover or focus

--- a/src/renderers/react/ElementWrapper.tsx
+++ b/src/renderers/react/ElementWrapper.tsx
@@ -15,24 +15,16 @@ export const Container = styled("div")`
 export const Body = styled("div")`
   display: flex;
   min-height: 134px;
-  .ProseMirrorElements__Wrapper:not(:hover) .actions,
-  .ProseMirrorElements__Wrapper:not(:focus-within) .actions,
-  .ProseMirrorElements__NestedElementField
-    .ProseMirrorElements__Wrapper:not(:hover)
-    .actions,
-  .ProseMirrorElements__NestedElementField
-    .ProseMirrorElements__Wrapper:not(:focus-within)
-    .actions {
+  &:not(:hover) .actions,
+  &:not(:focus-within) .actions,
+  .ProseMirrorElements__NestedElementField &:not(:hover) .actions,
+  .ProseMirrorElements__NestedElementField &:not(:focus-within) .actions {
     opacity: 0;
   }
-  .ProseMirrorElements__Wrapper:hover .actions,
-  .ProseMirrorElements__Wrapper:focus-within .actions,
-  .ProseMirrorElements__NestedElementField
-    .ProseMirrorElements__Wrapper:hover
-    .actions,
-  .ProseMirrorElements__NestedElementField
-    .ProseMirrorElements__Wrapper:focus-within
-    .actions {
+  &:hover .actions,
+  &:focus-within .actions,
+  .ProseMirrorElements__NestedElementField &:hover .actions,
+  .ProseMirrorElements__NestedElementField &:focus-within .actions {
     opacity: 1;
     // z-index: 11 is required to make sure the controls are on top of other ProseMirror styles
     z-index: 11;


### PR DESCRIPTION
## What does this change?

A small bug slipped through the cracks in https://github.com/guardian/prosemirror-elements/pull/355, where a user didn't need to hover or focus a non-nested element to see its controls. This PR fixes that bug, while preserving all the other hover / focus changes of https://github.com/guardian/prosemirror-elements/pull/355.

### Before
https://github.com/guardian/prosemirror-elements/assets/40991816/f1368c48-5989-48a7-930f-3f4f62233f87

### After
https://github.com/guardian/prosemirror-elements/assets/40991816/499675b6-9821-4f2f-b722-94080efb85ff


## How to test
Do all hover / focus events work as expected?


