### PR TITLE
Fix issues with decorations in nested and repeater fields

### DIFF
--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -1,3 +1,4 @@
+import type { insertElement } from "../../demo";
 import type { WindowType } from "../../demo/types";
 import { getFieldHeadingTestId } from "../../src/editorial-source-components/DemoInputHeading";
 import { placeholderTestAttribute } from "../../src/plugin/helpers/placeholder";
@@ -103,25 +104,22 @@ export const changeTestDecoString = (newTestString: string) => {
   });
 };
 
-export const addImageElement = (values: Record<string, unknown> = {}) => {
+const addElement = (
+  elementName: Parameters<typeof insertElement>[0]["elementName"]
+) => (values: Record<string, unknown> = {}) => {
   cy.window().then((win: WindowType) => {
     const { view, insertElement } = win.PM_ELEMENTS;
-    insertElement({ elementName: "demo-image-element", values })(
+    insertElement({ elementName, values: values as any })(
       view.state,
       view.dispatch
     );
   });
 };
 
-export const addAltStyleElement = (values: Record<string, unknown> = {}) => {
-  cy.window().then((win: WindowType) => {
-    const { view, insertElement } = win.PM_ELEMENTS;
-    insertElement({ elementName: "alt-style", values })(
-      view.state,
-      view.dispatch
-    );
-  });
-};
+export const addImageElement = addElement("demo-image-element");
+export const addAltStyleElement = addElement("alt-style");
+export const addRepeaterElement = addElement("repeater");
+export const addNestedElement = addElement("nested");
 
 export const getButton = (id: string) => cy.get(`button${selectDataCy(id)}`);
 

--- a/cypress/tests/AltStylesElement.cy.ts
+++ b/cypress/tests/AltStylesElement.cy.ts
@@ -7,6 +7,7 @@ import {
 } from "../../src/renderers/react/WrapperControls";
 import {
   addAltStyleElement,
+  addImageElement,
   getButton,
   getElementRichTextField,
   selectDataCy,
@@ -99,16 +100,52 @@ describe("AltStyleElement", () => {
   });
 
   it(`multiple NestedElements IN repeater – should render decorations passed from the parent editor`, () => {
-    addAltStyleElement(repeaterWithChildren);
-    getElementRichTextField("content").first().focus().type(" deco ");
-    getElementRichTextField("content").last().focus().type(" deco ");
+    addAltStyleElement({
+      repeater: [
+        {
+          title: "A",
+          content: [
+            {
+              assets: [],
+              elementType: "pullquote",
+              fields: { html: "Example pullquote with deco" },
+            },
+          ],
+        },
+        {
+          title: "C",
+          content: [
+            {
+              assets: [],
+              elementType: "pullquote",
+              fields: { html: "Example pullquote with deco" },
+            },
+          ],
+        },
+      ],
+    });
     getElementRichTextField("content")
-      .first()
       .find(".TestDecoration")
-      .should("have.text", "deco");
-    getElementRichTextField("content")
-      .last()
+      .each((el) => {
+        cy.wrap(el).should("have.text", "deco");
+      });
+  });
+
+  it("should render repeater decorations in other, non-nested elements correctly", () => {
+    addImageElement({
+      repeater: [
+        {
+          repeaterText: "example deco",
+        },
+        {
+          repeaterText: "example deco",
+        },
+      ],
+    });
+    getElementRichTextField("repeaterText")
       .find(".TestDecoration")
-      .should("have.text", "deco");
+      .each((el) => {
+        cy.wrap(el).should("have.text", "deco");
+      });
   });
 });

--- a/cypress/tests/Decorations.cy.ts
+++ b/cypress/tests/Decorations.cy.ts
@@ -1,0 +1,62 @@
+import {
+  addNestedElement,
+  addRepeaterElement,
+  getElementRichTextField,
+  visitRoot,
+} from "../helpers/editor";
+
+describe("Decorations", () => {
+  beforeEach(visitRoot);
+  it("should render decorations in repeater fields", () => {
+    addRepeaterElement({
+      repeater: [
+        {
+          repeaterText: "Example repeater text 1 deco",
+          nestedRepeater: [
+            { nestedRepeaterText: "Example nested repeater text 1 deco" },
+          ],
+        },
+        { repeaterText: "Example repeater text 2 deco" },
+      ],
+    });
+
+    getElementRichTextField("repeaterText")
+      .find(".TestDecoration")
+      .should("have.length", 2);
+    getElementRichTextField("nestedRepeaterText")
+      .find(".TestDecoration")
+      .should("have.length", 1);
+  });
+
+  it(`should render decorations in repeater fields within nested element fields`, () => {
+    addNestedElement({
+      repeater: [
+        {
+          title: "A",
+          content: [
+            {
+              assets: [],
+              elementType: "pullquote",
+              fields: { html: "Example pullquote with deco" },
+            },
+          ],
+        },
+        {
+          title: "C",
+          content: [
+            {
+              assets: [],
+              elementType: "pullquote",
+              fields: { html: "Example pullquote with deco" },
+            },
+          ],
+        },
+      ],
+    });
+    getElementRichTextField("content")
+      .find(".TestDecoration")
+      .each((el) => {
+        cy.wrap(el).should("have.text", "deco");
+      });
+  });
+});

--- a/cypress/tests/Decorations.cy.ts
+++ b/cypress/tests/Decorations.cy.ts
@@ -7,6 +7,21 @@ import {
 
 describe("Decorations", () => {
   beforeEach(visitRoot);
+
+  const assertDecosAreValidForField = (
+    fieldName: string,
+    decoCount: number
+  ) => {
+    getElementRichTextField(fieldName)
+      .find(".TestDecoration")
+      .then((items) => {
+        expect(items.length).to.equal(decoCount);
+        items.each((_, item) => {
+          expect(item).to.contain.text("deco");
+        });
+      });
+  };
+
   it("should render decorations in repeater fields", () => {
     addRepeaterElement({
       repeater: [
@@ -20,15 +35,11 @@ describe("Decorations", () => {
       ],
     });
 
-    getElementRichTextField("repeaterText")
-      .find(".TestDecoration")
-      .should("have.length", 2);
-    getElementRichTextField("nestedRepeaterText")
-      .find(".TestDecoration")
-      .should("have.length", 1);
+    assertDecosAreValidForField("repeaterText", 2);
+    assertDecosAreValidForField("nestedRepeaterText", 1);
   });
 
-  it(`should render decorations in repeater fields within nested element fields`, () => {
+  it.only(`should render decorations in repeater fields within nested element fields`, () => {
     addNestedElement({
       repeater: [
         {
@@ -53,10 +64,7 @@ describe("Decorations", () => {
         },
       ],
     });
-    getElementRichTextField("content")
-      .find(".TestDecoration")
-      .each((el) => {
-        cy.wrap(el).should("have.text", "deco");
-      });
+
+    assertDecosAreValidForField("content", 2);
   });
 });

--- a/cypress/tests/ImageElement.cy.ts
+++ b/cypress/tests/ImageElement.cy.ts
@@ -686,6 +686,24 @@ describe("ImageElement", () => {
           })
         );
       });
+
+      it.only("should render decorations correctly", () => {
+        addImageElement({
+          repeater: [
+            {
+              repeaterText: "example deco",
+            },
+            {
+              repeaterText: "example deco",
+            },
+          ],
+        });
+        getElementRichTextField("repeaterText")
+          .find(".TestDecoration")
+          .each((el) => {
+            cy.wrap(el).should("have.text", "deco");
+          });
+      });
     });
   });
 });

--- a/cypress/tests/ImageElement.cy.ts
+++ b/cypress/tests/ImageElement.cy.ts
@@ -686,24 +686,6 @@ describe("ImageElement", () => {
           })
         );
       });
-
-      it.only("should render decorations correctly", () => {
-        addImageElement({
-          repeater: [
-            {
-              repeaterText: "example deco",
-            },
-            {
-              repeaterText: "example deco",
-            },
-          ],
-        });
-        getElementRichTextField("repeaterText")
-          .find(".TestDecoration")
-          .each((el) => {
-            cy.wrap(el).should("have.text", "deco");
-          });
-      });
     });
   });
 });

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -110,34 +110,6 @@ const altStyleElementName = "alt-style";
 const repeaterElementName = "repeater";
 const nestedElementName = "nested";
 
-type Name =
-  | typeof embedElementName
-  | typeof imageElementName
-  | typeof demoImageElementName
-  | typeof codeElementName
-  | typeof formElementName
-  | typeof pullquoteElementName
-  | typeof recipeElementName
-  | typeof richlinkElementName
-  | typeof interactiveElementName
-  | typeof videoElementName
-  | typeof mapElementName
-  | typeof audioElementName
-  | typeof documentElementName
-  | typeof tableElementName
-  | typeof membershipElementName
-  | typeof witnessElementName
-  | typeof instagramElementName
-  | typeof vineElementName
-  | typeof tweetElementName
-  | typeof contentAtomName
-  | typeof commentElementName
-  | typeof campaignCalloutListElementName
-  | typeof cartoonElementName
-  | typeof altStyleElementName
-  | typeof repeaterElementName
-  | typeof nestedElementName;
-
 const createCaptionPlugins = (schema: Schema) => exampleSetup({ schema });
 const mockThirdPartyTracking = (html: string) =>
   html.includes("fail")
@@ -179,94 +151,94 @@ const standardElement = createStandardElement({
 
 const telemetryEventService = new UserTelemetryEventSender("example.com");
 
+const elements = {
+  [demoImageElementName]: createDemoImageElement(
+    onSelectImage,
+    onDemoCropImage
+  ),
+  [imageElementName]: imageElement,
+  [embedElementName]: createEmbedElement({
+    checkThirdPartyTracking: mockThirdPartyTracking,
+    convertTwitter: (src) => console.log(`Add Twitter embed with src: ${src}`),
+    convertYouTube: (src) => console.log(`Add youtube embed with src: ${src}`),
+    createCaptionPlugins,
+    targetingUrl: "https://targeting.code.dev-gutools.co.uk",
+  }),
+  [campaignCalloutListElementName]: createCalloutElement({
+    fetchCampaignList: () => Promise.resolve(sampleCampaignList),
+    targetingUrl: "https://targeting.code.dev-gutools.co.uk/",
+  }),
+  [interactiveElementName]: createInteractiveElement({
+    checkThirdPartyTracking: mockThirdPartyTracking,
+    createCaptionPlugins,
+  }),
+  [codeElementName]: codeElement,
+  [formElementName]: deprecatedElement,
+  [pullquoteElementName]: pullquoteElement,
+  [recipeElementName]: recipeElement,
+  "rich-link": richlinkElement,
+  [videoElementName]: createStandardElement({
+    createCaptionPlugins,
+    checkThirdPartyTracking: mockThirdPartyTracking,
+    hasThumbnailRole: false,
+  }),
+  [audioElementName]: standardElement,
+  [mapElementName]: standardElement,
+  [tableElementName]: tableElement,
+  [documentElementName]: createStandardElement({
+    createCaptionPlugins,
+    checkThirdPartyTracking: mockThirdPartyTracking,
+    useLargePreview: true,
+  }),
+  [membershipElementName]: membershipElement,
+  [witnessElementName]: deprecatedElement,
+  [vineElementName]: deprecatedElement,
+  [instagramElementName]: deprecatedElement,
+  [commentElementName]: commentElement,
+  [cartoonElementName]: createCartoonElement(
+    onCropCartoon,
+    createCaptionPlugins
+  ),
+  [tweetElementName]: createTweetElement({
+    checkThirdPartyTracking: mockThirdPartyTracking,
+    createCaptionPlugins,
+  }),
+  [contentAtomName]: createContentAtomElement(() =>
+    Promise.resolve({
+      title: "Test Atom",
+      defaultHtml: `<div class="atom-Profile">
+        <p><strong>Test item</strong></p>
+        <p><p>-here is a test item</p></p>
+        <p><strong>second post</strong></p>
+        <p><p>- test</p></p>
+      </div>`,
+      isPublished: false,
+      hasUnpublishedChanges: true,
+      embedLink: "https://example.com",
+      editorLink: "https://example.com",
+    })
+  ),
+  [altStyleElementName]: keyTakeawaysElement,
+  [repeaterElementName]: repeaterElement,
+  [nestedElementName]: nestedElement,
+};
+
 const {
   plugin: elementPlugin,
   insertElement,
   nodeSpec,
   getElementDataFromNode,
-} = buildElementPlugin(
-  {
-    "demo-image-element": createDemoImageElement(
-      onSelectImage,
-      onDemoCropImage
-    ),
-    image: imageElement,
-    embed: createEmbedElement({
-      checkThirdPartyTracking: mockThirdPartyTracking,
-      convertTwitter: (src) =>
-        console.log(`Add Twitter embed with src: ${src}`),
-      convertYouTube: (src) =>
-        console.log(`Add youtube embed with src: ${src}`),
-      createCaptionPlugins,
-      targetingUrl: "https://targeting.code.dev-gutools.co.uk",
+} = buildElementPlugin(elements, {
+  sendTelemetryEvent: (type: string, tags) =>
+    telemetryEventService.addEvent({
+      app: "ProseMirrorElements",
+      stage: "TEST",
+      eventTime: new Date().toISOString(),
+      type,
+      value: true,
+      tags,
     }),
-    callout: createCalloutElement({
-      fetchCampaignList: () => Promise.resolve(sampleCampaignList),
-      targetingUrl: "https://targeting.code.dev-gutools.co.uk/",
-    }),
-    interactive: createInteractiveElement({
-      checkThirdPartyTracking: mockThirdPartyTracking,
-      createCaptionPlugins,
-    }),
-    code: codeElement,
-    form: deprecatedElement,
-    pullquote: pullquoteElement,
-    recipe: recipeElement,
-    "rich-link": richlinkElement,
-    video: createStandardElement({
-      createCaptionPlugins,
-      checkThirdPartyTracking: mockThirdPartyTracking,
-      hasThumbnailRole: false,
-    }),
-    audio: standardElement,
-    map: standardElement,
-    table: tableElement,
-    document: createStandardElement({
-      createCaptionPlugins,
-      checkThirdPartyTracking: mockThirdPartyTracking,
-      useLargePreview: true,
-    }),
-    membership: membershipElement,
-    witness: deprecatedElement,
-    vine: deprecatedElement,
-    instagram: deprecatedElement,
-    comment: commentElement,
-    cartoon: createCartoonElement(onCropCartoon, createCaptionPlugins),
-    tweet: createTweetElement({
-      checkThirdPartyTracking: mockThirdPartyTracking,
-      createCaptionPlugins,
-    }),
-    "content-atom": createContentAtomElement(() =>
-      Promise.resolve({
-        title: "Test Atom",
-        defaultHtml: `<div class="atom-Profile">
-          <p><strong>Test item</strong></p>
-          <p><p>-here is a test item</p></p>
-          <p><strong>second post</strong></p>
-          <p><p>- test</p></p>
-        </div>`,
-        isPublished: false,
-        hasUnpublishedChanges: true,
-        embedLink: "https://example.com",
-        editorLink: "https://example.com",
-      })
-    ),
-    "alt-style": keyTakeawaysElement,
-    repeater: repeaterElement,
-    nested: nestedElement,
-  },
-  {
-    sendTelemetryEvent: (type: string, tags) =>
-      telemetryEventService.addEvent({
-        app: "ProseMirrorElements",
-        stage: "TEST",
-        eventTime: new Date().toISOString(),
-        type,
-        value: true,
-        tags,
-      }),
-  }
-);
+});
 
 const strike: MarkSpec = {
   parseDOM: [{ tag: "s" }, { tag: "del" }, { tag: "strike" }],
@@ -397,15 +369,15 @@ const createEditor = (server: CollabServer) => {
 
   const createElementButton = (
     buttonText: string,
-    elementName: Name,
-    values: Record<string, unknown>
+    elementName: keyof typeof elements,
+    values: Record<string, any>
   ) => {
     const elementButton = document.createElement("button");
     elementButton.innerHTML = `Add ${buttonText}`;
     elementButton.id = elementName;
-    elementButton.addEventListener("click", () =>
-      insertElement({ elementName, values })(view.state, view.dispatch)
-    );
+    elementButton.addEventListener("click", () => {
+      insertElement({ elementName, values })(view.state, view.dispatch);
+    });
     btnContainer.appendChild(elementButton);
   };
 

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -24,8 +24,10 @@ import type { MediaPayload } from "../src/elements/helpers/types/Media";
 import { createImageElement } from "../src/elements/image/ImageElementForm";
 import { createInteractiveElement } from "../src/elements/interactive/InteractiveForm";
 import { membershipElement } from "../src/elements/membership/MembershipForm";
+import { nestedElement } from "../src/elements/nested/NestedElementForm";
 import { pullquoteElement } from "../src/elements/pullquote/PullquoteForm";
 import { recipeElement } from "../src/elements/recipe/RecipeElementForm";
+import { repeaterElement } from "../src/elements/repeater/RepeaterElementForm";
 import { richlinkElement } from "../src/elements/rich-link/RichlinkForm";
 import { createStandardElement } from "../src/elements/standard/StandardForm";
 import { tableElement } from "../src/elements/table/TableForm";
@@ -66,8 +68,10 @@ import {
   sampleInteractiveAtom,
   sampleMap,
   sampleMembership,
+  sampleNested,
   samplePullquote,
   sampleRecipe,
+  sampleRepeater,
   sampleRichLink,
   sampleTable,
   sampleTweet,
@@ -103,6 +107,8 @@ const commentElementName = "comment";
 const campaignCalloutListElementName = "callout";
 const cartoonElementName = "cartoon";
 const altStyleElementName = "alt-style";
+const repeaterElementName = "repeater";
+const nestedElementName = "nested";
 
 type Name =
   | typeof embedElementName
@@ -128,7 +134,9 @@ type Name =
   | typeof commentElementName
   | typeof campaignCalloutListElementName
   | typeof cartoonElementName
-  | typeof altStyleElementName;
+  | typeof altStyleElementName
+  | typeof repeaterElementName
+  | typeof nestedElementName;
 
 const createCaptionPlugins = (schema: Schema) => exampleSetup({ schema });
 const mockThirdPartyTracking = (html: string) =>
@@ -244,6 +252,8 @@ const {
       })
     ),
     "alt-style": keyTakeawaysElement,
+    repeater: repeaterElement,
+    nested: nestedElement,
   },
   {
     sendTelemetryEvent: (type: string, tags) =>
@@ -442,6 +452,8 @@ const createEditor = (server: CollabServer) => {
       name: altStyleElementName,
       values: sampleAltStylesElement,
     },
+    { label: "Repeater", name: repeaterElementName, values: sampleRepeater },
+    { label: "Nested", name: nestedElementName, values: sampleNested },
   ] as const;
 
   buttonData.map(({ label, name, values }) =>

--- a/demo/sampleElements.ts
+++ b/demo/sampleElements.ts
@@ -268,11 +268,52 @@ export const sampleImage = {
   ],
 };
 
+export const sampleRepeater = {
+  repeater: [
+    {
+      repeaterText: "Example repeater text 1 deco",
+      nestedRepeater: [
+        { nestedRepeaterText: "Example nested repeater text 1 deco" },
+      ],
+    },
+    { repeaterText: "Example repeater text 2 deco" },
+  ],
+};
+
 export const sampleCallout = {
   altText: "",
   caption: "",
   html:
     '<div data-callout-tagname="callout-demo-2"><h2>Callout<h2><p>callout-demo-2</p></div>',
+};
+
+export const sampleNested = {
+  repeater: [
+    {
+      content: [
+        {
+          elementType: "pullquote",
+          fields: {
+            html: "1",
+            attribution: "",
+            weighting: "supporting",
+          },
+        },
+      ],
+    },
+    {
+      content: [
+        {
+          elementType: "pullquote",
+          fields: {
+            html: "2",
+            attribution: "",
+            weighting: "supporting",
+          },
+        },
+      ],
+    },
+  ],
 };
 
 export const sampleCampaignCalloutList = {};

--- a/src/elements/nested/NestedElement.ts
+++ b/src/elements/nested/NestedElement.ts
@@ -1,0 +1,15 @@
+import { createNestedElementField } from "../../plugin/fieldViews/NestedElementFieldView";
+import { createRepeaterField } from "../../plugin/fieldViews/RepeaterFieldView";
+
+export const nestedElementFields = {
+  repeater: createRepeaterField(
+    {
+      content: createNestedElementField({
+        isResizeable: false,
+        content: "block*",
+        minRows: 6,
+      }),
+    },
+    1
+  ),
+};

--- a/src/elements/nested/NestedElementForm.tsx
+++ b/src/elements/nested/NestedElementForm.tsx
@@ -1,0 +1,101 @@
+import styled from "@emotion/styled";
+import { neutral, space } from "@guardian/src-foundations";
+import React from "react";
+import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
+import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
+import {
+  actionSpacing,
+  buttonWidth,
+  RepeaterFieldMapIDKey,
+} from "../../plugin/helpers/constants";
+import { AltStyleElementWrapper } from "../../renderers/react/AltStyleElementWrapper";
+import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+import { Body } from "../../renderers/react/ElementWrapper";
+import {
+  LeftRepeaterActionControls,
+  RightRepeaterActionControls,
+} from "../../renderers/react/WrapperControls";
+import { nestedElementFields } from "./NestedElement";
+
+export const AltStyleElementTestId = "AltStyleElement";
+
+export const RepeaterChild = styled(Body)`
+  &:first-child {
+    margin-top: ${space[3]}px;
+  }
+  margin-bottom: ${space[3]}px;
+  position: relative;
+  &:not(:hover) .actions,
+  &:not(:focus-within) .actions {
+    opacity: 0;
+  }
+  &:hover .actions,
+  &:focus-within .actions {
+    opacity: 1;
+  }
+`;
+
+export const RepeatedFieldsWrapper = styled("div")`
+  width: 100%;
+`;
+
+export const ChildNumber = styled("div")`
+  box-sizing: border-box;
+  background-color: ${neutral[100]};
+  color: ${neutral[46]};
+  font-family: "Guardian Agate Sans", sans-serif;
+  line-height: 1;
+  font-weight: 700;
+  font-size: 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: ${buttonWidth}px;
+  width: ${buttonWidth}px;
+  top: 0;
+  left: -${actionSpacing - 1}px; // -1 ensures border of number overlaps/collapses into border of first field
+  padding: 2px;
+  border: 1px solid ${neutral[60]};
+  position: absolute;
+`;
+
+export const nestedElement = createReactElementSpec({
+  fieldDescriptions: nestedElementFields,
+  component: ({ fields }) => {
+    return (
+      <FieldLayoutVertical
+        data-cy={AltStyleElementTestId}
+        useAlternateStyles={true}
+      >
+        {fields.repeater.children.map((child, index) => (
+          // Use field ID as key instead of node index to avoid React render conflicts
+          <RepeaterChild key={child[RepeaterFieldMapIDKey]}>
+            <ChildNumber>{index + 1}</ChildNumber>
+            <LeftRepeaterActionControls
+              removeChildAt={() => fields.repeater.view.removeChildAt(index)}
+              numberOfChildNodes={fields.repeater.children.length}
+              minChildren={fields.repeater.view.minChildren}
+            />
+            <RepeatedFieldsWrapper>
+              <DemoFieldWrapper
+                field={child.content}
+                showHeading={false}
+                useAlternateStyles={true}
+              />
+            </RepeatedFieldsWrapper>
+            <RightRepeaterActionControls
+              addChildAfter={() => fields.repeater.view.addChildAfter(index)}
+              moveChildUpOne={() => fields.repeater.view.moveChildUpOne(index)}
+              moveChildDownOne={() =>
+                fields.repeater.view.moveChildDownOne(index)
+              }
+              numberOfChildNodes={fields.repeater.children.length}
+              index={index}
+            />
+          </RepeaterChild>
+        ))}
+      </FieldLayoutVertical>
+    );
+  },
+  wrapperComponent: AltStyleElementWrapper,
+});

--- a/src/elements/repeater/RepeaterElement.ts
+++ b/src/elements/repeater/RepeaterElement.ts
@@ -1,0 +1,11 @@
+import { createRepeaterField } from "../../plugin/fieldViews/RepeaterFieldView";
+import { createTextField } from "../../plugin/fieldViews/TextFieldView";
+
+export const repeaterElementFields = {
+  repeater: createRepeaterField({
+    repeaterText: createTextField(),
+    nestedRepeater: createRepeaterField({
+      nestedRepeaterText: createTextField(),
+    }),
+  }),
+};

--- a/src/elements/repeater/RepeaterElementForm.tsx
+++ b/src/elements/repeater/RepeaterElementForm.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { DemoFieldWrapper } from "../../editorial-source-components/DemoFieldWrapper";
+import { FieldLayoutVertical } from "../../editorial-source-components/FieldLayout";
+import { createReactElementSpec } from "../../renderers/react/createReactElementSpec";
+import { repeaterElementFields } from "./RepeaterElement";
+
+export const AddRepeaterButtonId = "AddRepeaterButton";
+export const AddNestedRepeaterButtonId = "AddNestedRepeaterButton";
+export const RemoveRepeaterButtonId = "RemoveRepeaterButton";
+export const RemoveNestedRepeaterButtonId = "RemoveNestedRepeaterButton";
+
+export const repeaterElement = createReactElementSpec({
+  fieldDescriptions: repeaterElementFields,
+  component: ({ fields }) => (
+    <FieldLayoutVertical>
+      <ul>
+        {fields.repeater.children.map((repeater, index) => (
+          <li key={repeater.__ID}>
+            <DemoFieldWrapper
+              headingLabel="Repeater text"
+              headingContent={
+                <>
+                  <button
+                    data-cy={RemoveRepeaterButtonId}
+                    onClick={() => fields.repeater.view.removeChildAt(index)}
+                  >
+                    -
+                  </button>
+                  <button
+                    data-cy={AddRepeaterButtonId}
+                    onClick={() => fields.repeater.view.addChildAfter(index)}
+                  >
+                    +
+                  </button>
+                </>
+              }
+              field={repeater.repeaterText}
+            />
+            <ul>
+              {repeater.nestedRepeater.children.map((nestedRepeater, index) => (
+                <li key={nestedRepeater.__ID}>
+                  <DemoFieldWrapper
+                    headingLabel="Nested repeater text"
+                    headingContent={
+                      <>
+                        <button
+                          data-cy={RemoveNestedRepeaterButtonId}
+                          onClick={() =>
+                            repeater.nestedRepeater.view.removeChildAt(index)
+                          }
+                        >
+                          -
+                        </button>
+                        <button
+                          data-cy={AddNestedRepeaterButtonId}
+                          onClick={() =>
+                            repeater.nestedRepeater.view.addChildAfter(index)
+                          }
+                        >
+                          +
+                        </button>
+                      </>
+                    }
+                    field={nestedRepeater.nestedRepeaterText}
+                  />
+                </li>
+              ))}
+            </ul>
+          </li>
+        ))}
+      </ul>
+    </FieldLayoutVertical>
+  ),
+});

--- a/src/plugin/field.ts
+++ b/src/plugin/field.ts
@@ -1,8 +1,6 @@
 import _ from "lodash";
 import { set } from "lodash/fp";
 import type { DOMSerializer, Node } from "prosemirror-model";
-import type { Selection } from "prosemirror-state";
-import { Mapping, StepMap } from "prosemirror-transform";
 import type { DecorationSource, EditorView } from "prosemirror-view";
 import { RepeaterFieldMapIDKey } from "./helpers/constants";
 import type {
@@ -21,21 +19,6 @@ import type {
   RepeaterField,
 } from "./types/Element";
 import { isRepeaterField } from "./types/Element";
-
-const getRepeaterDecorations = (
-  outerDecos: DecorationSource,
-  offset: number,
-  repeaterNode: Node
-) => {
-  const repeaterDecorations = outerDecos.forChild(offset, repeaterNode);
-
-  // this offsets by 1 specifically for repeaters to account for the repeater parent
-  // to counter -1 offset in `applyDecorationsFromOuterEditor` of `ProseMirrorFieldView`
-  return repeaterDecorations.map(
-    new Mapping([StepMap.offset(1)]),
-    repeaterNode
-  );
-};
 
 type GetFieldsFromNodeOptions<
   FDesc extends FieldDescriptions<Extract<keyof FDesc, string>>,
@@ -110,12 +93,6 @@ export const getFieldsFromNode = <
     if (fieldDescription.type === "repeater") {
       const children = [] as unknown[];
 
-      const repeaterDecos = getRepeaterDecorations(
-        innerDecos,
-        offset + localOffset,
-        fieldNode
-      );
-
       fieldNode.forEach((repeaterChildNode, repeaterOffset) => {
         // We offset by two positions here to account for the additional depth
         // of the parent and child repeater nodes.
@@ -126,7 +103,7 @@ export const getFieldsFromNode = <
           fieldDescriptions: fieldDescription.fields as FDesc,
           view,
           getPos,
-          innerDecos: repeaterDecos,
+          innerDecos,
           serializer,
           offset: offset + localOffset + repeaterOffset + depthOffset,
           getElementDataFromNode,
@@ -234,12 +211,6 @@ export const updateFieldsFromNode = <
     }
 
     if (isRepeaterField(field)) {
-      const repeaterDecos = getRepeaterDecorations(
-        innerDecos,
-        offset + localOffset,
-        fieldNode
-      );
-
       fieldNode.forEach((childNode, repeaterOffset, index) => {
         const accumulatedOffset = offset + localOffset + repeaterOffset;
 
@@ -264,7 +235,7 @@ export const updateFieldsFromNode = <
                 getPos,
                 serializer,
                 offset: accumulatedOffset,
-                innerDecos: repeaterDecos,
+                innerDecos,
                 getElementDataFromNode,
                 transformElementOut,
               });
@@ -276,7 +247,7 @@ export const updateFieldsFromNode = <
           view,
           getPos,
           offset: accumulatedOffset,
-          innerDecos: repeaterDecos,
+          innerDecos,
           getElementDataFromNode,
           transformElementOut,
         });
@@ -367,11 +338,6 @@ export const updateFieldViewsFromNode = <
       return;
     }
 
-    const repeaterDecos = getRepeaterDecorations(
-      decos,
-      offset + localOffset,
-      node
-    );
     // We offset by two positions here to account for the additional depth
     // of the parent and child repeater nodes.
     const depthOffset = 2;
@@ -379,7 +345,7 @@ export const updateFieldViewsFromNode = <
       updateFieldViewsFromNode(
         field.children[index],
         childNode,
-        repeaterDecos,
+        decos,
         offset + localOffset + repeaterOffset + depthOffset,
         selection
       );

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -303,9 +303,9 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
   }
 
   protected applyDecorationsFromOuterEditor(
-    decorations: DecorationSource,
-    node: Node,
-    elementOffset: number
+    decorations: DecorationSource, // The decorations for the NodeView that represents this element
+    node: Node, // The node that represents the field
+    fieldOffset: number // The offset of the field, relative to this element
   ) {
     // Do nothing if the decorations have not changed.
     if (decorations === this.outerDecorations) {


### PR DESCRIPTION
_co-authored-by: @rhystmills_

## What does this change?

#349 fixes a problem with decorations in `NestedFieldView` elements, but introduces an issue with repeater fields – the problem is illustrated in 14586e2f7524c60817a73083fe40b021bf59ee4e.

The likely cause of this problem is that prosemirror-elements has always passed decorations directly to child editor instances without altering their depth.

This seems to have worked while the decorations and the document have been in sync – by mapping Decorations to ensure that the relevant field always indexes into the correct position, child editors pick up the correct decoration set and ignore other decorations. (I think this is an artefact of the way Decorations are structured, as they are indexed with a start and end position, and as long as these line up with the relevant `Node`, things work as they normally would.)

But as we traverse the boundary between parent and child editors supporting elements, as we do in `NestedElementFieldView`, we introduce a shift in the document structure that introduces out-of-bounds errors. A detailed write up of this case to come.

The solution is likely to be to only pass exactly the decorations that are needed to each view, building on the useful API that was introduced in implementing #349.

## How to test

- [ ] The automated tests should pass. They should cover nested, repeated, and nested repeated/repeated nested elements.

## How can we measure success?

Problems with decorations in complex documents are resolved downstream.