### PR TITLE
Make list element title and content fields align with body in Composer

### DIFF
--- a/src/editorial-source-components/Editor.ts
+++ b/src/editorial-source-components/Editor.ts
@@ -29,7 +29,7 @@ export const Editor = styled.div<{
     outline: none;
   }
   .ProseMirrorElements__NestedElementField {
-    padding: 10px 15px;
+    padding: 8px 8px;
     &:focus-within {
       ${focusHalo};
       border: 1px solid ${background.inputChecked};

--- a/src/renderers/react/AltStyleElementWrapper.tsx
+++ b/src/renderers/react/AltStyleElementWrapper.tsx
@@ -8,7 +8,7 @@ const AltStyleContainer = styled("div")`
   padding-bottom: 8px;
   border-top: 1px dashed #ddd;
   border-bottom: 1px dashed #ddd;
-  margin: ${space[3]}px -10px;
+  margin: ${space[3]}px -9px;
 `;
 
 const AltStylePanel = styled("div")<{


### PR DESCRIPTION
## What does this change?
Makes some minor tweaks to `nestedElement` field and `altStyle` wrapper to make sure the list element title and content align with the main editor text in Composer. They were once aligned but there has been some drift.

| Before | After |
| --- | --- |
| ![image](https://github.com/guardian/prosemirror-elements/assets/34686302/1385e717-8b8a-4658-b33b-0ec4eb5dedd0) | ![image](https://github.com/guardian/prosemirror-elements/assets/34686302/d753314f-8d30-4181-928f-81399f3cd6e0) |

## How to test
1. Use `yarn yalc` in this repo to publish prosemirror-elements locally.
2. Use it in the composer directory of flexible-content with `yalc add @guardian/prosemirror-elements`
3. Create one of the list elements and check out the alignment.
