### PR TITLE
Add wait to flaky test to see if it helps

### DIFF
--- a/cypress/tests/ImageElement.cy.ts
+++ b/cypress/tests/ImageElement.cy.ts
@@ -409,13 +409,16 @@ describe("ImageElement", () => {
         addImageElement({ code: "Code \n \n \n \n \n text" });
         getElementRichTextField("code")
           .invoke("css", "height")
-          .then((height) =>
-            getElementRichTextField("code")
-              .invoke("css", "max-height")
-              // Chained expressions here allow us to compare numerical value of string px properties
-              .then((maxHeight) => parseInt(maxHeight.toString()))
-              .should("be.above", parseInt(height.toString()))
-          );
+          .then((height) => {
+            cy.wait(200);
+            return (
+              getElementRichTextField("code")
+                .invoke("css", "max-height")
+                // Chained expressions here allow us to compare numerical value of string px properties
+                .then((maxHeight) => parseInt(maxHeight.toString()))
+                .should("be.above", parseInt(height.toString()))
+            );
+          });
       });
 
       it(`should visually extend no more than the number of lines specified by maxRows`, () => {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [ ] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [ ] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
