### PR TITLE
Add changeset for selection handling in inner editor of ProseMirrorFieldView

### DIFF
--- a/.changeset/polite-beds-matter.md
+++ b/.changeset/polite-beds-matter.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-elements": patch
+---
+
+Handle selection changes passed from outer editor in ProseMirrorFieldViews


### PR DESCRIPTION
## What does this change?
Release a changeset for:
https://github.com/guardian/prosemirror-elements/pull/400 - inner selection handling, to solve F10 bug in Composer
https://github.com/guardian/prosemirror-elements/pull/402 - bump loader-utils to solve vulnerability