### PR TITLE
Remove double border between nested fields and text fields

### DIFF
--- a/.changeset/chilled-ravens-run.md
+++ b/.changeset/chilled-ravens-run.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-elements": patch
+---
+
+Remove double border between nested fields and text fields

--- a/src/editorial-source-components/Editor.ts
+++ b/src/editorial-source-components/Editor.ts
@@ -9,6 +9,10 @@ export const Editor = styled.div<{
   useAlternateStyles?: boolean;
 }>`
   ${({ useAlternateStyles }) => (useAlternateStyles ? null : body.small())}
+  ${({ useAlternateStyles }) =>
+    useAlternateStyles
+      ? null
+      : ".ProseMirrorElements__NestedElementField { margin-top: -1px; }"}
   .ProseMirrorElements__RichTextField, .ProseMirrorElements__TextField {
     background-color: ${background.primary};
   }
@@ -23,16 +27,25 @@ export const Editor = styled.div<{
       ${focusHalo}
     }
     ${({ hasValidationErrors }) =>
-      !!hasValidationErrors && `border-color: ${border.error};`}
+      !!hasValidationErrors &&
+      `
+        outline: 1px solid ${border.error};
+        outline-offset: -1px;
+      `}
   }
   .ProseMirrorElements__NestedElementField .ProseMirror-focused {
     outline: none;
   }
+  .ProseMirrorElements__RichTextField,
+  .ProseMirrorElements__TextField,
   .ProseMirrorElements__NestedElementField {
-    padding: 8px 8px;
     &:focus-within {
       ${focusHalo};
-      border: 1px solid ${background.inputChecked};
+      outline: 1px solid ${background.inputChecked};
+      outline-offset: -1px;
     }
+  }
+  .ProseMirrorElements__NestedElementField {
+    padding: 8px 8px;
   }
 `;

--- a/src/elements/alt-style/AltStyleElementForm.tsx
+++ b/src/elements/alt-style/AltStyleElementForm.tsx
@@ -58,7 +58,7 @@ const ChildNumber = styled("div")`
   height: ${buttonWidth}px;
   width: ${buttonWidth}px;
   top: 0;
-  left: -${actionSpacing}px;
+  left: -${actionSpacing - 1}px; // -1 ensures border of number overlaps/collapses into border of first field
   padding: 2px;
   border: 1px solid ${neutral[60]};
   position: absolute;


### PR DESCRIPTION
Co-authored with @simonbyford.

We thought we'd have another pop at this to see if we could avoid the side effects in https://github.com/guardian/flexible-content/pull/4704

This time around, we've used outlines rather than borders to avoid layout shifts when we apply the styles, and to make sure validation and focus states are always 'above' the existing borders.

### Before:
![image](https://github.com/guardian/prosemirror-elements/assets/34686302/49390745-b947-404e-96cf-2bb1c7694cfc)

### After:
![image](https://github.com/guardian/prosemirror-elements/assets/34686302/132d0d78-a95b-437b-a322-47214f42f46c)
![image](https://github.com/guardian/prosemirror-elements/assets/34686302/04c137cb-5d87-42eb-a7c6-6d7390014e92)
![image](https://github.com/guardian/prosemirror-elements/assets/34686302/afc5937c-a91b-4403-a3fd-ff11641fb21f)
![image](https://github.com/guardian/prosemirror-elements/assets/34686302/a9e926c6-b0d5-4446-8da0-25bfee0a62f6)
<img width="730" alt="image" src="https://github.com/guardian/prosemirror-elements/assets/34686302/86daaf9b-5418-4a28-86e1-809040f8a857">


## How to test
Pull this branch into composer locally with `yalc` and check that this is working properly in one of the list elements.