### PR TITLE
Exported required styles and controls for timeline element

### DIFF
--- a/src/elements/alt-style/AltStyleElementForm.tsx
+++ b/src/elements/alt-style/AltStyleElementForm.tsx
@@ -24,7 +24,7 @@ import { keyTakeawaysFields } from "./AltStyleElementSpec";
 
 export const AltStyleElementTestId = "AltStyleElement";
 
-const RepeaterChild = styled(Body)`
+export const RepeaterChild = styled(Body)`
   &:first-child {
     margin-top: ${space[3]}px;
   }
@@ -40,11 +40,11 @@ const RepeaterChild = styled(Body)`
   }
 `;
 
-const RepeatedFieldsWrapper = styled("div")`
+export const RepeatedFieldsWrapper = styled("div")`
   width: 100%;
 `;
 
-const ChildNumber = styled("div")`
+export const ChildNumber = styled("div")`
   box-sizing: border-box;
   background-color: ${neutral[100]};
   color: ${neutral[46]};

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,16 @@ export { createStore } from "./renderers/react/store";
 export { TelemetryContext } from "./renderers/react/TelemetryContext";
 export { useCustomFieldState } from "./renderers/react/useCustomFieldViewState";
 export { createReactElementSpec } from "./renderers/react/createReactElementSpec";
-export { createReactAltStylesElementSpec } from "./elements/alt-style/AltStyleElementForm";
+export {
+  createReactAltStylesElementSpec,
+  RepeaterChild,
+  RepeatedFieldsWrapper,
+  ChildNumber,
+} from "./elements/alt-style/AltStyleElementForm";
+export {
+  LeftRepeaterActionControls,
+  RightRepeaterActionControls,
+} from "./renderers/react/WrapperControls";
 export { CustomCheckboxView } from "./renderers/react/customFieldViewComponents/CustomCheckboxView";
 export { CustomDropdownView } from "./renderers/react/customFieldViewComponents/CustomDropdownView";
 export { FieldComponent } from "./renderers/react/FieldComponent";
@@ -42,3 +51,4 @@ export {
   INNER_EDITOR_FOCUS,
   INNER_EDITOR_BLUR,
 } from "./plugin/fieldViews/NestedElementFieldView";
+export { RepeaterFieldMapIDKey } from "./plugin/helpers/constants";


### PR DESCRIPTION
## What does this change?

Exports the required styles and controls for [this PR ](https://github.com/guardian/flexible-content/pull/4728) adding event-level controls for timelines.

## How to test
Test the composer PR, you should be able to import these and add a new event to a timeline section. 
