### PR TITLE
Release key event handling changes

### DIFF
--- a/.changeset/shiny-rice-eat.md
+++ b/.changeset/shiny-rice-eat.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-elements": patch
+---
+
+propagate key down & press events upwards from NestedElementFieldView up to the top-level editor so key mappings work as expected


### PR DESCRIPTION
## What does this change?
Release this change: https://github.com/guardian/prosemirror-elements/pull/363