### PR TITLE
Fix element movement near list elements

### DIFF
--- a/.changeset/metal-dots-bow.md
+++ b/.changeset/metal-dots-bow.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-elements": minor
+---
+
+Fix element movement near repeater elements

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -17,16 +17,15 @@ const nodesBetween = (state: EditorState, _from: number, _to: number) => {
   state.doc.nodesBetween(from, to, (node, pos, parent, index) => {
     arr.push([node, pos, parent, index]);
     /*
-      Returning false from state.doc.nodesBetween prevents recursion into the node's children.
-      We don't want to recurse.
+      Returning false from state.doc.nodesBetween prevents recursion into the node's children. We want
+      to allow one level of recursion (for textElements, which contain paragraphs), but no further.
 
-      This allows us to treat list elements and their nested contents as a single entity for movement purposes.
-      In other words, we can move top-level elements up and down past a list element.
-      Before, with recursion, top-level elements would move inside the list element, often breaking the document structure.
-
-      Note this still allows us to move nested elements **within** list elements.
+      This allows us to treat list elements and their contents as a single entity for movement purposes.
+      This means we can move top-level elements up and down past a list element. Before, with
+      recursion, top-level elements would move inside the list element, often breaking the document
+      structure. Note this still allows us to move nested elements **within** list elements.
     */
-    return false;
+    return parent?.type.name === "doc";
   });
   if (dir < 0) {
     arr.reverse();

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -13,13 +13,21 @@ const nodesBetween = (state: EditorState, _from: number, _to: number) => {
   const range = [_from, _to];
   range.sort((a, b) => a - b);
   const [from, to] = range;
-
   const arr: NodesBetweenArgs[] = [];
-  state.doc.nodesBetween(
-    from,
-    to,
-    (node, pos, parent, index) => !!arr.push([node, pos, parent, index])
-  );
+  state.doc.nodesBetween(from, to, (node, pos, parent, index) => {
+    arr.push([node, pos, parent, index]);
+    /*
+      Returning false from state.doc.nodesBetween prevents recursion into the node's children.
+      We don't want to recurse.
+
+      This allows us to treat list elements and their nested contents as a single entity for movement purposes.
+      In other words, we can move top-level elements up and down past a list element.
+      Before, with recursion, top-level elements would move inside the list element, often breaking the document structure.
+
+      Note this still allows us to move nested elements **within** list elements.
+    */
+    return false;
+  });
   if (dir < 0) {
     arr.reverse();
   }

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -4,6 +4,7 @@ import type { EditorState, Transaction } from "prosemirror-state";
 import { AllSelection, NodeSelection, TextSelection } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 import { Decoration, DecorationSet } from "prosemirror-view";
+import { anyDescendantFieldIsNestedElementField } from "../fieldViews/NestedElementFieldView";
 
 type NodesBetweenArgs = [Node, number, Node | null, number];
 export type Commands = ReturnType<typeof buildCommands>;
@@ -17,15 +18,15 @@ const nodesBetween = (state: EditorState, _from: number, _to: number) => {
   state.doc.nodesBetween(from, to, (node, pos, parent, index) => {
     arr.push([node, pos, parent, index]);
     /*
-      Returning false from state.doc.nodesBetween prevents recursion into the node's children. We want
-      to allow one level of recursion (for textElements, which contain paragraphs), but no further.
+      Returning false from state.doc.nodesBetween prevents recursion into the node's children. We don't
+      want to recurse when the node is a list element.
 
       This allows us to treat list elements and their contents as a single entity for movement purposes.
       This means we can move top-level elements up and down past a list element. Before, with
       recursion, top-level elements would move inside the list element, often breaking the document
       structure. Note this still allows us to move nested elements **within** list elements.
     */
-    return parent?.type.name === "doc";
+    return !anyDescendantFieldIsNestedElementField(node);
   });
   if (dir < 0) {
     arr.reverse();


### PR DESCRIPTION
## The Problem
Before this PR, moving elements **up** past a list element was a dangerous pursuit, sometimes even deadly. 

1. If your list element had content, the element moving up would jump into the list element. This is not desired: I think we want the element to move _past_ the list element[^1]. 

https://github.com/guardian/prosemirror-elements/assets/40991816/caff134f-b9f2-4424-bd4e-5876641fb0b0

2. If your list element was empty, the element moving up would get deleted. Also not desired, you would think.

https://github.com/guardian/prosemirror-elements/assets/40991816/0dcfa31e-f84e-4c5a-a983-79367e479615

So what's going on? And why is it only affecting elements moved up?

## Explanation

When moving an element, we search for the next node along in the document to help calculate where to move our element. 

When moving down past a list element, it finds the next node correctly: the list element. It then using the list element's position and size to calculate our moved element's next position.

When moving up past a list element, it thinks that the next node isn't the list element itself, but a child node within the list element, and so breaks in the patterns described above.

This is a product of how the ProseMirror document hierarchy functions. At the "top" of a list element is the list element itself (parent), and at the "bottom" is some a nested element (child).

This is why moving down works, and moving up fails - the direction you approach the node from affects whether you are looking at the list element as a whole (down) or a child node (up).

### Illustration
#### Moving Down

* OurElement (If we move this element down...)
* ListElement (...it would find this node...)
	* NestedElement1
	* NestedElement2
* _OurElement (...and move to here.)_

___

#### Moving Up

* ListElement 
	* NestedElement1
	* _OurElement (...and move to here.)_
	* NestedElement2 (...it would find this node...)
* OurElement (If we move this element up...)

Or (when list element has no content):

* ListElement (...and break - deleting OurElement.)
	* NestedElement1 (...it would find this node...)
* OurElement (If we move this element up...)

## The Solution

The solution is to take advantage of the underlying ProseMirror method, [nodesBetween](https://prosemirror.net/docs/ref/#model.Node.nodesBetween) (used by our own `nodesBetween` method, which is used in `nextPosFinder` in `moveNode`):
> Invoke a callback for all descendant nodes recursively between the given two positions that are relative to start of this node's content. The callback is invoked with the node, its position relative to the original node (method receiver), its parent node, and its child index. **When the callback returns false for a given node, that node's children will not be recursed over**. The last parameter can be used to specify a starting position to count from.

I've highlighted the relevant part in bold. We can choose not to recurse in a given node, which would allow us to ignore the child nodes of a list element, and treat the whole element as if it were one node:

#### Moving Up (Take 2)
* _OurElement (...and move to here.)_
* ListElement (...it would find this node...)
	* NestedElement1 (...ignoring this node...)
	* NestedElement2 (...ignoring this node...)
* OurElement (If we move this element up...)

This fixes our problem, allowing us to move elements up and down past the list element as intended![^2]

## How to test
Publish to Composer locally using yalc.

Move top-level elements past a list element. Does this now work?

Does moving nested elements within list elements still work as before?

Are there any other movement related issues generated by this PR?

[^1]: I think the right approach is to move elements past list elements, not within them, but happy to hear arguments either way!

[^2]: I initially prevented recursion only when looking at list nodes, but discovered that preventing recursion everywhere is non-breaking, so went with that approach. The advantage of this is we don't need to check for list element types (the definitions for which are downstream in Composer), or nested-ness.