### PR TITLE
Have plugin handle scrollToSelection events when they occur within elements

### DIFF
--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -122,6 +122,21 @@ export const createPlugin = <
         getElementDataFromNode,
         transformElementOut
       ),
+      // Are we in an element? If so, mark scroll to selection as handled – or
+      // the parent editor will scroll to the top of the node containing the
+      // nested element.
+      handleScrollToSelection(view) {
+        const selection = view.state.selection;
+
+        let isWithinElement = false;
+        view.state.doc.nodesBetween(selection.from, selection.to, (node) => {
+          if (isProseMirrorElement(node)) {
+            isWithinElement = true;
+          }
+        });
+
+        return isWithinElement;
+      },
     },
   });
 };


### PR DESCRIPTION
_co-authored-by: @rhystmills_  - who is responsible for anything untrue in the following PR description:

## What does this change?
Currently, some inner editors (e.g. one of our text fields), hand responsibility for certain commands to the outer editor - notably the `nestedElementField`, which passes events to the outer editor so that it can handle undo, formatting, and other commands. As part of these commands, the outer editor calls `scrollIntoView` - which has led to a bug.

This behaviour hasn't caused problems until now - the only pre-existing fields that have formatting options have their own menu plugins (e.g. the caption in image elements), so don't need to hand control to the outer editor. There was [a PR to specifically handle this problem for history](https://github.com/guardian/prosemirror-elements/pull/372), which **did** have a similar problem. The problem is also much more obvious in our list elements because they can potentially be very long, so skipping to the 'top' of the element is very jarring for users.

This PR marks `scrollIntoView` as being handled by the `prosemirror-elements` plugin. We're not actually handling those events - we're just telling the outer editor that they're handled, then discarding them, so that the outer editor doesn't attempt to do so. 

We're keen to get this mitigation out quickly because the bug is degrading the experience significantly in our list formats. 

It would be good, in the near future, to:
1. Get tests out soon after this PR is merged, to cover this behaviour.
2. Handle the `scrollToSelection` behaviour properly, i.e. making sure the specific field within the `nestedElement` is scrolled to when a user makes changes - this will make it clearer what changes are being made when, e.g, a user uses undo or redo within `prosemirror-elements`. State changes to nodes are the only thing the inner editors see (i.e. they don't see transactions). We may want to set special markup on nodes that the inner editor can react to - we do something similar for selections at the moment.

## How to test
Use in Composer locally via `yalc` and test usual behaviour.
