### PR TITLE
Identify nestedElement fields even if their content expression is overridden

### DIFF
--- a/.changeset/little-donkeys-float.md
+++ b/.changeset/little-donkeys-float.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-elements": patch
+---
+
+Use stable identifier for nestedFields in fieldView update workaround

--- a/src/plugin/fieldViews/NestedElementFieldView.ts
+++ b/src/plugin/fieldViews/NestedElementFieldView.ts
@@ -42,7 +42,7 @@ export interface NestedElementFieldDescription
 export const anyDescendantFieldIsNestedElementField = (node: Node) => {
   let descendantFieldIsNestedElementField = false;
   node.descendants((node) => {
-    if (node.type.spec.content === "element+") {
+    if (node.type.spec.group?.includes("nested-element-field")) {
       descendantFieldIsNestedElementField = true;
     }
   });


### PR DESCRIPTION
## What does this change?
The [workaround](https://github.com/guardian/prosemirror-elements/pull/365) for the text element join after deleting a non-text element between two text elements relied on `nestedElement` fields having the content expression `element+`.

This is flawed, because the fields can have their content expression overridden - in fact we will need to override it to something like `nonKeyTakeawaysElement+` in order to prevent a key takeaway element being pasted into another a key takeaway element.

This PR uses the stable "nested-element-field" group that should appear in `nestedFields` as an identifier for our workaround to use. In the long run we'll want to fix the route cause of the `nestedElement` `fieldView` update bug that caused the join issue, rather than relying on this workaround.

n.b. Groups are modelled in a string of space-separated group strings rather than as an array of strings.

## How to test
If you're feeling diligent, use this version of `prosemirror-elements` locally in Composer via yalc.

Add text on either side of a pullquote and delete the pullquote. The document will appear invalid but will become valid on any mouse move. 
