### PR TITLE
Remove flaky test, because it frequently causes problems in CI

### DIFF
--- a/cypress/tests/ImageElement.cy.ts
+++ b/cypress/tests/ImageElement.cy.ts
@@ -405,19 +405,6 @@ describe("ImageElement", () => {
         assertDocHtml(getSerialisedHtml({ codeValue: "Code \n text" }));
       });
 
-      it(`should not reach its max height when text has fewer rows than the number of lines specified by maxRows`, () => {
-        addImageElement({ code: "Code \n \n \n \n \n text" });
-        getElementRichTextField("code")
-          .invoke("css", "height")
-          .then((height) =>
-            getElementRichTextField("code")
-              .invoke("css", "max-height")
-              // Chained expressions here allow us to compare numerical value of string px properties
-              .then((maxHeight) => parseInt(maxHeight.toString()))
-              .should("be.above", parseInt(height.toString()))
-          );
-      });
-
       it(`should visually extend no more than the number of lines specified by maxRows`, () => {
         addImageElement({ code: "Code \n \n \n \n \n \n \n \n \n \n \n text" });
         getElementRichTextField("code")


### PR DESCRIPTION
## What does this change?
This PR removes a flaky test, because it frequently fails in CI.

The test checks that fields with `maxRows` set don't reach the max (implied) height unless there is enough text to fill the maximum number of rows specified.

I've spent some time attempting to fix the test, but ultimately I don't think the test is valuable enough to justify more time spent, so I've removed it instead. It's been difficult to debug because it never fails for me locally, only in CI. The fact the test (falsely) fails in CI regularly means manually re-running the build/CI process when PRs are merged which affects agility on other changes.

## How to test
This should be a no-op - all the other tests should pass in CI.