### PR TITLE
Remove field update workaround for elements containing nested fields

### DIFF
--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -16,7 +16,6 @@ import {
   updateFieldViewsFromNode,
 } from "./field";
 import type { FieldView } from "./fieldViews/FieldView";
-import { anyDescendantFieldIsNestedElementField } from "./fieldViews/NestedElementFieldView";
 import { pluginKey } from "./helpers/constants";
 import type {
   GetElementDataFromNode,
@@ -286,14 +285,10 @@ const createNodeView = <
             })
           : currentFields;
 
-        // Only update our FieldViews if their content or decorations have changed, or the selection has changed.
-        // nestedElement FieldViews are always updated as a workaround for a bug
-        // with merging text elements in the zipRoot plugin after an intermediate element is
-        // deleted.
+        // Only update our FieldViews if their content or decorations have changed, or the selection or storedMarks have changed.
         if (
           fieldValuesChanged ||
           innerDecosChanged ||
-          anyDescendantFieldIsNestedElementField(newNode) ||
           selectionHasChanged ||
           storedMarksHaveChanged
         ) {


### PR DESCRIPTION
## What does this change?
This removes a [workaround](https://github.com/guardian/prosemirror-elements/pull/365) that meant elements containing `nestedFields` were updated any time a transaction occurred in the outer editor.

These elements should now only be updated when relevant information changes (their content, decorations, or the shared storedMarks).

The workaround was introduced due to a problem with the 'zipRoot' plugin in flexible-content, which adds empty text elements between other elements, the merges them when the intermediate elements are deleted. An example of that bug can be found in this PR: https://github.com/guardian/flexible-content/pull/4645

It looks like we have fixed the underlying issue since we introduced the workaround, as, testing locally with this branch - the `zipRoot` behaviour now works as expected in flexible-content.

We didn't get to the bottom of exactly what was causing that initial issue, so I don't have any suggestions as to tests that we could introduce. Since adding the workaround, was a change to how the inner and outer editor [in the `dispatchTransaction` method of `ProsemirrorFieldView` this PR](https://github.com/guardian/prosemirror-elements/pull/409) which fixed another obscure bug related to inner/outer editor interactions - perhaps that could be behind the fix but this is speculation.

## How to test
1. Release this branch locally using `yarn yalc`
2. Add it to the 'composer' directory of flexible-content.
3. Create a Key Takeaways format article
4. Create at least two items in the element and do the following for both of them in their main content fields: 
    1. Add a pullquote element, with text before and after
    2. Delete the pullquote
    3. Does everything work fine? Are the text elements both editable at their beginnings and ends? 

## How can we measure success?
`zipRoot` works find and can merge text elements when intermediate non-text elements are deleted.

## Fixed behaviour in action:
![Kapture 2024-07-16 at 14 15 34](https://github.com/user-attachments/assets/2968003e-b3a8-4146-bc98-43b7fe57aca6)
