### PR TITLE
Update inner selection when outer selection updates selection within a text field

### DIFF
--- a/src/plugin/__tests__/plugin.spec.tsx
+++ b/src/plugin/__tests__/plugin.spec.tsx
@@ -9,6 +9,7 @@ import type { FieldNameToValueMapWithEmptyValues } from "../helpers/fieldView";
 import { createEditorWithElements } from "../helpers/test";
 import { elementSelectedNodeAttr } from "../nodeSpec";
 import type { FieldDescriptions } from "../types/Element";
+import { Fragment, Slice } from "prosemirror-model";
 
 describe("createPlugin", () => {
   // Called when our consumer is updated by the plugin.
@@ -91,18 +92,19 @@ describe("createPlugin", () => {
       const initialFieldViewUpdateCount = fieldViewRenderSpy.mock.calls.length;
 
       const positionAfterElement = 19;
-      const tr = view.state.tr.replaceRangeWith(
+      const tr = view.state.tr.replace(
         positionAfterElement,
         positionAfterElement,
-        exampleText
+        new Slice(Fragment.from(exampleText), 0, 0)
       );
       view.dispatch(tr);
 
       expect(consumerRenderSpy.mock.calls.length).toBe(
         initialConsumerUpdateCount
       );
+      // replaceRangeWith will update the selection, updating the fieldView
       expect(fieldViewRenderSpy.mock.calls.length).toBe(
-        initialFieldViewUpdateCount
+        initialFieldViewUpdateCount + 1
       );
     });
 
@@ -288,18 +290,19 @@ describe("createPlugin", () => {
       // By inserting content before the element, we enable the content to move
       // upward, changing the command output.
       const positionThatEnablesUpCommand = 0;
-      const tr = view.state.tr.replaceWith(
+      const tr = view.state.tr.replace(
         positionThatEnablesUpCommand,
         positionThatEnablesUpCommand,
-        view.state.schema.text("Text before element")
-      );
+        new Slice(Fragment.from(view.state.schema.text("Text before element")), 0, 0)
+      )
       view.dispatch(tr);
 
       expect(consumerRenderSpy.mock.calls.length).toBe(
         initialConsumerUpdateCount + 1
       );
+      // The position of the selection is moved, so the fieldView is updated
       expect(fieldViewRenderSpy.mock.calls.length).toBe(
-        initialFieldViewUpdateCount
+        initialFieldViewUpdateCount + 1
       );
     });
   });
@@ -331,7 +334,7 @@ describe("createPlugin", () => {
         );
       });
 
-      it("should not update the fieldView", () => {
+      it("should update the fieldView", () => {
         const { view } = createDefaultEditor();
 
         const initialFieldViewUpdateCount =
@@ -340,7 +343,7 @@ describe("createPlugin", () => {
         applyNoopSelection(view);
 
         expect(fieldViewRenderSpy.mock.calls.length).toBe(
-          initialFieldViewUpdateCount
+          initialFieldViewUpdateCount + 1
         );
       });
 
@@ -367,7 +370,7 @@ describe("createPlugin", () => {
         );
       });
 
-      it("should not update the fieldView", () => {
+      it("should update the fieldView", () => {
         const { view } = createDefaultEditor();
 
         const initialFieldViewUpdateCount =
@@ -376,7 +379,7 @@ describe("createPlugin", () => {
         applyWholeDocSelection(view);
 
         expect(fieldViewRenderSpy.mock.calls.length).toBe(
-          initialFieldViewUpdateCount
+          initialFieldViewUpdateCount + 1
         );
       });
 
@@ -406,7 +409,7 @@ describe("createPlugin", () => {
         );
       });
 
-      it("should not update the fieldView", () => {
+      it("should update the fieldView", () => {
         const { view } = createDefaultEditor();
 
         applyWholeDocSelection(view);
@@ -417,7 +420,7 @@ describe("createPlugin", () => {
         applyNoopSelection(view);
 
         expect(fieldViewRenderSpy.mock.calls.length).toBe(
-          initialFieldViewUpdateCount
+          initialFieldViewUpdateCount + 1
         );
       });
 

--- a/src/plugin/__tests__/plugin.spec.tsx
+++ b/src/plugin/__tests__/plugin.spec.tsx
@@ -1,3 +1,4 @@
+import { Fragment, Slice } from "prosemirror-model";
 import { AllSelection, Plugin, TextSelection } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 import { Decoration, DecorationSet } from "prosemirror-view";
@@ -9,7 +10,6 @@ import type { FieldNameToValueMapWithEmptyValues } from "../helpers/fieldView";
 import { createEditorWithElements } from "../helpers/test";
 import { elementSelectedNodeAttr } from "../nodeSpec";
 import type { FieldDescriptions } from "../types/Element";
-import { Fragment, Slice } from "prosemirror-model";
 
 describe("createPlugin", () => {
   // Called when our consumer is updated by the plugin.
@@ -292,8 +292,12 @@ describe("createPlugin", () => {
       const tr = view.state.tr.replace(
         positionThatEnablesUpCommand,
         positionThatEnablesUpCommand,
-        new Slice(Fragment.from(view.state.schema.text("Text before element")), 0, 0)
-      )
+        new Slice(
+          Fragment.from(view.state.schema.text("Text before element")),
+          0,
+          0
+        )
+      );
       view.dispatch(tr);
 
       expect(consumerRenderSpy.mock.calls.length).toBe(

--- a/src/plugin/__tests__/plugin.spec.tsx
+++ b/src/plugin/__tests__/plugin.spec.tsx
@@ -102,7 +102,6 @@ describe("createPlugin", () => {
       expect(consumerRenderSpy.mock.calls.length).toBe(
         initialConsumerUpdateCount
       );
-      // replaceRangeWith will update the selection, updating the fieldView
       expect(fieldViewRenderSpy.mock.calls.length).toBe(
         initialFieldViewUpdateCount + 1
       );

--- a/src/plugin/field.ts
+++ b/src/plugin/field.ts
@@ -20,6 +20,7 @@ import type {
   RepeaterField,
 } from "./types/Element";
 import { isRepeaterField } from "./types/Element";
+import { Selection } from "prosemirror-state";
 
 const getRepeaterDecorations = (
   outerDecos: DecorationSource,
@@ -352,14 +353,15 @@ export const updateFieldViewsFromNode = <
   fields: FieldNameToField<FDesc>,
   node: Node,
   decos: DecorationSource,
-  offset = 0
+  offset = 0,
+  selection?: Selection
 ) => {
   node.forEach((node, localOffset) => {
     const fieldName = getFieldNameFromNode(
       node
     ) as keyof FieldNameToField<FDesc>;
     const field = fields[fieldName];
-    field.view.onUpdate(node, offset + localOffset, decos);
+    field.view.onUpdate(node, offset + localOffset, decos, selection);
 
     if (!isRepeaterField(field)) {
       return;
@@ -378,7 +380,8 @@ export const updateFieldViewsFromNode = <
         field.children[index],
         childNode,
         repeaterDecos,
-        offset + localOffset + repeaterOffset + depthOffset
+        offset + localOffset + repeaterOffset + depthOffset,
+        selection
       );
     });
   });

--- a/src/plugin/field.ts
+++ b/src/plugin/field.ts
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import { set } from "lodash/fp";
 import type { DOMSerializer, Node } from "prosemirror-model";
+import type { Selection } from "prosemirror-state";
 import { Mapping, StepMap } from "prosemirror-transform";
 import type { DecorationSource, EditorView } from "prosemirror-view";
 import { RepeaterFieldMapIDKey } from "./helpers/constants";
@@ -20,7 +21,6 @@ import type {
   RepeaterField,
 } from "./types/Element";
 import { isRepeaterField } from "./types/Element";
-import { Selection } from "prosemirror-state";
 
 const getRepeaterDecorations = (
   outerDecos: DecorationSource,

--- a/src/plugin/fieldViews/FieldView.ts
+++ b/src/plugin/fieldViews/FieldView.ts
@@ -2,6 +2,7 @@ import { uniqueId } from "lodash";
 import type { Node } from "prosemirror-model";
 import type { DecorationSource } from "prosemirror-view";
 import type { FieldValidator } from "../elementSpec";
+import { Selection } from "prosemirror-state";
 
 /**
  * The specification for an element field, to be modelled as a Node in Prosemirror.
@@ -45,7 +46,8 @@ export abstract class FieldView<NodeValue> {
   public abstract onUpdate(
     node: Node,
     elementOffset: number,
-    decorations: DecorationSource
+    decorations: DecorationSource,
+    selection: Selection
   ): boolean;
 
   /**

--- a/src/plugin/fieldViews/FieldView.ts
+++ b/src/plugin/fieldViews/FieldView.ts
@@ -1,8 +1,8 @@
 import { uniqueId } from "lodash";
 import type { Node } from "prosemirror-model";
+import type { Selection } from "prosemirror-state";
 import type { DecorationSource } from "prosemirror-view";
 import type { FieldValidator } from "../elementSpec";
-import { Selection } from "prosemirror-state";
 
 /**
  * The specification for an element field, to be modelled as a Node in Prosemirror.

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -1,6 +1,6 @@
-import { AttributeSpec, Node } from "prosemirror-model";
 import { DOMParser } from "prosemirror-model";
-import { Plugin, Selection, TextSelection, Transaction } from "prosemirror-state";
+import type { AttributeSpec, Node } from "prosemirror-model";
+import type { Plugin, Selection, Transaction } from "prosemirror-state";
 import { EditorState } from "prosemirror-state";
 import { Mapping, StepMap } from "prosemirror-transform";
 import type { DecorationSource, EditorProps } from "prosemirror-view";
@@ -200,39 +200,42 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
       const incomingHeadPos = selection.$head.pos;
 
       const fieldStart = this.offset + this.getPos() + 2;
-      const fieldEnd = this.offset + this.getPos() + this.innerEditorView.state.doc.nodeSize;
+      const fieldEnd =
+        this.offset + this.getPos() + this.innerEditorView.state.doc.nodeSize;
 
-      const selectionAnchorIsWithinThisField = incomingAnchorPos > fieldStart && incomingAnchorPos < fieldEnd;
-      const selectionHeadIsWithinThisField = incomingHeadPos > fieldStart && incomingHeadPos < fieldEnd;
-          
+      const selectionAnchorIsWithinThisField =
+        incomingAnchorPos > fieldStart && incomingAnchorPos < fieldEnd;
+      const selectionHeadIsWithinThisField =
+        incomingHeadPos > fieldStart && incomingHeadPos < fieldEnd;
+
       if (selectionAnchorIsWithinThisField && selectionHeadIsWithinThisField) {
         // The inner editor's selection will be offset relative to the start of this field, compared to the incoming selection
-        const currentAnchorPos = this.innerEditorView.state.selection.$anchor.pos;
+        const currentAnchorPos = this.innerEditorView.state.selection.$anchor
+          .pos;
         const currentHeadPos = this.innerEditorView.state.selection.$head.pos;
         const offsetIncomingAnchorPos = incomingAnchorPos - fieldStart;
         const offsetIncomingHeadPos = selection.$head.pos - fieldStart;
 
-        if (currentAnchorPos !== offsetIncomingAnchorPos || currentHeadPos !== offsetIncomingHeadPos){
-          const offsetMap = StepMap.offset(
-            -fieldStart
-          );
+        if (
+          currentAnchorPos !== offsetIncomingAnchorPos ||
+          currentHeadPos !== offsetIncomingHeadPos
+        ) {
+          const offsetMap = StepMap.offset(-fieldStart);
           const mappedSelection = selection.map(state.tr.doc, offsetMap);
 
           this.innerEditorView.dispatch(
             state.tr
-              .setSelection(
-                mappedSelection
-              )
+              .setSelection(mappedSelection)
               .replace(
                 diffStart,
                 endOfInnerDiff,
                 node.slice(diffStart, endOfOuterDiff)
               )
               .setMeta("fromOutside", true)
-          )
-          return
+          );
+          return;
         }
-      };
+      }
     }
     this.innerEditorView.dispatch(
       state.tr

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -157,7 +157,11 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
       const incomingAnchorPos = selection.$anchor.pos;
       const incomingHeadPos = selection.$head.pos;
 
-      const fieldStart = this.offset + this.getPos() + 2;
+      // We must offset to account for a few things:
+      //  - getPos() returns the position directly before the parent node (+1)
+      //  - the node we will be altering is a child of its parent (+1)
+      const contentOffset = 2;
+      const fieldStart = this.offset + this.getPos() + contentOffset;
       const fieldEnd =
         this.offset + this.getPos() + this.innerEditorView.state.doc.nodeSize;
 

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -147,52 +147,10 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
     this.applyDecorationsFromOuterEditor(decorations, node, elementOffset);
 
     const state = this.innerEditorView.state;
+    let shouldDispatchTransaction = false;
+    let tr = state.tr;
 
-    // Figure out the smallest change to the node content we need to make
-    // to successfully update the inner editor, and apply it.
-
-    const diffStart = node.content.findDiffStart(state.doc.content);
-
-    if (diffStart === null) {
-      return this.maybeRerenderDecorations();
-    }
-
-    const diffEnd = node.content.findDiffEnd(state.doc.content);
-    if (!diffEnd) {
-      // There's no difference between these nodes.
-      return this.maybeRerenderDecorations();
-    }
-
-    let { a: endOfOuterDiff, b: endOfInnerDiff } = diffEnd;
-
-    // This overlap accounts for a situation where we're diffing nodes where we encounter
-    // identical content.
-    //
-    // For example, if the inner node has content 'a', and the outer node has content 'aa',
-    // `diffStart` sees (numbers are positions, ^ denotes the value found by the method)
-    //
-    // ab    inner node
-    // abb   outer node
-    // 123
-    //   ^
-    //
-    // `diffEnd` for the inner node is
-    //  ab   inner node
-    // abb   outer node
-    // 123
-    //  ^
-    //
-    // But 2 is not the correct end of the diff. The correct diff is (3, 3).
-    //
-    // This happens because `findDiffEnd` finds the first point at which the content differs,
-    // starting from the end of the nodes. So if we encounter identical content, the diff will
-    // be shorter by the length of the identical content we encounter – or the overlap between
-    // the two nodes from the point of view of the diff.
-    const overlap = diffStart - Math.min(endOfOuterDiff, endOfInnerDiff);
-    if (overlap > 0) {
-      endOfOuterDiff += overlap;
-      endOfInnerDiff += overlap;
-    }
+    // Check if the inner selection needs to be updated
 
     if (selection) {
       // Check if incoming selection is within this field
@@ -207,45 +165,82 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
         incomingAnchorPos > fieldStart && incomingAnchorPos < fieldEnd;
       const selectionHeadIsWithinThisField =
         incomingHeadPos > fieldStart && incomingHeadPos < fieldEnd;
-
       if (selectionAnchorIsWithinThisField && selectionHeadIsWithinThisField) {
-        // The inner editor's selection will be offset relative to the start of this field, compared to the incoming selection
+        // The inner editor's selection will be offset relative to the start of this field, 
+        // compared to the incoming selection
         const currentAnchorPos = this.innerEditorView.state.selection.$anchor
           .pos;
         const currentHeadPos = this.innerEditorView.state.selection.$head.pos;
         const offsetIncomingAnchorPos = incomingAnchorPos - fieldStart;
         const offsetIncomingHeadPos = selection.$head.pos - fieldStart;
-
         if (
           currentAnchorPos !== offsetIncomingAnchorPos ||
           currentHeadPos !== offsetIncomingHeadPos
         ) {
           const offsetMap = StepMap.offset(-fieldStart);
           const mappedSelection = selection.map(state.tr.doc, offsetMap);
-
-          this.innerEditorView.dispatch(
-            state.tr
-              .setSelection(mappedSelection)
-              .replace(
-                diffStart,
-                endOfInnerDiff,
-                node.slice(diffStart, endOfOuterDiff)
-              )
-              .setMeta("fromOutside", true)
-          );
-          return;
+          shouldDispatchTransaction = true;
+          tr = tr.setSelection(mappedSelection)
         }
       }
     }
-    this.innerEditorView.dispatch(
-      state.tr
-        .replace(
-          diffStart,
-          endOfInnerDiff,
-          node.slice(diffStart, endOfOuterDiff)
-        )
-        .setMeta("fromOutside", true)
-    );
+
+    // Check if the passed-in Node is different to the existing content, 
+    // figure out the smallest change to the node content we need to make to
+    // successfully update the inner editor, and apply it.
+
+    const diffStart = node.content.findDiffStart(state.doc.content);
+    const diffEnd = node.content.findDiffEnd(state.doc.content);
+
+    if (diffStart && diffEnd){
+    let { a: endOfOuterDiff, b: endOfInnerDiff } = diffEnd;
+    let { a: endOfOuterDiff, b: endOfInnerDiff } = diffEnd;
+
+      let { a: endOfOuterDiff, b: endOfInnerDiff } = diffEnd;
+
+      // This overlap accounts for a situation where we're diffing nodes where we encounter
+      // identical content.
+      //
+      // For example, if the inner node has content 'a', and the outer node has content 'aa',
+      // `diffStart` sees (numbers are positions, ^ denotes the value found by the method)
+      //
+      // ab    inner node
+      // abb   outer node
+      // 123
+      //   ^
+      //
+      // `diffEnd` for the inner node is
+      //  ab   inner node
+      // abb   outer node
+      // 123
+      //  ^
+      //
+      // But 2 is not the correct end of the diff. The correct diff is (3, 3).
+      //
+      // This happens because `findDiffEnd` finds the first point at which the content differs,
+      // starting from the end of the nodes. So if we encounter identical content, the diff will
+      // be shorter by the length of the identical content we encounter – or the overlap between
+      // the two nodes from the point of view of the diff.
+      const overlap = diffStart - Math.min(endOfOuterDiff, endOfInnerDiff);
+      if (overlap > 0) {
+        endOfOuterDiff += overlap;
+        endOfInnerDiff += overlap;
+      }
+      
+      shouldDispatchTransaction = true;
+      tr = tr.replace(
+        diffStart,
+        endOfInnerDiff,
+        node.slice(diffStart, endOfOuterDiff)
+      )
+    }
+    if (shouldDispatchTransaction){
+      this.innerEditorView.dispatch(
+        tr.setMeta("fromOutside", true)
+      );
+    } else {
+      return this.maybeRerenderDecorations()
+    }
   }
 
   private updateOuterEditor(

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -51,7 +51,7 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
     // The outer editor instance. Updated from within this class when the inner state changes.
     private outerView: EditorView,
     // Returns the current position of the parent FieldView in the document.
-    private getPos: () => number,
+    protected getPos: () => number,
     // The offset of this node relative to its parent FieldView.
     public offset: number,
     // The initial decorations for the FieldView.
@@ -166,7 +166,7 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
       const selectionHeadIsWithinThisField =
         incomingHeadPos > fieldStart && incomingHeadPos < fieldEnd;
       if (selectionAnchorIsWithinThisField && selectionHeadIsWithinThisField) {
-        // The inner editor's selection will be offset relative to the start of this field, 
+        // The inner editor's selection will be offset relative to the start of this field,
         // compared to the incoming selection
         const currentAnchorPos = this.innerEditorView.state.selection.$anchor
           .pos;
@@ -180,24 +180,20 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
           const offsetMap = StepMap.offset(-fieldStart);
           const mappedSelection = selection.map(state.tr.doc, offsetMap);
           shouldDispatchTransaction = true;
-          tr = tr.setSelection(mappedSelection)
+          tr = tr.setSelection(mappedSelection);
         }
       }
     }
 
-    // Check if the passed-in Node is different to the existing content, 
+    // Check if the passed-in Node is different to the existing content,
     // figure out the smallest change to the node content we need to make to
     // successfully update the inner editor, and apply it.
 
     const diffStart = node.content.findDiffStart(state.doc.content);
     const diffEnd = node.content.findDiffEnd(state.doc.content);
 
-    if (diffStart && diffEnd){
-    let { a: endOfOuterDiff, b: endOfInnerDiff } = diffEnd;
-    let { a: endOfOuterDiff, b: endOfInnerDiff } = diffEnd;
-
+    if (diffStart && diffEnd) {
       let { a: endOfOuterDiff, b: endOfInnerDiff } = diffEnd;
-
       // This overlap accounts for a situation where we're diffing nodes where we encounter
       // identical content.
       //
@@ -226,20 +222,18 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
         endOfOuterDiff += overlap;
         endOfInnerDiff += overlap;
       }
-      
+
       shouldDispatchTransaction = true;
       tr = tr.replace(
         diffStart,
         endOfInnerDiff,
         node.slice(diffStart, endOfOuterDiff)
-      )
-    }
-    if (shouldDispatchTransaction){
-      this.innerEditorView.dispatch(
-        tr.setMeta("fromOutside", true)
       );
+    }
+    if (shouldDispatchTransaction) {
+      this.innerEditorView.dispatch(tr.setMeta("fromOutside", true));
     } else {
-      return this.maybeRerenderDecorations()
+      return this.maybeRerenderDecorations();
     }
   }
 

--- a/src/plugin/fieldViews/__tests__/TextFieldView.spec.ts
+++ b/src/plugin/fieldViews/__tests__/TextFieldView.spec.ts
@@ -1,0 +1,91 @@
+import type { NodeSpec } from "prosemirror-model";
+import { createEditorWithElements } from "../../helpers/test";
+import { getNodeNameFromField, getNodeSpecForField } from "../../nodeSpec";
+import { Schema } from 'prosemirror-model';
+import { schema } from "prosemirror-schema-basic";
+import { TextFieldDescription, TextFieldView } from "../TextFieldView";
+import { DecorationSet } from "prosemirror-view";
+import { StepMap } from "prosemirror-transform";
+import { TextSelection } from "prosemirror-state";
+
+
+class TestProseMirrorFieldView extends TextFieldView {
+    getInnerEditorView = () => {
+        return this.innerEditorView;
+    } 
+}
+
+const testSchema = new Schema({
+    nodes: {
+      doc: schema.nodes.doc,
+      text: schema.nodes.text,
+      ...(getNodeSpecForField("doc", "testField", {
+        type: "text",
+        defaultValue: "",
+        isMultiline: false,
+        rows: 4,
+        isCode: false
+      }) as { testField: NodeSpec }),
+    },
+});
+
+const textFieldDescription: TextFieldDescription = {
+    type: "text",
+    isMultiline: false,
+    rows: 4,
+    isCode: false
+}
+
+
+describe("the TextFieldView, as an extension of the ProseMirrorFieldView", () => {
+    it("should update its internal selection when a new selection is passed in, encompassed within its range", () => {
+        const { view } = createEditorWithElements([]);
+        const nodeName = getNodeNameFromField("testField", "doc");
+        const node = testSchema.nodes[nodeName].create({
+            type: "text",
+        }, testSchema.text("some text"));
+        const decorations = DecorationSet.create(view.state.doc, []);
+        const fieldView = new TestProseMirrorFieldView(node, view, () => 0, 0, decorations, textFieldDescription);
+        const offset = fieldView.offset;
+        const textFieldViewInnerEditor = fieldView.getInnerEditorView()
+        if (!textFieldViewInnerEditor) throw new Error("Text field editor was undefined");
+        
+        const initialSelection = textFieldViewInnerEditor.state.selection;
+        // Offset the initial selection so that it is within the inner editor's field
+        const offsetMap = StepMap.offset(3);
+        const mappedSelection = initialSelection.map(textFieldViewInnerEditor.state.tr.doc, offsetMap);
+        fieldView.onUpdate(node, offset, decorations, mappedSelection)
+        const updatedSelection = fieldView.getInnerEditorView()?.state.selection
+
+        expect(initialSelection.from).toBe(0)
+        expect(initialSelection.to).toBe(0)
+        // Selection is positioned at '1' relative to the outer editor, rather than 3, because 
+        // the inner editor is offset by 2 
+        expect(updatedSelection?.from).toBe(1)
+        expect(updatedSelection?.to).toBe(1)
+    })
+
+    it("should not update its internal selection when a selection is passed in outside of its range", () => {
+        const { view } = createEditorWithElements([], "Some arbitrary text content");
+        const nodeName = getNodeNameFromField("testField", "doc");
+        const node = testSchema.nodes[nodeName].create({
+            type: "text",
+        }, testSchema.text("some text"));
+        const decorations = DecorationSet.create(view.state.doc, []);
+        const fieldView = new TestProseMirrorFieldView(node, view, () => 0, 0, decorations, textFieldDescription);
+        const offset = fieldView.offset;
+        const textFieldViewInnerEditor = fieldView.getInnerEditorView()
+        if (!textFieldViewInnerEditor) throw new Error("Text field editor was undefined");
+        
+        const initialSelection = textFieldViewInnerEditor.state.selection;
+        // A selection that will be outside the innerEditor's range
+        const newSelection = TextSelection.create(view.state.doc, 15, 15) 
+        fieldView.onUpdate(node, offset, decorations, newSelection)
+        const updatedSelection = fieldView.getInnerEditorView()?.state.selection
+
+        expect(initialSelection.from).toBe(0)
+        expect(initialSelection.to).toBe(0)
+        expect(updatedSelection?.from).toBe(0)
+        expect(updatedSelection?.to).toBe(0)
+    })
+})

--- a/src/plugin/fieldViews/__tests__/TextFieldView.spec.ts
+++ b/src/plugin/fieldViews/__tests__/TextFieldView.spec.ts
@@ -1,91 +1,118 @@
 import type { NodeSpec } from "prosemirror-model";
+import { Schema } from "prosemirror-model";
+import { schema } from "prosemirror-schema-basic";
+import { TextSelection } from "prosemirror-state";
+import { StepMap } from "prosemirror-transform";
+import { DecorationSet } from "prosemirror-view";
 import { createEditorWithElements } from "../../helpers/test";
 import { getNodeNameFromField, getNodeSpecForField } from "../../nodeSpec";
-import { Schema } from 'prosemirror-model';
-import { schema } from "prosemirror-schema-basic";
-import { TextFieldDescription, TextFieldView } from "../TextFieldView";
-import { DecorationSet } from "prosemirror-view";
-import { StepMap } from "prosemirror-transform";
-import { TextSelection } from "prosemirror-state";
-
+import type { TextFieldDescription } from "../TextFieldView";
+import { TextFieldView } from "../TextFieldView";
 
 class TestProseMirrorFieldView extends TextFieldView {
-    getInnerEditorView = () => {
-        return this.innerEditorView;
-    } 
+  getInnerEditorView = () => {
+    return this.innerEditorView;
+  };
 }
 
 const testSchema = new Schema({
-    nodes: {
-      doc: schema.nodes.doc,
-      text: schema.nodes.text,
-      ...(getNodeSpecForField("doc", "testField", {
-        type: "text",
-        defaultValue: "",
-        isMultiline: false,
-        rows: 4,
-        isCode: false
-      }) as { testField: NodeSpec }),
-    },
+  nodes: {
+    doc: schema.nodes.doc,
+    text: schema.nodes.text,
+    ...(getNodeSpecForField("doc", "testField", {
+      type: "text",
+      defaultValue: "",
+      isMultiline: false,
+      rows: 4,
+      isCode: false,
+    }) as { testField: NodeSpec }),
+  },
 });
 
 const textFieldDescription: TextFieldDescription = {
-    type: "text",
-    isMultiline: false,
-    rows: 4,
-    isCode: false
-}
-
+  type: "text",
+  isMultiline: false,
+  rows: 4,
+  isCode: false,
+};
 
 describe("the TextFieldView, as an extension of the ProseMirrorFieldView", () => {
-    it("should update its internal selection when a new selection is passed in, encompassed within its range", () => {
-        const { view } = createEditorWithElements([]);
-        const nodeName = getNodeNameFromField("testField", "doc");
-        const node = testSchema.nodes[nodeName].create({
-            type: "text",
-        }, testSchema.text("some text"));
-        const decorations = DecorationSet.create(view.state.doc, []);
-        const fieldView = new TestProseMirrorFieldView(node, view, () => 0, 0, decorations, textFieldDescription);
-        const offset = fieldView.offset;
-        const textFieldViewInnerEditor = fieldView.getInnerEditorView()
-        if (!textFieldViewInnerEditor) throw new Error("Text field editor was undefined");
-        
-        const initialSelection = textFieldViewInnerEditor.state.selection;
-        // Offset the initial selection so that it is within the inner editor's field
-        const offsetMap = StepMap.offset(3);
-        const mappedSelection = initialSelection.map(textFieldViewInnerEditor.state.tr.doc, offsetMap);
-        fieldView.onUpdate(node, offset, decorations, mappedSelection)
-        const updatedSelection = fieldView.getInnerEditorView()?.state.selection
+  it("should update its internal selection when a new selection is passed in, encompassed within its range", () => {
+    const { view } = createEditorWithElements([]);
+    const nodeName = getNodeNameFromField("testField", "doc");
+    const node = testSchema.nodes[nodeName].create(
+      {
+        type: "text",
+      },
+      testSchema.text("some text")
+    );
+    const decorations = DecorationSet.create(view.state.doc, []);
+    const fieldView = new TestProseMirrorFieldView(
+      node,
+      view,
+      () => 0,
+      0,
+      decorations,
+      textFieldDescription
+    );
+    const offset = fieldView.offset;
+    const textFieldViewInnerEditor = fieldView.getInnerEditorView();
+    if (!textFieldViewInnerEditor)
+      throw new Error("Text field editor was undefined");
 
-        expect(initialSelection.from).toBe(0)
-        expect(initialSelection.to).toBe(0)
-        // Selection is positioned at '1' relative to the outer editor, rather than 3, because 
-        // the inner editor is offset by 2 
-        expect(updatedSelection?.from).toBe(1)
-        expect(updatedSelection?.to).toBe(1)
-    })
+    const initialSelection = textFieldViewInnerEditor.state.selection;
+    // Offset the initial selection so that it is within the inner editor's field
+    const offsetMap = StepMap.offset(3);
+    const mappedSelection = initialSelection.map(
+      textFieldViewInnerEditor.state.tr.doc,
+      offsetMap
+    );
+    fieldView.onUpdate(node, offset, decorations, mappedSelection);
+    const updatedSelection = fieldView.getInnerEditorView()?.state.selection;
 
-    it("should not update its internal selection when a selection is passed in outside of its range", () => {
-        const { view } = createEditorWithElements([], "Some arbitrary text content");
-        const nodeName = getNodeNameFromField("testField", "doc");
-        const node = testSchema.nodes[nodeName].create({
-            type: "text",
-        }, testSchema.text("some text"));
-        const decorations = DecorationSet.create(view.state.doc, []);
-        const fieldView = new TestProseMirrorFieldView(node, view, () => 0, 0, decorations, textFieldDescription);
-        const offset = fieldView.offset;
-        const textFieldViewInnerEditor = fieldView.getInnerEditorView()
-        if (!textFieldViewInnerEditor) throw new Error("Text field editor was undefined");
-        
-        const initialSelection = textFieldViewInnerEditor.state.selection;
-        // A selection that will be outside the innerEditor's range
-        const newSelection = TextSelection.create(view.state.doc, 15, 15) 
-        fieldView.onUpdate(node, offset, decorations, newSelection)
-        const updatedSelection = fieldView.getInnerEditorView()?.state.selection
+    expect(initialSelection.from).toBe(0);
+    expect(initialSelection.to).toBe(0);
+    // Selection is positioned at '1' relative to the outer editor, rather than 3, because
+    // the inner editor is offset by 2
+    expect(updatedSelection?.from).toBe(1);
+    expect(updatedSelection?.to).toBe(1);
+  });
 
-        expect(initialSelection.from).toBe(0)
-        expect(initialSelection.to).toBe(0)
-        expect(updatedSelection?.from).toBe(0)
-        expect(updatedSelection?.to).toBe(0)
-    })
-})
+  it("should not update its internal selection when a selection is passed in outside of its range", () => {
+    const { view } = createEditorWithElements(
+      [],
+      "Some arbitrary text content"
+    );
+    const nodeName = getNodeNameFromField("testField", "doc");
+    const node = testSchema.nodes[nodeName].create(
+      {
+        type: "text",
+      },
+      testSchema.text("some text")
+    );
+    const decorations = DecorationSet.create(view.state.doc, []);
+    const fieldView = new TestProseMirrorFieldView(
+      node,
+      view,
+      () => 0,
+      0,
+      decorations,
+      textFieldDescription
+    );
+    const offset = fieldView.offset;
+    const textFieldViewInnerEditor = fieldView.getInnerEditorView();
+    if (!textFieldViewInnerEditor)
+      throw new Error("Text field editor was undefined");
+
+    const initialSelection = textFieldViewInnerEditor.state.selection;
+    // A selection that will be outside the innerEditor's range
+    const newSelection = TextSelection.create(view.state.doc, 15, 15);
+    fieldView.onUpdate(node, offset, decorations, newSelection);
+    const updatedSelection = fieldView.getInnerEditorView()?.state.selection;
+
+    expect(initialSelection.from).toBe(0);
+    expect(initialSelection.to).toBe(0);
+    expect(updatedSelection?.from).toBe(0);
+    expect(updatedSelection?.to).toBe(0);
+  });
+});

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -1,7 +1,7 @@
 import { DOMSerializer } from "prosemirror-model";
 import type { Node } from "prosemirror-model";
 import type { EditorState } from "prosemirror-state";
-import { NodeSelection, Plugin, TextSelection } from "prosemirror-state";
+import { NodeSelection, Plugin } from "prosemirror-state";
 import type { EditorProps } from "prosemirror-view";
 import type { SendTelemetryEvent } from "../elements/helpers/types/TelemetryEvents";
 import type {
@@ -293,7 +293,13 @@ const createNodeView = <
           anyDescendantFieldIsNestedElementField(newNode) ||
           selectionHasChanged
         ) {
-          updateFieldViewsFromNode(newFields, newNode, innerDecos, 0, newSelection);
+          updateFieldViewsFromNode(
+            newFields,
+            newNode,
+            innerDecos,
+            0,
+            newSelection
+          );
         }
 
         // Only update our consumer if anything internal to the field has changed.

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -1,7 +1,7 @@
 import { DOMSerializer } from "prosemirror-model";
 import type { Node } from "prosemirror-model";
 import type { EditorState } from "prosemirror-state";
-import { NodeSelection, Plugin } from "prosemirror-state";
+import { NodeSelection, Plugin, TextSelection } from "prosemirror-state";
 import type { EditorProps } from "prosemirror-view";
 import type { SendTelemetryEvent } from "../elements/helpers/types/TelemetryEvents";
 import type {
@@ -221,6 +221,7 @@ const createNodeView = <
   let currentDecos = innerDecos;
   let currentIsSelected = false;
   let currentCommandValues = getCommandValues(initCommands);
+  let currentSelection = view.state.selection;
 
   const getElementDataForUpdator = () =>
     getFieldValuesFromNode(
@@ -257,6 +258,7 @@ const createNodeView = <
         const newIsSelected = isProseMirrorElementSelected(newNode);
         const newCommands = commands(getPos, view);
         const newCommandValues = getCommandValues(newCommands);
+        const newSelection = view.state.selection;
 
         const isSelectedChanged = currentIsSelected !== newIsSelected;
         const innerDecosChanged = currentDecos !== innerDecos;
@@ -265,6 +267,7 @@ const createNodeView = <
           currentCommandValues,
           newCommandValues
         );
+        const selectionHasChanged = !newSelection.eq(currentSelection);
 
         // Only recalculate our field values if our node content has changed.
         const newFields = fieldValuesChanged
@@ -280,16 +283,17 @@ const createNodeView = <
             })
           : currentFields;
 
-        // Only update our FieldViews if their content or decorations have changed.
+        // Only update our FieldViews if their content or decorations have changed, or the selection has changed.
         // nestedElement FieldViews are always updated as a workaround for a bug
         // with merging text elements in the zipRoot plugin after an intermediate element is
         // deleted.
         if (
           fieldValuesChanged ||
           innerDecosChanged ||
-          anyDescendantFieldIsNestedElementField(newNode)
+          anyDescendantFieldIsNestedElementField(newNode) ||
+          selectionHasChanged
         ) {
-          updateFieldViewsFromNode(newFields, newNode, innerDecos);
+          updateFieldViewsFromNode(newFields, newNode, innerDecos, 0, newSelection);
         }
 
         // Only update our consumer if anything internal to the field has changed.
@@ -302,6 +306,7 @@ const createNodeView = <
         currentDecos = innerDecos;
         currentFields = newFields;
         currentCommandValues = newCommandValues;
+        currentSelection = newSelection;
 
         return true;
       }


### PR DESCRIPTION
## Background
In prosemirror-elements, elements are a collection of fields representing user-editable data. Most logic managing these fields is in the relevant `FieldView`. Text fields are all based on `ProseMirrorFieldView`, via implementations that extend it, e.g. `TextFieldView`. These contain instances of ProseMirror ('inner editors'), and the 'outer editor' (the editor that contains the element) delegates control of certain actions to the 'inner editor' managed by the FieldView.

Currently, two kinds of changes from the outer editor can cause changes in the field view:
  1. Changes to the nodes that the inner editor manages:
  2. Changes to `Decorations` that affect the range covered by the field view.

However, if the selection is updated by the outer editor, the selection within a relevant field is not updated.

This hasn't been obvious in the past, because usually the selection is updated by the field's 'inner' editor. With notes being supported in nested element fields, when a user hits 'F10' in Composer with text selected inside the nested element, the selection is updated by the outer editor (to which the menu belongs), and should be moved to the end of the note as users expect. Because the selection is not passed to the inner editor, the note content remains selected, so when the user types, they overwrite the content of the note.


## What does this change?

This PR updates field views when the selection changes, and the text fields (extensions of `ProsemirrorFieldView`) update their inner editor selection to match the incoming selection. This means that the usual F10 behaviour for notes also works inside our test fields.

![Kapture 2024-05-14 at 15 49 59](https://github.com/guardian/prosemirror-elements/assets/34686302/2876d6b3-1f84-4aae-af24-8cb31058ef6c)

This happens as follows:
1. The outer selection changes
2. Update` in `plugin.ts`, a function at the boundary of the plugin, receives state changes from the outer editor, which included the updated `Selection`.
3.  We pass this into the `FieldViews` via some intermediate functions.
4. The only `FieldView` that needs to handle the selection change is the abstract `ProseMirrorFieldView`, which all text `FieldViews` extend.
5. Every text `FieldView` checks if the selection covers its own range. If it does, it updates its internal selection.

## How to test
1. Use prosemirror-elements locally with flexible-content using `yalc`.
6. Create a list format document, like Key Takeaways
7. Type some text in the nested element field, highlight some of it, and hit F10. The cursor should move to the end of the note.

**n.b. - due to an unrelated bug with menu clicks causing the editor to lose focus, this only works with the F10 shortcut, not the notes menu button**

I have updated existing tests to match the new update behaviour and added a test to reflect the selection behaviour itself, making sure that the inner selection is properly updated when there is a relevant incoming selection.