### PR TITLE
propagate click events upwards from inner editors (e.g. `NestedElementFieldView`) up to the top-level editor so that plugins work

### DIFF
--- a/cypress/tests/EventPropagationFromInnerEditors.cy.ts
+++ b/cypress/tests/EventPropagationFromInnerEditors.cy.ts
@@ -1,0 +1,30 @@
+import type { WindowType } from "../../demo/types";
+import {
+  addAltStyleElement,
+  getElementRichTextField,
+  visitRoot,
+} from "../helpers/editor";
+
+describe("should propagate events from inner editors to outer editor, so plugins etc. receive them'", () => {
+  beforeEach(visitRoot);
+
+  const startingPoint = {
+    repeater: [
+      {
+        title: "",
+        content: [],
+      },
+    ],
+  };
+
+  it("single clicks", () => {
+    addAltStyleElement(startingPoint); // add an element with an inner editor
+
+    getElementRichTextField("content").click();
+
+    cy.window().then((win: WindowType) => {
+      // @ts-expect-error - just using for testing so don't want to add to the window type
+      expect(win.viewPassedToPlugin).to.equal(win.PM_ELEMENTS.view);
+    });
+  });
+});

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -35,7 +35,10 @@ import {
   docToHtml,
   htmlToDoc,
 } from "../src/plugin/helpers/prosemirror";
-import { testDecorationPlugin } from "../src/plugin/helpers/test";
+import {
+  testDecorationPlugin,
+  testInnerEditorEventPropagationPlugin,
+} from "../src/plugin/helpers/test";
 import { CollabServer, EditorConnection } from "./collab/CollabServer";
 import { createSelectionCollabPlugin } from "./collab/SelectionPlugin";
 import {
@@ -370,6 +373,7 @@ const createEditor = (server: CollabServer) => {
         ...exampleSetup({ schema }),
         elementPlugin,
         testDecorationPlugin,
+        testInnerEditorEventPropagationPlugin,
         collabPlugin,
         updateElementDataPlugin,
         createSelectionCollabPlugin(clientID),

--- a/src/plugin/fieldViews/NestedElementFieldView.ts
+++ b/src/plugin/fieldViews/NestedElementFieldView.ts
@@ -97,10 +97,11 @@ export class NestedElementFieldView extends ProseMirrorFieldView {
       getPos,
       offset,
       decorations,
-      outerView.state.plugins.filter((plugin) =>
-        plugin.spec.key === undefined
-          ? true
-          : [pluginKey, ...allowedPlugins].includes(plugin.spec.key)
+      outerView.state.plugins.filter(
+        (plugin) =>
+          !plugin.spec.key ||
+          pluginKey === plugin.spec.key ||
+          allowedPlugins.includes(plugin.spec.key)
       ),
       placeholder,
       isResizeable

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -248,6 +248,18 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
       // This lets us propagate changes to the outer EditorView when needed.
       dispatchTransaction: this.dispatchTransaction.bind(this),
       decorations: () => this.decorations,
+
+      // we need to 'forward' clicks to the outer editor to ensure plugins etc. receive the events
+      handleClick: (view, pos, event) =>
+        this.outerView.someProp("handleClick", (f) =>
+          f(
+            // we pass the outer view here rather than inner view,
+            // so the correct 'state' is available to the final destination handler (e.g. plugin)
+            this.outerView,
+            pos,
+            event
+          )
+        ),
     });
 
     view.dom.id = this.getId();

--- a/src/plugin/helpers/test.ts
+++ b/src/plugin/helpers/test.ts
@@ -8,15 +8,15 @@ import { createElementSpec } from "../elementSpec";
 import type { ElementSpecMap, FieldDescriptions } from "../types/Element";
 import { createParsers } from "./prosemirror";
 
-const initialPhrase = "deco";
-const key = new PluginKey<string>("TEST_DECO_PLUGIN");
+const initialDecoPhrase = "deco";
+const testDecorationPluginKey = new PluginKey<string>("TEST_DECO_PLUGIN");
 export const ChangeTestDecoStringAction = "CHANGE_TEST_DECO_STRING";
 
 export const testDecorationPlugin = new Plugin<string>({
-  key,
+  key: testDecorationPluginKey,
   state: {
     init() {
-      return initialPhrase;
+      return initialDecoPhrase;
     },
     apply(tr, oldTestString) {
       const maybeNewTestString = tr.getMeta(ChangeTestDecoStringAction) as
@@ -27,7 +27,8 @@ export const testDecorationPlugin = new Plugin<string>({
   },
   props: {
     decorations: (state) => {
-      const testString = key.getState(state) ?? initialPhrase;
+      const testString =
+        testDecorationPluginKey.getState(state) ?? initialDecoPhrase;
       const ranges = [] as Array<[number, number]>;
       state.doc.descendants((node, offset) => {
         if (node.isLeaf && node.textContent) {
@@ -47,6 +48,24 @@ export const testDecorationPlugin = new Plugin<string>({
           Decoration.inline(from, to, { class: "TestDecoration" })
         )
       );
+    },
+  },
+});
+
+const testInnerEditorEventPropagationPluginKey = new PluginKey<string>(
+  "TEST_INNER_EDITOR_EVENT_PROPAGATION_PLUGIN"
+);
+export const testInnerEditorEventPropagationPlugin = new Plugin<string>({
+  key: testInnerEditorEventPropagationPluginKey,
+  props: {
+    handleClick: (view, pos, event) => {
+      console.log(
+        "click event received in",
+        testInnerEditorEventPropagationPluginKey,
+        { view, pos, event }
+      );
+      // @ts-expect-error - just using for testing so don't want to add to the window type
+      window.viewPassedToPlugin = view;
     },
   },
 });


### PR DESCRIPTION
https://trello.com/c/MhfcXb4t/2168-ensure-plugins-work-across-the-nestedelement-boundary-eg-noting-dragdrop-media-etc

Whilst reviewing #349 @Georges-GNM observed that when used in composer, notes weren’t individually clickable when inside a 'NestedElement` (i.e. an inner ProseMirror instance). This is because the [noting plugin](https://github.com/guardian/prosemirror-noting) operates on the top-level editor (and we don't re-register the plugin for inner editors as they instances of the plugin will essentially fight over the content).

Digging deeper, by utilising the debugger to view the call stack when interacting with notes in the top-level editor and comparing to interacting with notes in inner editors, the default `handleClick` for the inner editor was effectively eating the event and preventing it from travelling up to outer editor (where the plugin could do its thing). 

## What does this change?
This PR address the above (for more than just plugins) by defining a `handleClick` for all `ProseMirrorFieldView` (i.e. inner editors) and explicitly calls the `handleClick` for the 'outer view' (i.e. top-level editor) and crucially passing that function the outer view for the `view` argument to ensure when handled (in plugins etc.) it has access to the right view and state to perform as it should.

## How to test
Yalc it into composer local and add a note inside a nested element (e.g. key takeaways) and observe that you can click the left/right side of a note and collapse & expand it individually.

## How can we measure success?
More behaviour that users will naturally expect to work should indeed work.