### PR TITLE
Support drag and drop events in nested elements

### DIFF
--- a/.changeset/silent-frogs-unite.md
+++ b/.changeset/silent-frogs-unite.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-elements": patch
+---
+
+Support drag and drop in nested elements

--- a/src/plugin/fieldViews/NestedElementFieldView.ts
+++ b/src/plugin/fieldViews/NestedElementFieldView.ts
@@ -181,8 +181,32 @@ export class NestedElementFieldView extends ProseMirrorFieldView {
       handleKeyPress: (view, event) =>
         outerView.someProp(
           "handleKeyPress",
-          (f) => event.key !== "Enter" && f(outerView, event)
+          (
+            f: (
+              this: any,
+              view: EditorView,
+              event: KeyboardEvent
+            ) => boolean | void
+          ) => event.key !== "Enter" && f(outerView, event)
         ),
+      // Construct handleDOMEvents object, which propagates all drag events up to the handlers in OuterView's handleDOMEvents
+      handleDOMEvents: [
+        "dragover",
+        "dragend",
+        "dragleave",
+        "dragstart",
+        "dragenter",
+        "drop",
+      ].reduce(
+        (acc, eventName) => ({
+          ...acc,
+          [eventName]: (_: EditorView, event: DragEvent) =>
+            outerView.someProp("handleDOMEvents", (handleDOMEvents) =>
+              handleDOMEvents[eventName]?.(outerView, event)
+            ),
+        }),
+        {}
+      ),
     };
   }
 }


### PR DESCRIPTION
Co-authored with @twrichards 
______
## What does this change?
Currently Composer's [drop embed plugin](https://github.com/guardian/flexible-content/blob/main/composer/src/js/prosemirror-setup/drop-embed.js#L61) does not work in nested elements (such as Key Takeaways or Q&A). This is because the drag and drop events are swallowed by the inner editor.

This PR builds on the approach @twrichards set out in in #362 and #363 by propagating these events up to the outer editor.

ProseMirror does not have inbuilt support for the drag events in the same way it does for `handleClick` and `handleKeyPress`, so in this PR we have made use of the `handleDOMEvents` property, an object which maps DOM events to handler functions. 

We propagate the events up to be handled by the outer editor, where the drop embed plugin sets its [own handleDOMEvents property](https://github.com/guardian/flexible-content/blob/main/composer/src/js/prosemirror-setup/drop-embed.js#L83-L87) to handle the drag and drop behaviour.

## How to test
Publish locally to Composer using yalc. Drag and drop various Grid links, images and crops into the `content` field of a Key Takeaways / Q&A article. This should trigger the usual drag and drop behaviour.
