### PR TITLE
Pass storedMarks from inner editors to outer editor

### DIFF
--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -307,11 +307,12 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
       innerTr.storedMarks
     );
 
-    if (storedMarksHaveChanged){
+    if (storedMarksHaveChanged) {
       outerTr.setStoredMarks(innerTr.storedMarks);
     }
-    
-    const shouldUpdateOuter = innerTr.docChanged || selectionHasChanged || storedMarksHaveChanged;
+
+    const shouldUpdateOuter =
+      innerTr.docChanged || selectionHasChanged || storedMarksHaveChanged;
     if (shouldUpdateOuter) this.dispatchToOuterView(outerTr);
   }
 

--- a/src/plugin/fieldViews/ProseMirrorFieldView.ts
+++ b/src/plugin/fieldViews/ProseMirrorFieldView.ts
@@ -302,7 +302,16 @@ export abstract class ProseMirrorFieldView extends FieldView<string> {
       outerTr.setMeta("paste", true);
     }
 
-    const shouldUpdateOuter = innerTr.docChanged || selectionHasChanged;
+    const storedMarksHaveChanged = !isEqual(
+      this.outerView.state.storedMarks,
+      innerTr.storedMarks
+    );
+
+    if (storedMarksHaveChanged){
+      outerTr.setStoredMarks(innerTr.storedMarks);
+    }
+    
+    const shouldUpdateOuter = innerTr.docChanged || selectionHasChanged || storedMarksHaveChanged;
     if (shouldUpdateOuter) this.dispatchToOuterView(outerTr);
   }
 

--- a/src/plugin/fieldViews/__tests__/TextFieldView.spec.ts
+++ b/src/plugin/fieldViews/__tests__/TextFieldView.spec.ts
@@ -328,7 +328,6 @@ describe("the TextFieldView, as an extension of the ProseMirrorFieldView", () =>
     const exampleMark = testSchema.marks.strike.create();
     fieldView.onUpdate(node, offset, decorations, undefined, [exampleMark]);
     const markTr = textFieldViewInnerEditor.state.tr.addStoredMark(exampleMark);
-
     textFieldViewInnerEditor.dispatch(markTr);
     const updatedInnerMarks = textFieldViewInnerEditor.state.storedMarks;
     const updatedOuterMarks = view.state.storedMarks;

--- a/src/plugin/fieldViews/__tests__/TextFieldView.spec.ts
+++ b/src/plugin/fieldViews/__tests__/TextFieldView.spec.ts
@@ -316,24 +316,20 @@ describe("the TextFieldView, as an extension of the ProseMirrorFieldView", () =>
   it("should update the storedMarks in the outer editor state when the inner editor sets a storedMark", () => {
     const {
       view,
-      node,
-      decorations,
-      fieldView,
-      offset,
       textFieldViewInnerEditor,
     } = getEditorWithTextField();
     const initialInnerMarks = textFieldViewInnerEditor.state.storedMarks;
     const initialOuterMarks = view.state.storedMarks;
 
+    expect(initialInnerMarks).toBe(null);
+    expect(initialOuterMarks).toBe(null);
+
     const exampleMark = testSchema.marks.strike.create();
-    fieldView.onUpdate(node, offset, decorations, undefined, [exampleMark]);
     const markTr = textFieldViewInnerEditor.state.tr.addStoredMark(exampleMark);
     textFieldViewInnerEditor.dispatch(markTr);
     const updatedInnerMarks = textFieldViewInnerEditor.state.storedMarks;
     const updatedOuterMarks = view.state.storedMarks;
 
-    expect(initialInnerMarks).toBe(null);
-    expect(initialOuterMarks).toBe(null);
     expect(updatedInnerMarks).toStrictEqual([exampleMark]);
     expect(updatedOuterMarks).toStrictEqual([exampleMark]);
   });

--- a/src/plugin/fieldViews/__tests__/TextFieldView.spec.ts
+++ b/src/plugin/fieldViews/__tests__/TextFieldView.spec.ts
@@ -314,10 +314,7 @@ describe("the TextFieldView, as an extension of the ProseMirrorFieldView", () =>
   });
 
   it("should update the storedMarks in the outer editor state when the inner editor sets a storedMark", () => {
-    const {
-      view,
-      textFieldViewInnerEditor,
-    } = getEditorWithTextField();
+    const { view, textFieldViewInnerEditor } = getEditorWithTextField();
     const initialInnerMarks = textFieldViewInnerEditor.state.storedMarks;
     const initialOuterMarks = view.state.storedMarks;
 

--- a/src/plugin/fieldViews/__tests__/TextFieldView.spec.ts
+++ b/src/plugin/fieldViews/__tests__/TextFieldView.spec.ts
@@ -313,6 +313,32 @@ describe("the TextFieldView, as an extension of the ProseMirrorFieldView", () =>
     expect(removedMarks).toStrictEqual(null);
   });
 
+  it("should update the storedMarks in the outer editor state when the inner editor sets a storedMark", () => {
+    const {
+      view,
+      node,
+      decorations,
+      fieldView,
+      offset,
+      textFieldViewInnerEditor,
+    } = getEditorWithTextField();
+    const initialInnerMarks = textFieldViewInnerEditor.state.storedMarks;
+    const initialOuterMarks = view.state.storedMarks;
+
+    const exampleMark = testSchema.marks.strike.create();
+    fieldView.onUpdate(node, offset, decorations, undefined, [exampleMark]);
+    const markTr = textFieldViewInnerEditor.state.tr.addStoredMark(exampleMark);
+
+    textFieldViewInnerEditor.dispatch(markTr);
+    const updatedInnerMarks = textFieldViewInnerEditor.state.storedMarks;
+    const updatedOuterMarks = view.state.storedMarks;
+
+    expect(initialInnerMarks).toBe(null);
+    expect(initialOuterMarks).toBe(null);
+    expect(updatedInnerMarks).toStrictEqual([exampleMark]);
+    expect(updatedOuterMarks).toStrictEqual([exampleMark]);
+  });
+
   it("should preserve 'paste' meta in transactions dispatched to the outer editor", () => {
     const { view } = createEditorWithElements(
       [],


### PR DESCRIPTION
## What does this change?
This PR modifies the `ProsemirrorFieldView` so that it passes `storedMarks` to the outer editor (the editor that is using the `prosemirror-elements` plugin).

In `updateOuterEditor`, we already updated the outer editor's state with any [steps](https://prosemirror.net/docs/ref/#transform.Steps) (representing node changes) and selection changes from the inner editor's transaction so that the outer editor would reflect state changes in the inner editor.

However, we weren't updating the outer editor's `storedMarks` when an inner editor set them. This led to a bug with our `richText` field editor menu in certain contexts[^1], where a transaction from the outer editor would immediately nullify `storedMarks` set by the inner editor. This happened when clicking on mark buttons like `bold` or `italic` - when the user clicked on the text field after clicking the button, and started typing, the `storedMark` set by the button click had already been removed.

Until [a recent PR](https://github.com/guardian/prosemirror-elements/pull/409), inner editors didn't reflect `storedMarks` set by the outer editor, so this problem would probably not have occurred - the inner editor's `storedMarks` were never updated as a result of changes from the outer editor, so wouldn't be nullified.


[^1]: specifically, it occurred with a `richText` field in an element that also contained a `nestedElement` field. There is a currently a [workaround](https://github.com/guardian/prosemirror-elements/blob/be37a41991e41c2d3680b2a585eceae00fbf89ff/src/plugin/plugin.ts#L289) in this plugin that forces elements that contain `nestedElement` FieldViews to update on every transaction in the parent editor. Consequently, there are lots of transactions being processed for these elements, (and more than are necessary), contributing to problem in this PR, because the outer editor updates the inner editors more frequently than other elements, so overwrote the `storedMarks`. It would be good to revisit this workaround and figure out a way to update these field views more selectively.

## How to test
1. Run the tests - they don't pass without this PRs fix. You could comment out `outerTr.setStoredMarks(innerTr.storedMarks);` on line 311 of ProseMirrorFieldView to test this.
2. Publish this branch locally with `yarn yalc` and install it with `yalc add @guardian/prosemirror-elements` in the 'composer' directory of flexible-content, then: 
    1. Run Composer locally.  
    2. Activate the mini-profiles feature switch.
    3. Create a mini-profiles article
    4. Click the bold key in the empty 'bio' field editor's menu, move the mouse to the text field and click, then type. Is the text bold? (It should be)