### PR TITLE
Make addChildAfter optional in RightActionControls

### DIFF
--- a/.changeset/wicked-goats-glow.md
+++ b/.changeset/wicked-goats-glow.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-elements": minor
+---
+
+Make addChildAfter optioanl for RightActionControls

--- a/.changeset/wicked-goats-glow.md
+++ b/.changeset/wicked-goats-glow.md
@@ -2,4 +2,4 @@
 "@guardian/prosemirror-elements": minor
 ---
 
-Make addChildAfter optioanl for RightActionControls
+Make addChildAfter optional for RightActionControls

--- a/src/renderers/react/WrapperControls.tsx
+++ b/src/renderers/react/WrapperControls.tsx
@@ -316,7 +316,7 @@ export type LeftRepeaterActionProps = {
 };
 
 export type RightRepeaterActionProps = {
-  addChildAfter: MouseEventHandler<HTMLButtonElement>;
+  addChildAfter?: MouseEventHandler<HTMLButtonElement>;
   moveChildUpOne: MouseEventHandler<HTMLButtonElement>;
   moveChildDownOne: MouseEventHandler<HTMLButtonElement>;
   numberOfChildNodes: number;
@@ -387,16 +387,18 @@ export const RightRepeaterActionControls = ({
           <SvgArrowDownStraight />
         </Button>
       </VerticalActions>
-      <VerticalActions verticalPosition={"bottom"}>
-        <Button
-          type="button"
-          data-cy={addChildTestId}
-          onClick={addChildAfter}
-          aria-label="Add repeater child"
-        >
-          +
-        </Button>
-      </VerticalActions>
+      {addChildAfter ?
+        <VerticalActions verticalPosition={"bottom"}>
+          <Button
+            type="button"
+            data-cy={addChildTestId}
+            onClick={addChildAfter}
+            aria-label="Add repeater child"
+          >
+            +
+          </Button>
+        </VerticalActions>
+      : null }
     </SideActions>
   );
 };

--- a/src/renderers/react/WrapperControls.tsx
+++ b/src/renderers/react/WrapperControls.tsx
@@ -387,7 +387,7 @@ export const RightRepeaterActionControls = ({
           <SvgArrowDownStraight />
         </Button>
       </VerticalActions>
-      {addChildAfter ?
+      {addChildAfter ? (
         <VerticalActions verticalPosition={"bottom"}>
           <Button
             type="button"
@@ -398,7 +398,7 @@ export const RightRepeaterActionControls = ({
             +
           </Button>
         </VerticalActions>
-      : null }
+      ) : null}
     </SideActions>
   );
 };


### PR DESCRIPTION
For the timeline element, we want to add event addition controls under the event, rather than in the RightActionPanel.

This PR therefore makes the `addChildAfter` value optional, and hides the corresponding `+` button if `addChildAfter` is falsy.

## How to test
Use via yalc in this flexible-content PR: https://github.com/guardian/flexible-content/pull/4750/files

