### PR TITLE
Do not coerce HTML nodes without field attributes to a field value of `{}`

### DIFF
--- a/.changeset/curvy-dryers-serve.md
+++ b/.changeset/curvy-dryers-serve.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-elements": patch
+---
+
+Do not coerce HTML nodes without field attributes to a field value of {}

--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -217,6 +217,7 @@ export const getSerialisedHtml = ({
     <div pme-field-name="demo_image_element__resizeable"></div>
     <div pme-field-name="demo_image_element__restrictedTextField">${restrictedTextValue}</div>
     <div pme-field-name="demo_image_element__src">${srcValue}</div>
+    <div pme-field-name="demo_image_element__undefinedByDefault"></div>
     <div pme-field-name="demo_image_element__useSrc" fields="${useSrcValue}"></div>
   </div><p>First paragraph</p><p>Second paragraph</p>`);
 };

--- a/src/elements/demo-image/DemoImageElement.tsx
+++ b/src/elements/demo-image/DemoImageElement.tsx
@@ -79,6 +79,10 @@ export const createImageFields = (
         onCropImage,
       }
     ),
+    undefinedByDefault: createCustomField<string | undefined>(
+      undefined,
+      undefined
+    ),
     useSrc: createCheckBoxField(false),
     optionDropdown: createDropDownField(
       [

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -298,9 +298,7 @@ const getDefaultParseDOMForLeafNode = (nodeName: string) => [
       }
 
       const maybeFieldAttrs = dom.getAttribute("fields");
-      const fields = maybeFieldAttrs
-        ? (JSON.parse(maybeFieldAttrs) as unknown)
-        : undefined;
+      const fields: unknown | undefined = maybeFieldAttrs && JSON.parse(maybeFieldAttrs)
 
       return { fields };
     },

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -299,11 +299,12 @@ const getDefaultParseDOMForLeafNode = (nodeName: string) => [
         return false;
       }
 
-      const attrs = {
-        fields: JSON.parse(dom.getAttribute("fields") ?? "{}") as unknown,
-      };
+      const maybeFieldAttrs = dom.getAttribute("fields");
+      const fields = maybeFieldAttrs
+        ? (JSON.parse(maybeFieldAttrs) as unknown)
+        : undefined;
 
-      return attrs;
+      return { fields };
     },
   },
 ];

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -298,8 +298,9 @@ const getDefaultParseDOMForLeafNode = (nodeName: string) => [
       }
 
       const maybeFieldAttrs = dom.getAttribute("fields");
-      const fields: unknown | undefined =
-        maybeFieldAttrs && JSON.parse(maybeFieldAttrs);
+      const fields = maybeFieldAttrs
+        ? (JSON.parse(maybeFieldAttrs) as unknown)
+        : undefined;
 
       return { fields };
     },

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -68,7 +68,6 @@ const getNodeSpecForElement = (
       "div",
       {
         [elementTypeAttr]: node.attrs.type as string,
-        fields: JSON.stringify(node.attrs.fields),
       },
       0,
     ],
@@ -83,7 +82,6 @@ const getNodeSpecForElement = (
 
           return {
             type: nodeName,
-            fields: JSON.parse(dom.getAttribute("fields") ?? "{}") as unknown,
           };
         },
       },

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -298,7 +298,8 @@ const getDefaultParseDOMForLeafNode = (nodeName: string) => [
       }
 
       const maybeFieldAttrs = dom.getAttribute("fields");
-      const fields: unknown | undefined = maybeFieldAttrs && JSON.parse(maybeFieldAttrs)
+      const fields: unknown | undefined =
+        maybeFieldAttrs && JSON.parse(maybeFieldAttrs);
 
       return { fields };
     },


### PR DESCRIPTION
## What does this change?

Do not coerce HTML nodes without field attributes to a field value of `{}`. This has been causing problems in flexible-content with recipe elements, which often contain optional fields that should be `undefined`. When they instead become `{}`, the rendering code throws an error.

Also removes a redundant code path where we deserialise field values from an element node. Element nodes don't contain fields, so this step isn't required. Because the `fields` attr is not specified in the Element `NodeSpec`, they were never added anyway.

## How to test

The integration test should verify the change:
  - Before the fix in 81bccb5f534b3b442aa64000b97f153e5bb14b84, a field that is undefined by default will receive a value of `{}` when it is deserialised from HTML, and the test with the additional field `undefinedByDefault` will fail.
  - 81bccb5f534b3b442aa64000b97f153e5bb14b84 fixes by only providing a value to `fields` if the relevant attr is defined.

There remains the unhappy path of `JSON.parse` attempting to serialise invalid JSON and blowing up. We've never caught it in production, but the path is there. That's probably another PR.