### PR TITLE
Fix recently introduce bug affecting elements

### DIFF
--- a/src/plugin/__tests__/plugin.spec.tsx
+++ b/src/plugin/__tests__/plugin.spec.tsx
@@ -85,13 +85,14 @@ describe("createPlugin", () => {
     createEditorWithSingleElementPresent(defaultEditorOptions);
 
   describe("Response to content changes", () => {
-    it("should not update consumers or fieldViews when the element content has not changed", () => {
+    it("should not update consumers or fieldViews when the element content and selection have not changed", () => {
       const { view, exampleText } = createDefaultEditor();
 
       const initialConsumerUpdateCount = consumerRenderSpy.mock.calls.length;
       const initialFieldViewUpdateCount = fieldViewRenderSpy.mock.calls.length;
 
       const positionAfterElement = 19;
+      // replace does not update the selection
       const tr = view.state.tr.replace(
         positionAfterElement,
         positionAfterElement,
@@ -107,7 +108,7 @@ describe("createPlugin", () => {
       );
     });
 
-    it("should call the consumer and FieldView when the element content has changed", () => {
+    it("should call the consumer and FieldView when the element content has changed, but the selection has not", () => {
       const { view, exampleText } = createDefaultEditor();
 
       const initialConsumerUpdateCount = consumerRenderSpy.mock.calls.length;
@@ -115,10 +116,11 @@ describe("createPlugin", () => {
 
       // This edit falls inside of the element, inserting new content
       const positionInsideElement = 5;
-      const tr = view.state.tr.replaceWith(
+      // replace does not update the selection
+      const tr = view.state.tr.replace(
         positionInsideElement,
         positionInsideElement,
-        exampleText
+        new Slice(Fragment.from(exampleText), 0, 0)
       );
       view.dispatch(tr);
 
@@ -130,11 +132,12 @@ describe("createPlugin", () => {
       );
     });
 
-    it("should provide the consumer with new field values when element content has changed", () => {
+    it("should provide the consumer with new field values when element content and selection have changed", () => {
       const { view, exampleText } = createDefaultEditor();
 
       // This edit covers the whole of the element field, replacing its content
       const positionInsideElement = 2;
+      // replaceWith does update the selection
       const tr = view.state.tr.replaceWith(
         positionInsideElement,
         positionInsideElement + 15,

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -197,7 +197,7 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
     const diffStart = node.content.findDiffStart(state.doc.content);
     const diffEnd = node.content.findDiffEnd(state.doc.content);
 
-    if (diffStart && diffEnd) {
+    if (diffStart !== null && diffEnd) {
       let { a: endOfOuterDiff, b: endOfInnerDiff } = diffEnd;
       // This overlap accounts for a situation where we're diffing nodes where we encounter
       // identical content.


### PR DESCRIPTION
## Background
Developers and users have noticed some unusual behaviour in elements recently:
- Attempting to switch the position of two elements of the same type did not appear to update their text fields, so the elements didn't appear to switch. 
- Certain changes to text fields in image elements appeared garbled/disordered in preview after save and close
- Saving and closing then reopening list formats with an image element in them caused placeholders not to appear, and certain changes weren't being saved

Through testing we identified that version `9.6.1` (the most recent release of prosemirror-elements) introduced the change. The biggest and most relevant change in this release was https://github.com/guardian/prosemirror-elements/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Aclosed

That change was reverted in Composer and the issues seem to be resolved there now: https://github.com/guardian/flexible-content/pull/4803

## What does this PR change

This PR is intended to solve the bugs reported above.

The bug was caused by a subtle change in our logic during the refactor in the [selection PR](https://github.com/guardian/prosemirror-elements/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Aclosed).

Previously, we would check for a 'diff' between the previous state of the node represented by a text view, and its updated state, as follows:

```js
if (diffStart === null) {
      return this.maybeRerenderDecorations();
    }
```

I had changed this check to:
```js
    if (diffStart && diffEnd) {

```

However, a diff could often start at position 0 relative to the `innerEditorView` represented by the text field, if the entire text field had changed, e.g. as part of wider changes to an entire element.

Changing this check to `if (diffStart !== null && diffEnd)` seems to have resolved the issues mentioned above when testing locally.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [ ] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [ ] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
