### PR TITLE
Fix prosemirror-noting bugs by passing storedMarks to inner editor, and passing up paste meta

### DIFF
--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -1,3 +1,4 @@
+import type { Mark } from "prosemirror-model";
 import type { WindowType } from "../../demo/types";
 import { getFieldHeadingTestId } from "../../src/editorial-source-components/DemoInputHeading";
 import { placeholderTestAttribute } from "../../src/plugin/helpers/placeholder";
@@ -100,6 +101,21 @@ export const changeTestDecoString = (newTestString: string) => {
     view.dispatch(
       view.state.tr.setMeta(ChangeTestDecoStringAction, newTestString)
     );
+  });
+};
+
+export const setStrongStoredMark = () => {
+  cy.window().then((win: WindowType) => {
+    const view = win.PM_ELEMENTS.view;
+    const strongMark = view.state.schema.marks.strong.create();
+    view.dispatch(view.state.tr.setStoredMarks([strongMark]));
+  });
+};
+
+export const setStoredMark = (value: readonly Mark[] | null) => {
+  cy.window().then((win: WindowType) => {
+    const view = win.PM_ELEMENTS.view;
+    view.dispatch(view.state.tr.setStoredMarks(value));
   });
 };
 

--- a/cypress/tests/ImageElement.cy.ts
+++ b/cypress/tests/ImageElement.cy.ts
@@ -212,6 +212,10 @@ describe("ImageElement", () => {
       rteFieldStyles.forEach((style) => {
         it(`caption – should toggle style of an input in an element`, () => {
           addImageElement();
+
+          // This is not necessary outside of integration tests. Unclear why at present.
+          focusElementField("caption");
+
           getElementMenuButton("caption", `Toggle ${style.title}`).click();
           typeIntoElementField("caption", "Example text");
           getElementRichTextField("caption")
@@ -222,6 +226,10 @@ describe("ImageElement", () => {
 
       it(`restrictedTextField – can toggle italic style of an input in an element`, () => {
         addImageElement();
+
+        // This is not necessary outside of integration tests. Unclear why at present.
+        focusElementField("restrictedTextField");
+
         getElementMenuButton("restrictedTextField", "Toggle emphasis").click();
         typeIntoElementField("restrictedTextField", "Example text");
         getElementRichTextField("restrictedTextField")

--- a/cypress/tests/ImageElement.cy.ts
+++ b/cypress/tests/ImageElement.cy.ts
@@ -24,6 +24,8 @@ import {
   selectAllShortcut,
   selectDataCy,
   setDocFromHtml,
+  setStoredMark,
+  setStrongStoredMark,
   typeIntoElementField,
   visitRoot,
 } from "../helpers/editor";
@@ -207,6 +209,39 @@ describe("ImageElement", () => {
         getElementRichTextField("caption")
           .find(".TestDecoration")
           .should("have.text", oldDecoString);
+      });
+
+      it(`caption - should apply a storedMark to a character if one is specified by the outer editor`, () => {
+        addImageElement();
+        const focusedField = getElementRichTextField("caption").focus();
+        setStrongStoredMark();
+        focusedField.type("a");
+        getElementRichTextField("caption").should(
+          "have.html",
+          "<p><strong>a</strong></p>"
+        );
+      });
+
+      it(`caption - should stop applying an existing stored mark when the outer editor has an empty array as its stored marks`, () => {
+        addImageElement();
+        const focusedField = getElementRichTextField("caption").focus();
+        setStrongStoredMark();
+        focusedField.type("a");
+        setStoredMark([]);
+        focusedField.type("b");
+        getElementRichTextField("caption").should(
+          "have.html",
+          "<p><strong>a</strong>b</p>"
+        );
+      });
+
+      it(`caption - should not apply a stored mark when the outer editor has null as its stored mark`, () => {
+        addImageElement();
+        const focusedField = getElementRichTextField("caption").focus();
+        setStrongStoredMark();
+        setStoredMark(null);
+        focusedField.type("ab");
+        getElementRichTextField("caption").should("have.html", "<p>ab</p>");
       });
 
       rteFieldStyles.forEach((style) => {

--- a/src/plugin/field.ts
+++ b/src/plugin/field.ts
@@ -1,6 +1,6 @@
 import _ from "lodash";
 import { set } from "lodash/fp";
-import type { DOMSerializer, Node } from "prosemirror-model";
+import type { DOMSerializer, Mark, Node } from "prosemirror-model";
 import type { Selection } from "prosemirror-state";
 import { Mapping, StepMap } from "prosemirror-transform";
 import type { DecorationSource, EditorView } from "prosemirror-view";
@@ -354,14 +354,15 @@ export const updateFieldViewsFromNode = <
   node: Node,
   decos: DecorationSource,
   offset = 0,
-  selection?: Selection
+  selection?: Selection,
+  storedMarks?: readonly Mark[] | null
 ) => {
   node.forEach((node, localOffset) => {
     const fieldName = getFieldNameFromNode(
       node
     ) as keyof FieldNameToField<FDesc>;
     const field = fields[fieldName];
-    field.view.onUpdate(node, offset + localOffset, decos, selection);
+    field.view.onUpdate(node, offset + localOffset, decos, selection, storedMarks);
 
     if (!isRepeaterField(field)) {
       return;
@@ -381,7 +382,8 @@ export const updateFieldViewsFromNode = <
         childNode,
         repeaterDecos,
         offset + localOffset + repeaterOffset + depthOffset,
-        selection
+        selection,
+        storedMarks
       );
     });
   });

--- a/src/plugin/field.ts
+++ b/src/plugin/field.ts
@@ -362,7 +362,13 @@ export const updateFieldViewsFromNode = <
       node
     ) as keyof FieldNameToField<FDesc>;
     const field = fields[fieldName];
-    field.view.onUpdate(node, offset + localOffset, decos, selection, storedMarks);
+    field.view.onUpdate(
+      node,
+      offset + localOffset,
+      decos,
+      selection,
+      storedMarks
+    );
 
     if (!isRepeaterField(field)) {
       return;

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -235,7 +235,6 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
       }
 
       shouldDispatchTransaction = true;
-      // If stored mark, apply mark to diff before doing the replace transaction
 
       tr = tr.replace(
         diffStart,
@@ -246,13 +245,11 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
 
     if (storedMarks) {
       shouldDispatchTransaction = true;
+      tr = tr.setStoredMarks(storedMarks);
     }
 
     if (shouldDispatchTransaction) {
       tr = tr.setMeta("fromOutside", true);
-      if (storedMarks) {
-        tr = tr.setStoredMarks(storedMarks);
-      }
       this.innerEditorView.dispatch(tr);
     } else {
       return this.maybeRerenderDecorations();

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -1,4 +1,4 @@
-import { DOMParser, Fragment, Slice } from "prosemirror-model";
+import { DOMParser } from "prosemirror-model";
 import type { AttributeSpec, Mark, Node } from "prosemirror-model";
 import type { Plugin, Selection, Transaction } from "prosemirror-state";
 import { EditorState } from "prosemirror-state";
@@ -236,26 +236,12 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
 
       shouldDispatchTransaction = true;
       // If stored mark, apply mark to diff before doing the replace transaction
-      console.log({ storedMarks, stateMarks: state.storedMarks });
 
-      if (state.storedMarks?.length) {
-        tr = tr.addMark(diffStart, endOfInnerDiff, state.storedMarks[0]);
-      }
-
-      const slice = node.slice(diffStart, endOfOuterDiff);
-      if (storedMarks) {
-        const newNodes: Node[] = [];
-        slice.content.forEach((node) => newNodes.push(node.mark(storedMarks)));
-        const fragment = Fragment.fromArray(newNodes);
-        const sliceWithStoredMarks = new Slice(
-          fragment,
-          slice.openEnd,
-          slice.openEnd
-        );
-        tr = tr.replace(diffStart, endOfInnerDiff, sliceWithStoredMarks);
-      } else {
-        tr = tr.replace(diffStart, endOfInnerDiff, slice);
-      }
+      tr = tr.replace(
+        diffStart,
+        endOfInnerDiff,
+        node.slice(diffStart, endOfOuterDiff)
+      );
     }
 
     if (storedMarks) {

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -105,19 +105,13 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
     const node = this.getNodeFromValue(value);
     const tr = this.innerEditorView.state.tr;
     console.log("update");
-    tr.replaceWith(
-      0,
-      this.innerEditorView.state.doc.content.size,
-      node
-    ).setStoredMarks(this.innerEditorView.state.storedMarks);
+    tr.replaceWith(0, this.innerEditorView.state.doc.content.size, node);
     this.dispatchTransaction(tr);
   }
 
   public updatePlaceholder(value: PlaceholderOption) {
     this.innerEditorView?.dispatch(
-      this.innerEditorView.state.tr
-        .setMeta(PME_UPDATE_PLACEHOLDER, value)
-        .setStoredMarks(this.innerEditorView.state.storedMarks)
+      this.innerEditorView.state.tr.setMeta(PME_UPDATE_PLACEHOLDER, value)
     );
   }
 
@@ -129,44 +123,16 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
     if (!this.innerEditorView) {
       return;
     }
-    if (tr.doc.type.name === "key_takeaways__content") {
-      console.log({
-        innerStateFirst: this.innerEditorView.state,
-        tr,
-      });
-    }
+
     const { state, transactions } = this.innerEditorView.state.applyTransaction(
       tr
     );
-    // Applying the outer state first ensures that decorations in the parent
-    // view are correctly mapped through this transaction by the time they're
-    // accessed by the innerEditorView.
-    if (tr.doc.type.name === "key_takeaways__content") {
-      console.log({ innerState: this.innerEditorView.state });
-      console.log({ updatedState: state });
-    }
 
     this.innerEditorView.updateState(state);
-    if (tr.doc.type.name === "key_takeaways__content") {
-      console.log({ afterState: this.innerEditorView.state });
-    }
     this.decorationsPending = false;
 
     if (!tr.getMeta("fromOutside")) {
-      if (tr.doc.type.name === "key_takeaways__content") {
-        console.log({
-          time: new Date(Date.now()).toISOString(),
-          toOuter: transactions,
-        });
-      }
       this.updateOuterEditor(tr, state, transactions);
-    } else {
-      if (tr.doc.type.name === "key_takeaways__content") {
-        console.log({
-          time: new Date(Date.now()).toISOString(),
-          fromOuter: transactions,
-        });
-      }
     }
   }
 
@@ -335,9 +301,7 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
 
     const selectionHasChanged = !outerTr.selection.eq(mappedSelection);
     if (selectionHasChanged) {
-      outerTr
-        .setSelection(mappedSelection)
-        .setStoredMarks(this.outerView.state.storedMarks);
+      outerTr.setSelection(mappedSelection);
     }
 
     const shouldUpdateOuter = innerTr.docChanged || selectionHasChanged;
@@ -401,9 +365,7 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
     if (this.decorationsPending && this.innerEditorView) {
       // This empty transaction forces the editor to rerender its decorations.
       this.innerEditorView.dispatch(
-        this.innerEditorView.state.tr
-          .setMeta("fromOutside", true)
-          .setStoredMarks(this.innerEditorView.state.storedMarks)
+        this.innerEditorView.state.tr.setMeta("fromOutside", true)
       );
     }
   }

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -1,3 +1,4 @@
+import { isEqual } from "lodash";
 import { DOMParser } from "prosemirror-model";
 import type { AttributeSpec, Mark, Node } from "prosemirror-model";
 import type { Plugin, Selection, Transaction } from "prosemirror-state";
@@ -242,7 +243,12 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
       );
     }
 
-    if (Array.isArray(storedMarks) || storedMarks === null) {
+    const storedMarksHaveChanged = !isEqual(
+      storedMarks,
+      this.innerEditorView.state.storedMarks
+    );
+
+    if (storedMarksHaveChanged && storedMarks !== undefined) {
       shouldDispatchTransaction = true;
       tr = tr.setStoredMarks(storedMarks);
     }

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -304,6 +304,10 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
       outerTr.setSelection(mappedSelection);
     }
 
+    if (innerTr.getMeta("paste") === true) {
+      outerTr.setMeta("paste", true);
+    }
+
     const shouldUpdateOuter = innerTr.docChanged || selectionHasChanged;
     if (shouldUpdateOuter) this.outerView.dispatch(outerTr);
   }

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -243,7 +243,7 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
       );
     }
 
-    if (storedMarks) {
+    if (Array.isArray(storedMarks) || storedMarks === null) {
       shouldDispatchTransaction = true;
       tr = tr.setStoredMarks(storedMarks);
     }

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -295,7 +295,11 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
     }
 
     const shouldUpdateOuter = innerTr.docChanged || selectionHasChanged;
-    if (shouldUpdateOuter) this.outerView.dispatch(outerTr);
+    if (shouldUpdateOuter) this.dispatchToOuterView(outerTr);
+  }
+
+  protected dispatchToOuterView(tr: Transaction) {
+    this.outerView.dispatch(tr);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- default implementation

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -246,14 +246,15 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
     }
 
     if (storedMarks) {
-      storedMarks.forEach((mark) => {
-        tr = tr.addStoredMark(mark);
-        shouldDispatchTransaction = true;
-      });
+      shouldDispatchTransaction = true;
     }
 
     if (shouldDispatchTransaction) {
-      this.innerEditorView.dispatch(tr.setMeta("fromOutside", true));
+      tr = tr.setMeta("fromOutside", true);
+      if (storedMarks) {
+        tr = tr.setStoredMarks(storedMarks);
+      }
+      this.innerEditorView.dispatch(tr);
     } else {
       return this.maybeRerenderDecorations();
     }

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -104,7 +104,6 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
 
     const node = this.getNodeFromValue(value);
     const tr = this.innerEditorView.state.tr;
-    console.log("update");
     tr.replaceWith(0, this.innerEditorView.state.doc.content.size, node);
     this.dispatchTransaction(tr);
   }

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -305,6 +305,9 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
     }
 
     if (innerTr.getMeta("paste") === true) {
+      // Pass the "paste" meta specifically, because we know it's needed by
+      // another plugin to handle pastes - meta values won't be transferred
+      // to the outerTr unless we set them.
       outerTr.setMeta("paste", true);
     }
 

--- a/src/plugin/fieldViews/__tests__/TextFieldView.spec.ts
+++ b/src/plugin/fieldViews/__tests__/TextFieldView.spec.ts
@@ -291,10 +291,6 @@ describe("the TextFieldView, as an extension of the ProseMirrorFieldView", () =>
       throw new Error("Text field editor was undefined");
     }
 
-    // const initialSelection = textFieldViewInnerEditor.state.selection;
-    // // A selection that will be outside the innerEditor's range
-    // const newSelection = TextSelection.create(view.state.doc, 15, 15);
-    // fieldView.onUpdate(node, offset, decorations, newSelection);
     const tr = textFieldViewInnerEditor.state.tr;
     tr.setMeta("paste", true);
     textFieldViewInnerEditor.dispatch(tr);

--- a/src/plugin/fieldViews/__tests__/TextFieldView.spec.ts
+++ b/src/plugin/fieldViews/__tests__/TextFieldView.spec.ts
@@ -1,7 +1,8 @@
 import type { NodeSpec } from "prosemirror-model";
 import { Schema } from "prosemirror-model";
 import { schema } from "prosemirror-schema-basic";
-import { TextSelection, Transaction } from "prosemirror-state";
+import type { Transaction } from "prosemirror-state";
+import { TextSelection } from "prosemirror-state";
 import { StepMap } from "prosemirror-transform";
 import { DecorationSet } from "prosemirror-view";
 import { createEditorWithElements } from "../../helpers/test";

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -295,7 +295,7 @@ const createNodeView = <
           innerDecosChanged ||
           anyDescendantFieldIsNestedElementField(newNode) ||
           selectionHasChanged ||
-          newStoredMarks?.length ||
+          (Array.isArray(newStoredMarks) && newStoredMarks.length > 0) ||
           storedMarksHaveChanged
         ) {
           updateFieldViewsFromNode(

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -295,7 +295,6 @@ const createNodeView = <
           innerDecosChanged ||
           anyDescendantFieldIsNestedElementField(newNode) ||
           selectionHasChanged ||
-          (Array.isArray(newStoredMarks) && newStoredMarks.length > 0) ||
           storedMarksHaveChanged
         ) {
           updateFieldViewsFromNode(

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -222,6 +222,7 @@ const createNodeView = <
   let currentIsSelected = false;
   let currentCommandValues = getCommandValues(initCommands);
   let currentSelection = view.state.selection;
+  let currentStoredMarks = view.state.storedMarks;
 
   const getElementDataForUpdator = () =>
     getFieldValuesFromNode(
@@ -259,6 +260,7 @@ const createNodeView = <
         const newCommands = commands(getPos, view);
         const newCommandValues = getCommandValues(newCommands);
         const newSelection = view.state.selection;
+        const newStoredMarks = view.state.storedMarks;
 
         const isSelectedChanged = currentIsSelected !== newIsSelected;
         const innerDecosChanged = currentDecos !== innerDecos;
@@ -268,6 +270,7 @@ const createNodeView = <
           newCommandValues
         );
         const selectionHasChanged = !newSelection.eq(currentSelection);
+        const storedMarksHaveChanged = currentStoredMarks !== newStoredMarks;
 
         // Only recalculate our field values if our node content has changed.
         const newFields = fieldValuesChanged
@@ -291,14 +294,16 @@ const createNodeView = <
           fieldValuesChanged ||
           innerDecosChanged ||
           anyDescendantFieldIsNestedElementField(newNode) ||
-          selectionHasChanged
+          selectionHasChanged ||
+          storedMarksHaveChanged
         ) {
           updateFieldViewsFromNode(
             newFields,
             newNode,
             innerDecos,
             0,
-            newSelection
+            newSelection,
+            newStoredMarks
           );
         }
 
@@ -313,6 +318,7 @@ const createNodeView = <
         currentFields = newFields;
         currentCommandValues = newCommandValues;
         currentSelection = newSelection;
+        currentStoredMarks = newStoredMarks;
 
         return true;
       }

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -295,6 +295,7 @@ const createNodeView = <
           innerDecosChanged ||
           anyDescendantFieldIsNestedElementField(newNode) ||
           selectionHasChanged ||
+          newStoredMarks?.length ||
           storedMarksHaveChanged
         ) {
           updateFieldViewsFromNode(


### PR DESCRIPTION
## What does this change?
We have encountered a few bugs related to the interaction of nested fields with notes from [@guardian/prosemirror-noting](https://github.com/guardian/prosemirror-noting/) - specifically:
1. Typing in the first or final character of a note doesn't extend it
2. Pasting into a note doesn't apply the note mark to the pasted characters
3. Moving over the note boundary via key presses skips a character

This PR fixes these issues by making some changes to the `ProsemirrorFieldView`:
1. Passes in `storedMarks` defined by the outer editor to the inner editor, applying them on the next transaction in the inner editor. The note extension functionality is managed by `storedMarks`, rather than by setting an `inclusive` attribute on the mark, as we see with something like `strong` or `em` marks. Until now, we haven't passed stored marks from the outer editor to our fields.
2. Swaps the order in which we update the inner and outer editor in `dispatchTransaction` - we now update the inner editor first, then update the outer editor. 

The existing order of operations here was leading to some issues with my `storedMarks` work.

When a user moved their cursor in a note within a text field: the inner editor dispatched a transaction, the outer editor (which has the copy of the `prosemirror-noting` plugin, and therefore 'knows' about the note) would then introduce a stored mark representing the note mark, which was passed into the plugin. The inner state change would then finish, with no knowledge of the intermediate transaction from the outer editor that had occurred, effectively ignoring the introduced stored mark.

Now, the inner transaction is dispatched, then the outer editor transaction is dispatched, including the stored mark, and it can be applied on the next transaction (e.g. a typed character).

This change also fixed the 'moving over a note boundary' issue.

3. Passes 'paste' meta to the outer editor. `prosemirror-noting` uses this to identify transactions that are pastes within a note, and apply the note mark to them.

Noting without these changes:
![Kapture 2024-06-07 at 12 34 05](https://github.com/guardian/prosemirror-elements/assets/34686302/f2b1e554-4395-4216-a60a-005160464c72)

Noting with the change:
![Kapture 2024-06-07 at 12 37 45](https://github.com/guardian/prosemirror-elements/assets/34686302/336060d2-f3e1-442c-bebb-96006c943f20)


## How to test
Run the tests, I've added some.
You may want to test in Composer via `yalc` to test the noting behaviour specifically.