### PR TITLE
Use redo shortcut that is consistent with Composer

### DIFF
--- a/.changeset/eleven-cats-teach.md
+++ b/.changeset/eleven-cats-teach.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-elements": patch
+---
+
+Use Composer's standard redo shortcut rather than Mod-y

--- a/src/plugin/helpers/keymap.ts
+++ b/src/plugin/helpers/keymap.ts
@@ -21,7 +21,7 @@ export const createHistoryCommands = (
     undoNoScroll(outerView.state, outerView.dispatch);
     return view?.dispatch(view.state.tr.scrollIntoView()) ?? false;
   },
-  "Mod-y": (_, __, view) => {
+  "Mod-shift-z": (_, __, view) => {
     redoNoScroll(outerView.state, outerView.dispatch);
     return view?.dispatch(view.state.tr.scrollIntoView()) ?? false;
   },


### PR DESCRIPTION
This PR updates the shortcut for redo used in text fields to use the same shortcut that we use in the main editor in Composer.

This will fix an issue with element text fields in Composer using <kbd>cmd Y</kbd> rather than <kbd>cmd shift Z</kbd>

## To test
1. Run the Prosemirror elements demo locally using yarn start in the root directory of this repo. 
2. Try adding an element, type some text in a text field other than the image caption.
3. Try to use <kbd>cmd Z</kbd> and <kbd>cmd shift Z</kbd> to undo and redo changes to the text. Do they work? (They should.)