### PR TITLE
Scroll to focused field, not top of element, when calling history commands in text editor fields

### DIFF
--- a/.changeset/loud-years-care.md
+++ b/.changeset/loud-years-care.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-elements": patch
+---
+
+Fix scrolling to top of element on undo in element field

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prosemirror-commands": "^1.5.2",
     "prosemirror-dev-tools": "^4.0.0",
     "prosemirror-example-setup": "^1.2.2",
-    "prosemirror-history": "^1.3.2",
+    "prosemirror-history": "^1.4.0",
     "prosemirror-keymap": "^1.2.2",
     "prosemirror-model": "^1.19.4",
     "prosemirror-schema-basic": "^1.2.2",

--- a/src/plugin/fieldViews/RichTextFieldView.ts
+++ b/src/plugin/fieldViews/RichTextFieldView.ts
@@ -1,11 +1,10 @@
 import { exampleSetup } from "prosemirror-example-setup";
-import { redo, undo } from "prosemirror-history";
 import { keymap } from "prosemirror-keymap";
 import type { AttributeSpec, Node, Schema } from "prosemirror-model";
 import type { EditorState, Plugin, Transaction } from "prosemirror-state";
 import type { DecorationSource, EditorView } from "prosemirror-view";
 import type { FieldValidator } from "../elementSpec";
-import { filteredKeymap } from "../helpers/keymap";
+import { createHistoryCommands, filteredKeymap } from "../helpers/keymap";
 import type { PlaceholderOption } from "../helpers/placeholder";
 import { createPlaceholderPlugin } from "../helpers/placeholder";
 import { selectAllText } from "../helpers/prosemirror";
@@ -133,8 +132,7 @@ export class RichTextFieldView extends ProseMirrorFieldView {
       decorations,
       [
         keymap({
-          "Mod-z": () => undo(outerView.state, outerView.dispatch),
-          "Mod-y": () => redo(outerView.state, outerView.dispatch),
+          ...createHistoryCommands(outerView),
           "Mod-a": selectAllText,
           ...filteredKeymap,
         }),

--- a/src/plugin/fieldViews/TextFieldView.ts
+++ b/src/plugin/fieldViews/TextFieldView.ts
@@ -1,11 +1,10 @@
 import { baseKeymap, newlineInCode } from "prosemirror-commands";
-import { redo, undo } from "prosemirror-history";
 import { keymap } from "prosemirror-keymap";
 import type { AttributeSpec, Node } from "prosemirror-model";
 import type { Command, EditorState, Transaction } from "prosemirror-state";
 import type { DecorationSource, EditorView } from "prosemirror-view";
 import type { FieldValidator } from "../elementSpec";
-import { filteredKeymap } from "../helpers/keymap";
+import { createHistoryCommands, filteredKeymap } from "../helpers/keymap";
 import type { PlaceholderOption } from "../helpers/placeholder";
 import { createPlaceholderPlugin } from "../helpers/placeholder";
 import { selectAllText } from "../helpers/prosemirror";
@@ -101,8 +100,7 @@ export class TextFieldView extends ProseMirrorFieldView {
     const { Enter, "Mod-Enter": ModEnter, ...modifiedBaseKeymap } = baseKeymap;
     const keymapping: Record<string, Command> = {
       ...modifiedBaseKeymap,
-      "Mod-z": () => undo(outerView.state, outerView.dispatch),
-      "Mod-y": () => redo(outerView.state, outerView.dispatch),
+      ...createHistoryCommands(outerView),
       ...filteredKeymap,
     };
 

--- a/src/plugin/helpers/keymap.ts
+++ b/src/plugin/helpers/keymap.ts
@@ -1,7 +1,28 @@
 import { baseKeymap } from "prosemirror-commands";
+import { redoNoScroll, undoNoScroll } from "prosemirror-history";
+import type { Command } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
 
 const blockedKeys = ["Enter", "Mod-Enter", "Mod-a"];
 
 export const filteredKeymap = Object.fromEntries(
   Object.entries(baseKeymap).filter(([key]) => !blockedKeys.includes(key))
 );
+
+/**
+ * To prevent the editor from scrolling to the top of an element when undo or
+ * redo are called, we dispatch the command without scroll on the outer editor,
+ * and then separately call `scrollIntoView` on the inner.
+ */
+export const createHistoryCommands = (
+  outerView: EditorView
+): Record<string, Command> => ({
+  "Mod-z": (_, __, view) => {
+    undoNoScroll(outerView.state, outerView.dispatch);
+    return view?.dispatch(view.state.tr.scrollIntoView()) ?? false;
+  },
+  "Mod-y": (_, __, view) => {
+    redoNoScroll(outerView.state, outerView.dispatch);
+    return view?.dispatch(view.state.tr.scrollIntoView()) ?? false;
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1319,9 +1319,9 @@
   integrity sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==
 
 "@emotion/is-prop-valid@^1.1.0":
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz"
-  integrity sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz"
+  integrity sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==
   dependencies:
     "@emotion/memoize" "^0.8.1"
 
@@ -1344,9 +1344,9 @@
     hoist-non-react-statics "^3.3.1"
 
 "@emotion/serialize@^1.0.0", "@emotion/serialize@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.2.tgz"
-  integrity sha512-zR6a/fkFP4EAcCMQtLOhIgpprZOwNmCldtpaISpvz348+DP4Mz8ZoKaGGCQpbzepNIUWbq4w6hNZkwDyKoS+HA==
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.3.tgz"
+  integrity sha512-iD4D6QVZFDhcbH0RAG1uVu1CwVLMWUkCvAqqlewO/rxf8+87yIBAlt4+AxMiiKPLs5hFc0owNk/sLLAOROw3cA==
   dependencies:
     "@emotion/hash" "^0.9.1"
     "@emotion/memoize" "^0.8.1"
@@ -3067,7 +3067,7 @@ binary-extensions@^2.0.0:
 
 bindings@^1.5.0:
   version "1.5.0"
-  resolved "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
@@ -4995,7 +4995,7 @@ file-entry-cache@^6.0.1:
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
-  resolved "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 fill-range@^4.0.0:
@@ -5222,7 +5222,7 @@ fs.realpath@^1.0.0:
 
 fsevents@^1.2.7:
   version "1.2.13"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.13.tgz#f325cb0455592428bcf11b383370ef70e3bfcc38"
   integrity sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==
   dependencies:
     bindings "^1.5.0"
@@ -7312,9 +7312,9 @@ multicast-dns@^6.0.1:
     thunky "^1.0.2"
 
 nan@^2.12.1:
-  version "2.17.0"
-  resolved "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz"
-  integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.19.0.tgz#bb58122ad55a6c5bc973303908d5b16cfdd5a8c0"
+  integrity sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==
 
 nanoid@^2.1.11:
   version "2.1.11"
@@ -8078,10 +8078,10 @@ prosemirror-gapcursor@^1.0.0:
     prosemirror-state "^1.0.0"
     prosemirror-view "^1.0.0"
 
-prosemirror-history@^1.0.0, prosemirror-history@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.3.2.tgz"
-  integrity sha512-/zm0XoU/N/+u7i5zepjmZAEnpvjDtzoPWW6VmKptcAnPadN/SStsBjMImdCEbb3seiNTpveziPTIrXQbHLtU1g==
+prosemirror-history@^1.0.0, prosemirror-history@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.4.0.tgz"
+  integrity sha512-UUiGzDVcqo1lovOPdi9YxxUps3oBFWAIYkXLu3Ot+JPv1qzVogRbcizxK3LhHmtaUxclohgiOVesRw5QSlMnbQ==
   dependencies:
     prosemirror-state "^1.2.2"
     prosemirror-transform "^1.0.0"


### PR DESCRIPTION
_co-authored-by_: @Divs-B 

## What does this change?

Ensure that the editor scrolls to the focused field, not the top of the element, when undoing or redoing in text editor fields.

This makes use of a change that [@Divs-B requested in prosemirror-history](
https://github.com/ProseMirror/prosemirror/issues/1451) to provide a way of triggering a history command without a scroll side effect 🎉 

|Before|After|
|--|--|
|![scroll-incorrect](https://github.com/guardian/prosemirror-elements/assets/7767575/37a4d2ad-be00-44f4-a4ed-170cf8a6ed1f)|![scroll-correct](https://github.com/guardian/prosemirror-elements/assets/7767575/ef7cc171-99c0-4382-aae5-11d529bc811b)|

## How to test

Running locally, have a play with undoing text changes within a text or rich text field. Does the scroll behaviour work as expected?

It'd be nice to include an integration test for this behaviour. We timeboxed writing a test for this, but ran out of time. 

## How can we measure success?

Less user confusion when hitting Mod-Z!