### PR TITLE
Fix selection error when backwards selections cover fields

### DIFF
--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -176,7 +176,10 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
         this.offset + this.getPos() + this.innerEditorView.state.doc.nodeSize;
 
       const incomingSelectionIsWithinThisField =
-        incomingAnchorPos > fieldStart && incomingHeadPos < fieldEnd;
+        incomingAnchorPos > fieldStart &&
+        incomingAnchorPos < fieldEnd &&
+        incomingHeadPos > fieldStart &&
+        incomingHeadPos < fieldEnd;
 
       // The inner editor's selection will be offset relative to the start of this field,
       // compared to the incoming selection

--- a/src/plugin/fieldViews/__tests__/TextFieldView.spec.ts
+++ b/src/plugin/fieldViews/__tests__/TextFieldView.spec.ts
@@ -2,7 +2,7 @@ import type { NodeSpec } from "prosemirror-model";
 import { Schema } from "prosemirror-model";
 import { schema } from "prosemirror-schema-basic";
 import type { Transaction } from "prosemirror-state";
-import { TextSelection } from "prosemirror-state";
+import { AllSelection, TextSelection } from "prosemirror-state";
 import { StepMap } from "prosemirror-transform";
 import { DecorationSet } from "prosemirror-view";
 import { createEditorWithElements } from "../../helpers/test";
@@ -139,7 +139,55 @@ describe("the TextFieldView, as an extension of the ProseMirrorFieldView", () =>
     expect(updatedSelection.to).toBe(0);
   });
 
-  it(`should update its internal doc when a node with different content is passed in, 
+  it("should not update its internal selection when a selection is passed in outside of its range - forward selection that covers the node", () => {
+    const {
+      view,
+      node,
+      decorations,
+      fieldView,
+      offset,
+      textFieldViewInnerEditor,
+    } = getEditorWithTextField();
+
+    const initialSelection = textFieldViewInnerEditor.state.selection;
+    // A selection that will be outside the innerEditor's range
+    const newSelection = new AllSelection(view.state.doc);
+    fieldView.onUpdate(node, offset, decorations, newSelection);
+    const updatedSelection = textFieldViewInnerEditor.state.selection;
+
+    expect(initialSelection.from).toBe(0);
+    expect(initialSelection.to).toBe(0);
+    expect(updatedSelection.from).toBe(0);
+    expect(updatedSelection.to).toBe(0);
+  });
+
+  it("should not update its internal selection when a selection is passed in outside of its range - backwards selection that covers the node", () => {
+    const {
+      view,
+      node,
+      decorations,
+      fieldView,
+      offset,
+      textFieldViewInnerEditor,
+    } = getEditorWithTextField();
+
+    const initialSelection = textFieldViewInnerEditor.state.selection;
+    // A selection that will be outside the innerEditor's range
+    const newSelection = TextSelection.create(
+      view.state.doc,
+      view.state.doc.content.size,
+      0
+    );
+    fieldView.onUpdate(node, offset, decorations, newSelection);
+    const updatedSelection = textFieldViewInnerEditor.state.selection;
+
+    expect(initialSelection.from).toBe(0);
+    expect(initialSelection.to).toBe(0);
+    expect(updatedSelection.from).toBe(0);
+    expect(updatedSelection.to).toBe(0);
+  });
+
+  it(`should update its internal doc when a node with different content is passed in,
       with different content starting at the first position of the inner editor`, () => {
     const {
       nodeName,
@@ -160,7 +208,7 @@ describe("the TextFieldView, as an extension of the ProseMirrorFieldView", () =>
     expect(updatedNode?.textContent).toBe("abcdef");
   });
 
-  it(`should update its internal doc when a node with different content is passed in, 
+  it(`should update its internal doc when a node with different content is passed in,
       with different content only in the final position of the inner editor`, () => {
     const {
       nodeName,
@@ -182,7 +230,7 @@ describe("the TextFieldView, as an extension of the ProseMirrorFieldView", () =>
     expect(updatedNode.textContent).toBe("abcde");
   });
 
-  it(`should update its internal doc when a node with different content is passed in, 
+  it(`should update its internal doc when a node with different content is passed in,
       with different content not at the beginning or end of the inner editor`, () => {
     const {
       nodeName,


### PR DESCRIPTION
## What does this change?

Fixes an error where backwards selections that extend beyond a field are passed into the field view, causing range errors.

The errors are largely harmless – they're a no-op on the state and do not halt the outer editor – but they're causing some noise in [our downstream CMS's error reporting.](https://the-guardian.sentry.io/issues/5384237869/?project=26737&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=0&utc=true)

There's a question as to whether fields should be aware of selections that cover them entirely. I don't think we've seen a use case yet, but we could map and clamp the selection values, rather than just ignoring, if we wanted that behaviour.

## How to test

- The new unit tests should pass. The commit history shows the failure, then the pass.
- Try adding a backwards selection across an element. You should not see red ink in the console:

![error-selection](https://github.com/guardian/prosemirror-elements/assets/7767575/e0b3832c-42ce-457b-906a-02ce391d207c)
