### PR TITLE
Rename FieldWrapper and InputHeading to Demo[ClassName] to avoid ambiguity

### DIFF
--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -1,5 +1,5 @@
 import type { WindowType } from "../../demo/types";
-import { getFieldHeadingTestId } from "../../src/editorial-source-components/InputHeading";
+import { getFieldHeadingTestId } from "../../src/editorial-source-components/DemoInputHeading";
 import { placeholderTestAttribute } from "../../src/plugin/helpers/placeholder";
 import {
   ChangeTestDecoStringAction,

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -70,14 +70,14 @@ const pullquoteElement = createReactElementSpec(
  }
 )
 ```
-In `prosemirror-elements`, we’ve defined helper components to make it easy to expose inputs and data. Let’s use the `FieldWrapper` component to display an appropriate input for our `content` rich text Field:
+In `prosemirror-elements`, we’ve defined helper components to make it easy to expose inputs and data. Let’s use the `DemoFieldWrapper` component to display an appropriate input for our `content` rich text Field - though we would provide our own component in a consuming project:
 ```ts
 const pullquoteElement = createReactElementSpec(
  pullquoteFields,
  ({ fields, fieldValues, errors }) => {
    return (
      <div>
-       <FieldWrapper
+       <DemoFieldWrapper
          field={fields.content}
          errors={errors.content}
          headingLabel="Pullquote content"
@@ -94,12 +94,12 @@ const pullquoteElement = createReactElementSpec(
  ({ fields, fieldValues, errors }) => {
    return (
      <div>
-       <FieldWrapper
+       <DemoFieldWrapper
          field={fields.content}
          errors={errors.content}
          headingLabel="Pullquote content"
        />
-       <FieldWrapper
+       <DemoFieldWrapper
          field={fields.content}
          errors={errors.content}
          headingLabel="Attribution"
@@ -116,12 +116,12 @@ const pullquoteElement = createReactElementSpec(
  ({ fields, fieldValues, errors }) => {
    return (
      <div>
-       <FieldWrapper
+       <DemoFieldWrapper
          field={fields.content}
          errors={errors.content}
          headingLabel="Pullquote content"
        />
-       <FieldWrapper
+       <DemoFieldWrapper
          field={fields.content}
          errors={errors.content}
          headingLabel="Attribution"
@@ -146,7 +146,7 @@ const pullquoteElement = createReactElementSpec(
  ({ fields, fieldValues, errors }) => {
    return (
      <div>
-       <FieldWrapper
+       <DemoFieldWrapper
          field={fields.content}
          errors={errors.content}
          headingLabel="Pullquote content"

--- a/src/editorial-source-components/DemoFieldWrapper.tsx
+++ b/src/editorial-source-components/DemoFieldWrapper.tsx
@@ -1,4 +1,3 @@
-import { css } from "@emotion/react";
 import type { ValidationError } from "../plugin/elementSpec";
 import type { FieldView } from "../plugin/fieldViews/FieldView";
 import type { Field } from "../plugin/types/Element";

--- a/src/editorial-source-components/DemoFieldWrapper.tsx
+++ b/src/editorial-source-components/DemoFieldWrapper.tsx
@@ -1,8 +1,9 @@
+import { css } from "@emotion/react";
 import type { ValidationError } from "../plugin/elementSpec";
 import type { FieldView } from "../plugin/fieldViews/FieldView";
 import type { Field } from "../plugin/types/Element";
 import { FieldComponent } from "../renderers/react/FieldComponent";
-import { InputHeading } from "./InputHeading";
+import { DemoInputHeading } from "./DemoInputHeading";
 
 type Props<F> = {
   field: F;
@@ -17,7 +18,8 @@ type Props<F> = {
   showHeading?: boolean;
 };
 
-export const FieldWrapper = <F extends Field<FieldView<unknown>>>({
+// This component is used only in the prosemirror-elements internal demo
+export const DemoFieldWrapper = <F extends Field<FieldView<unknown>>>({
   field,
   errors,
   headingLabel,
@@ -30,7 +32,7 @@ export const FieldWrapper = <F extends Field<FieldView<unknown>>>({
 }: Props<F>) => (
   <div className={className}>
     {showHeading ? (
-      <InputHeading
+      <DemoInputHeading
         name={field.name}
         fieldId={field.view.getId()}
         headingLabel={headingLabel}

--- a/src/editorial-source-components/DemoInputHeading.tsx
+++ b/src/editorial-source-components/DemoInputHeading.tsx
@@ -5,7 +5,7 @@ import { Error } from "./Error";
 import { Heading } from "./Heading";
 import { Label } from "./Label";
 
-const InputHeadingContainer = styled.div<{ useAlternateStyles?: boolean }>`
+const DemoInputHeadingContainer = styled.div<{ useAlternateStyles?: boolean }>`
   display: flex;
   flex-wrap: wrap;
   ${({ useAlternateStyles }) =>
@@ -42,7 +42,7 @@ const Errors = ({
 
 export const getFieldHeadingTestId = (name: string) => `FieldHeading-${name}`;
 
-export type InputHeadingProps = {
+export type DemoInputHeadingProps = {
   headingLabel: React.ReactNode;
   fieldId?: string;
   headingContent?: React.ReactNode;
@@ -53,7 +53,8 @@ export type InputHeadingProps = {
   useAlternateStyles?: boolean;
 };
 
-export const InputHeading = ({
+// This component is used only in the prosemirror-elements internal demo
+export const DemoInputHeading = ({
   headingLabel,
   headingContent,
   description,
@@ -62,8 +63,8 @@ export const InputHeading = ({
   fieldId,
   headingDirection = "row",
   useAlternateStyles = false,
-}: InputHeadingProps) => (
-  <InputHeadingContainer
+}: DemoInputHeadingProps) => (
+  <DemoInputHeadingContainer
     data-cy={getFieldHeadingTestId(name ?? "")}
     useAlternateStyles={useAlternateStyles}
   >
@@ -83,5 +84,5 @@ export const InputHeading = ({
     ) : description ? (
       <Description>{description}</Description>
     ) : null}
-  </InputHeadingContainer>
+  </DemoInputHeadingContainer>
 );

--- a/src/elements/alt-style/AltStyleElementForm.tsx
+++ b/src/elements/alt-style/AltStyleElementForm.tsx
@@ -1,8 +1,8 @@
 import styled from "@emotion/styled";
 import { neutral, space } from "@guardian/src-foundations";
 import React from "react";
-import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
+import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import {
   actionSpacing,
   buttonWidth,

--- a/src/elements/alt-style/AltStyleElementForm.tsx
+++ b/src/elements/alt-style/AltStyleElementForm.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { neutral, space } from "@guardian/src-foundations";
 import React from "react";
 import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
-import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
 import {
   actionSpacing,
   buttonWidth,
@@ -119,12 +119,12 @@ export const keyTakeawaysElement = createReactAltStylesElementSpec(
   (fields) => fields.repeater,
   (repeaterChild) => (
     <>
-      <FieldWrapper
+      <DemoFieldWrapper
         field={repeaterChild.title}
         showHeading={false}
         useAlternateStyles={true}
       />
-      <FieldWrapper
+      <DemoFieldWrapper
         field={repeaterChild.content}
         showHeading={false}
         useAlternateStyles={true}

--- a/src/elements/callout/CalloutTable.tsx
+++ b/src/elements/callout/CalloutTable.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import { neutral, space, text } from "@guardian/src-foundations";
 import { Button } from "../../editorial-source-components/Button";
-import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
 import { Label } from "../../editorial-source-components/Label";
 import type { FieldView as TFieldView } from "../../plugin/fieldViews/FieldView";
 import type { CustomField, Field } from "../../plugin/types/Element";
@@ -183,7 +183,7 @@ export const CalloutTable = ({
             </span>
           </div>
         ) : (
-          <FieldWrapper
+          <DemoFieldWrapper
             className="callout-field"
             field={overridePrompt}
             headingLabel="Callout Prompt"
@@ -219,7 +219,7 @@ export const CalloutTable = ({
             </span>
           </div>
         ) : (
-          <FieldWrapper
+          <DemoFieldWrapper
             className="callout-field"
             field={overrideTitle}
             headingLabel="Callout Title"
@@ -260,7 +260,7 @@ export const CalloutTable = ({
           </>
         ) : (
           <div css={descriptionStyle}>
-            <FieldWrapper
+            <DemoFieldWrapper
               className="callout-field"
               field={overrideDescription}
               headingLabel="Callout Description"

--- a/src/elements/cartoon/CartoonForm.tsx
+++ b/src/elements/cartoon/CartoonForm.tsx
@@ -6,12 +6,12 @@ import type { Plugin } from "prosemirror-state";
 import type { FunctionComponent } from "react";
 import React from "react";
 import { Button } from "../../editorial-source-components/Button";
+import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
+import { DemoInputHeading } from "../../editorial-source-components/DemoInputHeading";
 import {
   FieldLayoutHorizontal,
   FieldLayoutVertical,
 } from "../../editorial-source-components/FieldLayout";
-import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
-import { DemoInputHeading } from "../../editorial-source-components/DemoInputHeading";
 import { SvgCrop } from "../../editorial-source-components/SvgCrop";
 import { SvgCrossRound } from "../../editorial-source-components/SvgCrossRound";
 import { Tooltip } from "../../editorial-source-components/Tooltip";

--- a/src/elements/cartoon/CartoonForm.tsx
+++ b/src/elements/cartoon/CartoonForm.tsx
@@ -10,8 +10,8 @@ import {
   FieldLayoutHorizontal,
   FieldLayoutVertical,
 } from "../../editorial-source-components/FieldLayout";
-import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
-import { InputHeading } from "../../editorial-source-components/InputHeading";
+import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
+import { DemoInputHeading } from "../../editorial-source-components/DemoInputHeading";
 import { SvgCrop } from "../../editorial-source-components/SvgCrop";
 import { SvgCrossRound } from "../../editorial-source-components/SvgCrossRound";
 import { Tooltip } from "../../editorial-source-components/Tooltip";
@@ -100,8 +100,8 @@ export const createCartoonElement = (
             }}
             mainMediaId={fields.largeImages.value[0]?.mediaId}
           />
-          <FieldWrapper field={fields.caption} headingLabel="Caption" />
-          <FieldWrapper
+          <DemoFieldWrapper field={fields.caption} headingLabel="Caption" />
+          <DemoFieldWrapper
             field={fields.alt}
             headingLabel={
               <span
@@ -143,13 +143,13 @@ export const createCartoonElement = (
           />
           <Columns>
             <Column width={1 / 3}>
-              <FieldWrapper
+              <DemoFieldWrapper
                 field={fields.photographer}
                 headingLabel={"Byline"}
               />
             </Column>
             <Column width={1 / 3}>
-              <FieldWrapper field={fields.source} headingLabel={"Source"} />
+              <DemoFieldWrapper field={fields.source} headingLabel={"Source"} />
             </Column>
             <Column width={1 / 3}>
               <CustomDropdownView
@@ -198,7 +198,7 @@ const ImageSet: FunctionComponent<{
 }) => {
   return (
     <div>
-      <InputHeading headingLabel={label} />
+      <DemoInputHeading headingLabel={label} />
       <FieldLayoutHorizontal>
         {images.map((image, index) => (
           <ImageThumbnail

--- a/src/elements/code/CodeElementForm.tsx
+++ b/src/elements/code/CodeElementForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
+import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import { codeFields } from "./CodeElementSpec";

--- a/src/elements/code/CodeElementForm.tsx
+++ b/src/elements/code/CodeElementForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
-import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import { codeFields } from "./CodeElementSpec";
@@ -11,7 +11,7 @@ export const codeElement = createReactElementSpec({
   fieldDescriptions: codeFields,
   component: ({ fields }) => (
     <FieldLayoutVertical data-cy={CodeElementTestId}>
-      <FieldWrapper headingLabel="Code" field={fields.html} />
+      <DemoFieldWrapper headingLabel="Code" field={fields.html} />
       <CustomDropdownView
         label="Language"
         field={fields.language}

--- a/src/elements/demo-image/DemoImageElementForm.tsx
+++ b/src/elements/demo-image/DemoImageElementForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
-import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
 import type { CustomField } from "../../plugin/types/Element";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
@@ -24,26 +24,26 @@ export const createDemoImageElement = (
     fieldDescriptions: createImageFields(onSelect, onCrop),
     component: ({ fields }) => (
       <FieldLayoutVertical data-cy={ImageElementTestId}>
-        <FieldWrapper headingLabel="Caption" field={fields.caption} />
-        <FieldWrapper headingLabel="Alt text" field={fields.altText} />
+        <DemoFieldWrapper headingLabel="Caption" field={fields.caption} />
+        <DemoFieldWrapper headingLabel="Alt text" field={fields.altText} />
         <button
           data-cy={UpdateAltTextButtonId}
           onClick={() => fields.altText.update("Default alt text")}
         >
           Programmatically update alt text
         </button>
-        <FieldWrapper
+        <DemoFieldWrapper
           headingLabel="Resizeable Text Field"
           field={fields.resizeable}
         />
-        <FieldWrapper
+        <DemoFieldWrapper
           field={fields.restrictedTextField}
           headingLabel="Restricted Text Field"
         />
-        <FieldWrapper headingLabel="Src" field={fields.src} />
-        <FieldWrapper headingLabel="Code" field={fields.code} />
-        <FieldWrapper headingLabel="Use image source?" field={fields.useSrc} />
-        <FieldWrapper headingLabel="Options" field={fields.optionDropdown} />
+        <DemoFieldWrapper headingLabel="Src" field={fields.src} />
+        <DemoFieldWrapper headingLabel="Code" field={fields.code} />
+        <DemoFieldWrapper headingLabel="Use image source?" field={fields.useSrc} />
+        <DemoFieldWrapper headingLabel="Options" field={fields.optionDropdown} />
         <ImageView
           field={fields.mainImage}
           onChange={(_, __, ___, description) => {
@@ -55,7 +55,7 @@ export const createDemoImageElement = (
         <ul>
           {fields.repeater.children.map((repeater, index) => (
             <li key={repeater.__ID}>
-              <FieldWrapper
+              <DemoFieldWrapper
                 headingLabel="Repeater text"
                 headingContent={
                   <>
@@ -79,7 +79,7 @@ export const createDemoImageElement = (
                 {repeater.nestedRepeater.children.map(
                   (nestedRepeater, index) => (
                     <li key={nestedRepeater.__ID}>
-                      <FieldWrapper
+                      <DemoFieldWrapper
                         headingLabel="Nested repeater text"
                         headingContent={
                           <>

--- a/src/elements/demo-image/DemoImageElementForm.tsx
+++ b/src/elements/demo-image/DemoImageElementForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
+import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import type { CustomField } from "../../plugin/types/Element";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
@@ -42,8 +42,14 @@ export const createDemoImageElement = (
         />
         <DemoFieldWrapper headingLabel="Src" field={fields.src} />
         <DemoFieldWrapper headingLabel="Code" field={fields.code} />
-        <DemoFieldWrapper headingLabel="Use image source?" field={fields.useSrc} />
-        <DemoFieldWrapper headingLabel="Options" field={fields.optionDropdown} />
+        <DemoFieldWrapper
+          headingLabel="Use image source?"
+          field={fields.useSrc}
+        />
+        <DemoFieldWrapper
+          headingLabel="Options"
+          field={fields.optionDropdown}
+        />
         <ImageView
           field={fields.mainImage}
           onChange={(_, __, ___, description) => {

--- a/src/elements/deprecated/DeprecatedForm.tsx
+++ b/src/elements/deprecated/DeprecatedForm.tsx
@@ -1,8 +1,8 @@
 import { upperFirst } from "lodash";
 import React from "react";
+import { DemoInputHeading } from "../../editorial-source-components/DemoInputHeading";
 import { Description } from "../../editorial-source-components/Description";
 import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
-import { DemoInputHeading } from "../../editorial-source-components/DemoInputHeading";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { fields } from "./DeprecatedSpec";
 

--- a/src/elements/deprecated/DeprecatedForm.tsx
+++ b/src/elements/deprecated/DeprecatedForm.tsx
@@ -2,7 +2,7 @@ import { upperFirst } from "lodash";
 import React from "react";
 import { Description } from "../../editorial-source-components/Description";
 import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
-import { InputHeading } from "../../editorial-source-components/InputHeading";
+import { DemoInputHeading } from "../../editorial-source-components/DemoInputHeading";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { fields } from "./DeprecatedSpec";
 
@@ -21,7 +21,7 @@ export const deprecatedElement = createReactElementSpec({
     return (
       <div>
         <FieldLayoutVertical>
-          <InputHeading headingLabel={`Content from ${elementType}`} />
+          <DemoInputHeading headingLabel={`Content from ${elementType}`} />
           <Description>
             <p>
               This element represents content from {elementType}. It was added

--- a/src/elements/embed/EmbedForm.tsx
+++ b/src/elements/embed/EmbedForm.tsx
@@ -2,7 +2,7 @@ import type { Schema } from "prosemirror-model";
 import type { Plugin } from "prosemirror-state";
 import React from "react";
 import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
-import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
@@ -35,10 +35,10 @@ export const createEmbedElement = (options: MainEmbedOptions) =>
         />
         <Preview html={fields.html.value} />
         <CustomDropdownView field={fields.role} label="Weighting" />
-        <FieldWrapper field={fields.url} headingLabel="Source URL" />
-        <FieldWrapper field={fields.html} headingLabel="Embed code" />
-        <FieldWrapper field={fields.caption} headingLabel="Caption" />
-        <FieldWrapper field={fields.alt} headingLabel="Alt text" />
+        <DemoFieldWrapper field={fields.url} headingLabel="Source URL" />
+        <DemoFieldWrapper field={fields.html} headingLabel="Embed code" />
+        <DemoFieldWrapper field={fields.caption} headingLabel="Caption" />
+        <DemoFieldWrapper field={fields.alt} headingLabel="Alt text" />
         <CustomCheckboxView
           field={fields.isMandatory}
           label="This element is required for publication"

--- a/src/elements/embed/EmbedForm.tsx
+++ b/src/elements/embed/EmbedForm.tsx
@@ -1,8 +1,8 @@
 import type { Schema } from "prosemirror-model";
 import type { Plugin } from "prosemirror-state";
 import React from "react";
-import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
+import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";

--- a/src/elements/helpers/Preview.tsx
+++ b/src/elements/helpers/Preview.tsx
@@ -1,11 +1,11 @@
 import { css } from "@emotion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Description } from "../../editorial-source-components/Description";
-import type { InputHeadingProps } from "../../editorial-source-components/InputHeading";
-import { InputHeading } from "../../editorial-source-components/InputHeading";
+import type { DemoInputHeadingProps } from "../../editorial-source-components/DemoInputHeading";
+import { DemoInputHeading } from "../../editorial-source-components/DemoInputHeading";
 import { hasOwnProperty } from "./hasOwnProperty";
 
-type PreviewProps = Partial<InputHeadingProps> & {
+type PreviewProps = Partial<DemoInputHeadingProps> & {
   html?: string;
   iframeUrl?: string;
   minHeight?: number;
@@ -159,7 +159,7 @@ export const Preview = ({
 
   return (
     <div>
-      {headingLabel && <InputHeading headingLabel={headingLabel} {...rest} />}
+      {headingLabel && <DemoInputHeading headingLabel={headingLabel} {...rest} />}
       {preview}
     </div>
   );

--- a/src/elements/helpers/Preview.tsx
+++ b/src/elements/helpers/Preview.tsx
@@ -1,8 +1,8 @@
 import { css } from "@emotion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Description } from "../../editorial-source-components/Description";
 import type { DemoInputHeadingProps } from "../../editorial-source-components/DemoInputHeading";
 import { DemoInputHeading } from "../../editorial-source-components/DemoInputHeading";
+import { Description } from "../../editorial-source-components/Description";
 import { hasOwnProperty } from "./hasOwnProperty";
 
 type PreviewProps = Partial<DemoInputHeadingProps> & {
@@ -159,7 +159,9 @@ export const Preview = ({
 
   return (
     <div>
-      {headingLabel && <DemoInputHeading headingLabel={headingLabel} {...rest} />}
+      {headingLabel && (
+        <DemoInputHeading headingLabel={headingLabel} {...rest} />
+      )}
       {preview}
     </div>
   );

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -6,7 +6,7 @@ import React, { useContext, useEffect, useMemo } from "react";
 import { Button } from "../../editorial-source-components/Button";
 import { Error } from "../../editorial-source-components/Error";
 import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
-import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
 import { SvgCrop } from "../../editorial-source-components/SvgCrop";
 import { Tooltip } from "../../editorial-source-components/Tooltip";
 import type { Options } from "../../plugin/fieldViews/DropdownFieldView";
@@ -85,14 +85,14 @@ export const createImageElement = (options: ImageElementOptions) => {
             </Column>
             <Column width={3 / 5}>
               <FieldLayoutVertical>
-                <FieldWrapper
+                <DemoFieldWrapper
                   field={fields.caption}
                   headingLabel="Caption"
                   description={`${htmlLength(
                     fields.caption.value
                   )}/600 characters`}
                 />
-                <FieldWrapper
+                <DemoFieldWrapper
                   field={fields.alt}
                   headingLabel={<AltText>Alt text</AltText>}
                   headingContent={
@@ -130,13 +130,13 @@ export const createImageElement = (options: ImageElementOptions) => {
                 />
                 <Columns>
                   <Column width={1 / 2}>
-                    <FieldWrapper
+                    <DemoFieldWrapper
                       field={fields.photographer}
                       headingLabel="Photographer"
                     />
                   </Column>
                   <Column width={1 / 2}>
-                    <FieldWrapper field={fields.source} headingLabel="Source" />
+                    <DemoFieldWrapper field={fields.source} headingLabel="Source" />
                   </Column>
                 </Columns>
                 <Columns>

--- a/src/elements/image/ImageElementForm.tsx
+++ b/src/elements/image/ImageElementForm.tsx
@@ -4,9 +4,9 @@ import { space } from "@guardian/src-foundations";
 import { Column, Columns } from "@guardian/src-layout";
 import React, { useContext, useEffect, useMemo } from "react";
 import { Button } from "../../editorial-source-components/Button";
+import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
 import { Error } from "../../editorial-source-components/Error";
 import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
-import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
 import { SvgCrop } from "../../editorial-source-components/SvgCrop";
 import { Tooltip } from "../../editorial-source-components/Tooltip";
 import type { Options } from "../../plugin/fieldViews/DropdownFieldView";
@@ -136,7 +136,10 @@ export const createImageElement = (options: ImageElementOptions) => {
                     />
                   </Column>
                   <Column width={1 / 2}>
-                    <DemoFieldWrapper field={fields.source} headingLabel="Source" />
+                    <DemoFieldWrapper
+                      field={fields.source}
+                      headingLabel="Source"
+                    />
                   </Column>
                 </Columns>
                 <Columns>

--- a/src/elements/interactive/InteractiveForm.tsx
+++ b/src/elements/interactive/InteractiveForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
-import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
 import { Link } from "../../editorial-source-components/Link";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";
@@ -35,8 +35,8 @@ export const createInteractiveElement = (props: MainInteractiveProps) =>
           iframeUrl={fields.iframeUrl.value}
         />
         <CustomDropdownView field={fields.role} label="Weighting" />
-        <FieldWrapper field={fields.alt} headingLabel="Alt text" />
-        <FieldWrapper field={fields.caption} headingLabel="Caption" />
+        <DemoFieldWrapper field={fields.alt} headingLabel="Alt text" />
+        <DemoFieldWrapper field={fields.caption} headingLabel="Caption" />
         <CustomCheckboxView
           field={fields.isMandatory}
           label="This element is required for publication"

--- a/src/elements/interactive/InteractiveForm.tsx
+++ b/src/elements/interactive/InteractiveForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
+import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { Link } from "../../editorial-source-components/Link";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomCheckboxView } from "../../renderers/react/customFieldViewComponents/CustomCheckboxView";

--- a/src/elements/membership/MembershipForm.tsx
+++ b/src/elements/membership/MembershipForm.tsx
@@ -1,8 +1,8 @@
 import { css } from "@emotion/react";
 import { space } from "@guardian/src-foundations";
 import React from "react";
-import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { DemoInputHeading } from "../../editorial-source-components/DemoInputHeading";
+import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { Link } from "../../editorial-source-components/Link";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";

--- a/src/elements/membership/MembershipForm.tsx
+++ b/src/elements/membership/MembershipForm.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import { space } from "@guardian/src-foundations";
 import React from "react";
 import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
-import { InputHeading } from "../../editorial-source-components/InputHeading";
+import { DemoInputHeading } from "../../editorial-source-components/DemoInputHeading";
 import { Link } from "../../editorial-source-components/Link";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
@@ -21,7 +21,7 @@ export const membershipElement = createReactElementSpec({
   component: ({ fields }) => (
     <FieldLayoutVertical data-cy={MembershipElementTestId}>
       <div css={flexRow}>
-        <InputHeading headingLabel="Membership event:" />
+        <DemoInputHeading headingLabel="Membership event:" />
         <Link href={fields.originalUrl.value}>{fields.linkText.value}</Link>
       </div>
       <CustomDropdownView field={fields.role} label="Weighting" />

--- a/src/elements/pullquote/PullquoteForm.tsx
+++ b/src/elements/pullquote/PullquoteForm.tsx
@@ -1,7 +1,7 @@
 import { Column, Columns } from "@guardian/src-layout";
 import React from "react";
 import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
-import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import { pullquoteFields } from "./PullquoteSpec";
@@ -30,7 +30,7 @@ export const pullquoteElement = createReactElementSpec({
       <div data-cy={PullquoteElementTestId}>
         <Columns>
           <Column width={2 / 3}>
-            <FieldWrapper
+            <DemoFieldWrapper
               headingLabel="Pullquote"
               field={fields.html}
               errors={htmlErrors}
@@ -38,7 +38,7 @@ export const pullquoteElement = createReactElementSpec({
           </Column>
           <Column width={1 / 3}>
             <FieldLayoutVertical>
-              <FieldWrapper
+              <DemoFieldWrapper
                 headingLabel="Attribution"
                 field={fields.attribution}
               />

--- a/src/elements/pullquote/PullquoteForm.tsx
+++ b/src/elements/pullquote/PullquoteForm.tsx
@@ -1,7 +1,7 @@
 import { Column, Columns } from "@guardian/src-layout";
 import React from "react";
-import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
+import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { CustomDropdownView } from "../../renderers/react/customFieldViewComponents/CustomDropdownView";
 import { pullquoteFields } from "./PullquoteSpec";

--- a/src/elements/recipe/RecipeElementForm.tsx
+++ b/src/elements/recipe/RecipeElementForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
-import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
+import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { recipeFields } from "./RecipeElementSpec";
 
@@ -10,7 +10,7 @@ export const recipeElement = createReactElementSpec({
   fieldDescriptions: recipeFields,
   component: ({ fields }) => (
     <FieldLayoutVertical data-cy={RecipeElementTestId}>
-      <FieldWrapper headingLabel="Recipe" field={fields.recipeJson} />
+      <DemoFieldWrapper headingLabel="Recipe" field={fields.recipeJson} />
     </FieldLayoutVertical>
   ),
 });

--- a/src/elements/recipe/RecipeElementForm.tsx
+++ b/src/elements/recipe/RecipeElementForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
+import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
 import { recipeFields } from "./RecipeElementSpec";
 

--- a/src/elements/standard/StandardForm.tsx
+++ b/src/elements/standard/StandardForm.tsx
@@ -1,9 +1,9 @@
 import styled from "@emotion/styled";
 import { Column, Columns } from "@guardian/src-layout";
 import React from "react";
-import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
 import { DemoInputHeading } from "../../editorial-source-components/DemoInputHeading";
+import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
 import { Link } from "../../editorial-source-components/Link";
 import type { FieldNameToField } from "../../plugin/types/Element";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";

--- a/src/elements/standard/StandardForm.tsx
+++ b/src/elements/standard/StandardForm.tsx
@@ -2,8 +2,8 @@ import styled from "@emotion/styled";
 import { Column, Columns } from "@guardian/src-layout";
 import React from "react";
 import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
-import { FieldWrapper } from "../../editorial-source-components/FieldWrapper";
-import { InputHeading } from "../../editorial-source-components/InputHeading";
+import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
+import { DemoInputHeading } from "../../editorial-source-components/DemoInputHeading";
 import { Link } from "../../editorial-source-components/Link";
 import type { FieldNameToField } from "../../plugin/types/Element";
 import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
@@ -52,7 +52,7 @@ const IframeAspectRatioContainer: React.FunctionComponent<{
   originalUrl: string;
 }> = ({ height, width, html, originalUrl }) => (
   <div>
-    <InputHeading
+    <DemoInputHeading
       headingLabel="Preview"
       headingContent={
         <span>
@@ -114,7 +114,7 @@ export const StandardForm: React.FunctionComponent<Props> = ({
         </Column>
         <Column width={2 / 3}>
           <FieldLayoutVertical>
-            <FieldWrapper
+            <DemoFieldWrapper
               field={fields.caption}
               headingLabel="Caption"
               description={`${htmlLength(
@@ -155,7 +155,7 @@ export const StandardFormLargePreview: React.FunctionComponent<Props> = ({
         html={fields.html.value}
         originalUrl={fields.originalUrl.value}
       />
-      <FieldWrapper
+      <DemoFieldWrapper
         field={fields.caption}
         headingLabel="Caption"
         description={`${htmlLength(fields.caption.value)}/1000 characters`}

--- a/src/renderers/react/__tests__/createReactElementSpec.spec.tsx
+++ b/src/renderers/react/__tests__/createReactElementSpec.spec.tsx
@@ -1,5 +1,5 @@
 import { getByLabelText, getByText, waitFor } from "@testing-library/dom";
-import { FieldWrapper } from "../../../editorial-source-components/FieldWrapper";
+import { DemoFieldWrapper } from "../../../editorial-source-components/DemoFieldWrapper";
 import { createTextField } from "../../../plugin/fieldViews/TextFieldView";
 import { createEditorWithElements } from "../../../plugin/helpers/test";
 import { createReactElementSpec } from "../createReactElementSpec";
@@ -12,10 +12,10 @@ describe("createReactElementSpec", () => {
     },
     component: ({ fields }) => (
       <div>
-        <FieldWrapper
+        <DemoFieldWrapper
           headingLabel="field1"
           field={fields.field1}
-        ></FieldWrapper>
+        ></DemoFieldWrapper>
       </div>
     ),
     validate: undefined,


### PR DESCRIPTION
## What does this change?
These two components (`FieldWrapper` and `InputHeading`) are now [directly](https://github.com/guardian/flexible-content/blob/5dc2e938a6a285e4528bb5c4c4fb140ba4386956/composer/src/js/components/elements/FieldWrapper.tsx#L18) [implemented](https://github.com/guardian/flexible-content/blob/5dc2e938a6a285e4528bb5c4c4fb140ba4386956/composer/src/js/components/elements/InputHeading.tsx#L34) in Composer, and the elements in Composer use those implementations, but there are mostly identically implementations within `prosemirror-elements` too. 

This PR renames the versions used internally in `prosemirror-elements` because it's currently very easy to be tripped up by mistaking them for the one implemented in Composer.

## How to test
Run the demo locally according to the instructions in the readme and check if all is working as expected.
