### PR TITLE
Support alt styles for Timelines

### DIFF
--- a/src/editorial-source-components/Editor.ts
+++ b/src/editorial-source-components/Editor.ts
@@ -8,6 +8,7 @@ export const Editor = styled.div<{
   hasValidationErrors: boolean;
   useAlternateStyles?: boolean;
 }>`
+  flex-grow: 1;
   ${({ useAlternateStyles }) => (useAlternateStyles ? null : body.small())}
   ${({ useAlternateStyles }) =>
     useAlternateStyles

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export { createStore } from "./renderers/react/store";
 export { TelemetryContext } from "./renderers/react/TelemetryContext";
 export { useCustomFieldState } from "./renderers/react/useCustomFieldViewState";
 export { createReactElementSpec } from "./renderers/react/createReactElementSpec";
-export { AltStyleElementWrapper } from './renderers/react/AltStyleElementWrapper';
+export { AltStyleElementWrapper } from "./renderers/react/AltStyleElementWrapper";
 export {
   createReactAltStylesElementSpec,
   RepeaterChild,

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ export { TelemetryContext } from "./renderers/react/TelemetryContext";
 export { useCustomFieldState } from "./renderers/react/useCustomFieldViewState";
 export { createReactElementSpec } from "./renderers/react/createReactElementSpec";
 export { createReactAltStylesElementSpec } from "./elements/alt-style/AltStyleElementForm";
+export { AltStyleElementWrapper } from './renderers/react/AltStyleElementWrapper';
 export { CustomCheckboxView } from "./renderers/react/customFieldViewComponents/CustomCheckboxView";
 export { CustomDropdownView } from "./renderers/react/customFieldViewComponents/CustomDropdownView";
 export { FieldComponent } from "./renderers/react/FieldComponent";


### PR DESCRIPTION
## What does this change?
This exports the `AltStyleElementWrapper` for use in the `TimelineForm` in Composer. We may want to move this to Composer in the long run, but I'm leaving that for a future optimisation.

It also adds a `flex-grow` style to ProsemirrorFields, i.e. text, rich text and nested. This won't affect most uses but will cause the text fields to fill their horizontal space in a flex layout.

## How to test
This should be a no-op, but you can test locally with my current branch on Composer:
https://github.com/guardian/flexible-content/compare/main...rm/alt-style-timeline
