### PR TITLE
Always update fieldView of nestedElement field

### DIFF
--- a/.changeset/neat-guests-study.md
+++ b/.changeset/neat-guests-study.md
@@ -1,0 +1,8 @@
+---
+"@guardian/prosemirror-elements": patch
+---
+
+Always update fieldViews for nestedElement fields, in order to fix
+a problem related to our zipRoot plugin in Composer, where joining
+text elements within a nestedElement causes the document to enter
+an invalid state, unless the fieldViews are updated again.

--- a/src/plugin/fieldViews/NestedElementFieldView.ts
+++ b/src/plugin/fieldViews/NestedElementFieldView.ts
@@ -38,12 +38,12 @@ export interface NestedElementFieldDescription
 export const anyDescendantFieldIsNestedElementField = (node: Node) => {
   let descendantFieldIsNestedElementField = false;
   node.descendants((node) => {
-    if (node.type.spec.content = "element+"){
-      descendantFieldIsNestedElementField = true
+    if (node.type.spec.content === "element+") {
+      descendantFieldIsNestedElementField = true;
     }
-  })
+  });
   return descendantFieldIsNestedElementField;
-}
+};
 
 export const createNestedElementField = ({
   absentOnEmpty,

--- a/src/plugin/fieldViews/NestedElementFieldView.ts
+++ b/src/plugin/fieldViews/NestedElementFieldView.ts
@@ -35,6 +35,16 @@ export interface NestedElementFieldDescription
   minRows?: number;
 }
 
+export const anyDescendantFieldIsNestedElementField = (node: Node) => {
+  let descendantFieldIsNestedElementField = false;
+  node.descendants((node) => {
+    if (node.type.spec.content = "element+"){
+      descendantFieldIsNestedElementField = true
+    }
+  })
+  return descendantFieldIsNestedElementField;
+}
+
 export const createNestedElementField = ({
   absentOnEmpty,
   attrs,

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -30,6 +30,7 @@ import {
   isProseMirrorElement,
   isProseMirrorElementSelected,
 } from "./nodeSpec";
+import { anyDescendantFieldIsNestedElementField } from "./fieldViews/NestedElementFieldView";
 
 const decorations = createUpdateDecorations();
 
@@ -263,9 +264,12 @@ const createNodeView = <
               transformElementOut,
             })
           : currentFields;
-
+        
         // Only update our FieldViews if their content or decorations have changed.
-        if (fieldValuesChanged || innerDecosChanged) {
+        // nestedElement FieldViews are always updated as a workaround for a bug
+        // with merging text elements in the zipRoot plugin after an intermediate element is 
+        // deleted.
+        if (fieldValuesChanged || innerDecosChanged || anyDescendantFieldIsNestedElementField(newNode)) {
           updateFieldViewsFromNode(newFields, newNode, innerDecos);
         }
 

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -16,6 +16,7 @@ import {
   updateFieldViewsFromNode,
 } from "./field";
 import type { FieldView } from "./fieldViews/FieldView";
+import { anyDescendantFieldIsNestedElementField } from "./fieldViews/NestedElementFieldView";
 import { pluginKey } from "./helpers/constants";
 import type {
   GetElementDataFromNode,
@@ -30,7 +31,6 @@ import {
   isProseMirrorElement,
   isProseMirrorElementSelected,
 } from "./nodeSpec";
-import { anyDescendantFieldIsNestedElementField } from "./fieldViews/NestedElementFieldView";
 
 const decorations = createUpdateDecorations();
 
@@ -264,12 +264,16 @@ const createNodeView = <
               transformElementOut,
             })
           : currentFields;
-        
+
         // Only update our FieldViews if their content or decorations have changed.
         // nestedElement FieldViews are always updated as a workaround for a bug
-        // with merging text elements in the zipRoot plugin after an intermediate element is 
+        // with merging text elements in the zipRoot plugin after an intermediate element is
         // deleted.
-        if (fieldValuesChanged || innerDecosChanged || anyDescendantFieldIsNestedElementField(newNode)) {
+        if (
+          fieldValuesChanged ||
+          innerDecosChanged ||
+          anyDescendantFieldIsNestedElementField(newNode)
+        ) {
           updateFieldViewsFromNode(newFields, newNode, innerDecos);
         }
 


### PR DESCRIPTION
## What does this change?
To be used in conjunction with https://github.com/guardian/flexible-content/pull/4645

This PR makes sure `nestedElement` fieldViews are always updated, as a workaround for a bug with the zipRoot plugin, that causes the document to be uneditable when an element is deleted between two text elements.

## How to test
1. Use this branch locally with Composer using yalc.
2. Do all the things suggested in the other PR: https://github.com/guardian/flexible-content/pull/4645