### PR TITLE
Add changeset for recent fix supporting storedMarks in text fields

### DIFF
--- a/.changeset/twelve-peaches-allow.md
+++ b/.changeset/twelve-peaches-allow.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-elements": patch
+---
+
+Pass stored marks to element fields from outer editor (fixing problem with guardian/prosemirror-noting)


### PR DESCRIPTION
## What does this change?

Add changeset for https://github.com/guardian/prosemirror-elements/pull/410 so that we can release it.