### PR TITLE
A few naming tweaks

### DIFF
--- a/src/plugin/helpers/__tests__/validation.spec.ts
+++ b/src/plugin/helpers/__tests__/validation.spec.ts
@@ -3,7 +3,7 @@ import {
   createValidator,
   maxLength,
   required,
-  validateWithFieldAndElementValidators,
+  createElementValidator,
 } from "../validation";
 
 describe("Validation helpers", () => {
@@ -91,7 +91,7 @@ describe("Validation helpers", () => {
         field2: [maxLength(5)],
       });
 
-      const validator = validateWithFieldAndElementValidators(
+      const validator = createElementValidator(
         fieldDescriptions,
         elementValidator
       );
@@ -118,7 +118,7 @@ describe("Validation helpers", () => {
         field2: createDefaultRichTextField([maxLength(5)]),
       };
 
-      const validator = validateWithFieldAndElementValidators(
+      const validator = createElementValidator(
         fieldDescriptions
       );
 
@@ -148,7 +148,7 @@ describe("Validation helpers", () => {
         field2: [maxLength(5)],
       });
 
-      const validator = validateWithFieldAndElementValidators(
+      const validator = createElementValidator(
         fieldDescriptions,
         elementValidator
       );

--- a/src/plugin/helpers/validation.ts
+++ b/src/plugin/helpers/validation.ts
@@ -27,9 +27,7 @@ export const createValidator = (
   return errors;
 };
 
-export const validateWithFieldAndElementValidators = <
-  FDesc extends FieldDescriptions<string>
->(
+export const createElementValidator = <FDesc extends FieldDescriptions<string>>(
   fieldDescriptions: FDesc,
   validateElement: Validator<FDesc> | undefined = undefined
 ): Validator<FDesc> => (fields: Partial<FieldNameToValueMap<FDesc>>) => {

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -261,7 +261,7 @@ const createNodeView = <
   let currentSelection = view.state.selection;
   let currentStoredMarks = view.state.storedMarks;
 
-  const getElementDataForUpdator = () =>
+  const getElementDataForUpdater = () =>
     getFieldValuesFromNode(
       currentNode,
       element.fieldDescriptions,
@@ -270,7 +270,7 @@ const createNodeView = <
       transformElementOut
     );
 
-  const update = element.createUpdator(
+  const updateElementView = element.createUpdateElementViewFn(
     dom,
     fields,
     (fields) => {
@@ -283,7 +283,7 @@ const createNodeView = <
     },
     initCommands,
     sendTelemetryEvent,
-    getElementDataForUpdator
+    getElementDataForUpdater
   );
 
   return {
@@ -354,7 +354,7 @@ const createNodeView = <
 
         // Only update our consumer if anything internal to the field has changed.
         if (fieldValuesChanged || commandsChanged || isSelectedChanged) {
-          update(newFields, newCommands, newIsSelected);
+          updateElementView(newFields, newCommands, newIsSelected);
         }
 
         currentNode = newNode;

--- a/src/plugin/types/Element.ts
+++ b/src/plugin/types/Element.ts
@@ -106,7 +106,7 @@ export type FieldNameToField<FDesc extends FieldDescriptions<string>> = {
 export type ElementSpec<FDesc extends FieldDescriptions<string>> = {
   fieldDescriptions: FDesc;
   validate: Validator<FDesc>;
-  createUpdator: (
+  createUpdateElementViewFn: (
     dom: HTMLElement,
     fields: FieldNameToField<FDesc>,
     updateState: (fields: FieldNameToValueMap<FDesc>) => void,

--- a/src/renderers/react/createReactElementSpec.tsx
+++ b/src/renderers/react/createReactElementSpec.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from "react";
 import React from "react";
 import { render, unmountComponentAtNode } from "react-dom";
 import { createElementSpec } from "../../plugin/elementSpec";
-import type { Renderer, Validator } from "../../plugin/elementSpec";
+import type { InitElementView, Validator } from "../../plugin/elementSpec";
 import type { Consumer } from "../../plugin/types/Consumer";
 import type {
   ExtractFieldValues,
@@ -32,7 +32,7 @@ export const createReactElementSpec = <
   onRemove,
   wrapperComponent = ElementWrapper,
 }: CreateReactElementSpecOptions<FDesc>) => {
-  const renderer: Renderer<FDesc> = (
+  const initElementView: InitElementView<FDesc> = (
     validate,
     dom,
     fields,
@@ -56,9 +56,10 @@ export const createReactElementSpec = <
       />,
       dom
     );
+
   const destroy = (dom: HTMLElement) => {
     unmountComponentAtNode(dom);
   };
 
-  return createElementSpec(fieldDescriptions, renderer, validate, destroy);
+  return createElementSpec(fieldDescriptions, initElementView, validate, destroy);
 };


### PR DESCRIPTION
## What does this change?

Tweaks a few names after pairing with @KaliedaRik reminded me that some of our naming conventions aren't very clear:

- `updator` -> `updater` (just a typo)
- `validateWithFieldAndElementValidators` -> `createElementValidator`
- `createUpdator `-> `createUpdateElementViewFn` (a typo, and hopefully this is more descriptive)
- `render` -> `initElementView`
- `type Renderer` -> `type InitElementView`

Hopefully introducing the idea of an `ElementView`, the part of the element definition responsible for creating and updating its UI, makes this part of the code clearer.

As part of this work, I've refactored the `createUpdater` function, which implements a pub/sub pattern for state updates. It's now a class, ElementStateUpdatePublisher, which I hope better illustrates both its stateful nature, and its job.

## How to test

This should be a no-op. Automated tests should pass.

## How can we measure success?

Marginally less confused developers when pairing on this codebase 😀 
