### PR TITLE
Do not render decorations unless necessary

### DIFF
--- a/.changeset/sixty-pumpkins-jam.md
+++ b/.changeset/sixty-pumpkins-jam.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-elements": patch
+---
+
+Do not render element decorations unless necessary, improving performance in large documents

--- a/cypress/helpers/editor.ts
+++ b/cypress/helpers/editor.ts
@@ -74,8 +74,7 @@ export const typeIntoElementField = (fieldName: string, content: string) =>
   getElementRichTextField(fieldName).focus().type(content);
 
 export const getArrayOfBlockElementTypes = () => {
-  // eslint-disable-next-line prefer-const -- it is reassigned.
-  let elementTypes = [] as string[];
+  const elementTypes = [] as string[];
   return new Cypress.Promise((resolve) => {
     cy.get(".Editor > .ProseMirror-menubar-wrapper > .ProseMirror")
       .children()

--- a/cypress/tests/ElementWrapper.cy.ts
+++ b/cypress/tests/ElementWrapper.cy.ts
@@ -62,7 +62,7 @@ describe("ElementWrapper", () => {
       expect(expectedBtnStates).to.deep.equal(btnStates);
     };
 
-    it("should move an element the top downwards", async () => {
+    it("should move an element from the top downwards", async () => {
       addImageElement();
       const { downBtn } = getButtons();
       downBtn.click();
@@ -70,6 +70,7 @@ describe("ElementWrapper", () => {
       const elementTypes = await getArrayOfBlockElementTypes();
 
       expect(elementTypes).to.deep.equal(["paragraph", "element", "paragraph"]);
+
       await assertButtonStates({
         topBtn: false,
         upBtn: false,
@@ -87,6 +88,7 @@ describe("ElementWrapper", () => {
       const elementTypes = await getArrayOfBlockElementTypes();
 
       expect(elementTypes).to.deep.equal(["paragraph", "element", "paragraph"]);
+
       await assertButtonStates({
         topBtn: false,
         upBtn: false,
@@ -121,6 +123,7 @@ describe("ElementWrapper", () => {
       const elementTypes = await getArrayOfBlockElementTypes();
 
       expect(elementTypes).to.deep.equal(["paragraph", "element", "paragraph"]);
+
       await assertButtonStates({
         topBtn: false,
         upBtn: false,
@@ -139,6 +142,7 @@ describe("ElementWrapper", () => {
       const elementTypes = await getArrayOfBlockElementTypes();
 
       expect(elementTypes).to.deep.equal(["element", "paragraph", "paragraph"]);
+
       await assertButtonStates({
         topBtn: true,
         upBtn: true,

--- a/cypress/tests/ElementWrapper.cy.ts
+++ b/cypress/tests/ElementWrapper.cy.ts
@@ -40,26 +40,32 @@ describe("ElementWrapper", () => {
       };
     };
 
-    const assertButtonStates = async (
+    const assertButtonStates = (
       expectedBtnStates: Record<keyof ReturnType<typeof getButtons>, boolean>
     ) => {
-      const btns = getButtons();
-      const btnStates: Record<string, boolean> = {};
+      // This is how the docs describe waiting for promises:
+      // https://docs.cypress.io/api/utilities/promise#Waiting-for-Promises
+      // Removing this causes the test to fail in headless mode at the
+      // time of writing
+      cy.wrap(null).then(() => {
+        const btns = getButtons();
+        const btnStates: Record<string, boolean> = {};
 
-      await Cypress.Promise.all(
-        Object.entries(btns).map(
-          ([name, btnEl]: [string, Cypress.Chainable<JQuery>]) => {
-            return new Cypress.Promise<void>((resolve) => {
-              btnEl.then((el) => {
-                btnStates[name] = el.prop("disabled") as boolean;
-                resolve();
+        return Cypress.Promise.all(
+          Object.entries(btns).map(
+            ([name, btnEl]: [string, Cypress.Chainable<JQuery>]) => {
+              return new Cypress.Promise<void>((resolve) => {
+                btnEl.then((el) => {
+                  btnStates[name] = el.prop("disabled") as boolean;
+                  resolve();
+                });
               });
-            });
-          }
-        )
-      );
-
-      expect(expectedBtnStates).to.deep.equal(btnStates);
+            }
+          )
+        ).then(() => {
+          expect(expectedBtnStates).to.deep.equal(btnStates);
+        });
+      });
     };
 
     it("should move an element from the top downwards", async () => {
@@ -71,7 +77,7 @@ describe("ElementWrapper", () => {
 
       expect(elementTypes).to.deep.equal(["paragraph", "element", "paragraph"]);
 
-      await assertButtonStates({
+      assertButtonStates({
         topBtn: false,
         upBtn: false,
         downBtn: false,
@@ -89,7 +95,7 @@ describe("ElementWrapper", () => {
 
       expect(elementTypes).to.deep.equal(["paragraph", "element", "paragraph"]);
 
-      await assertButtonStates({
+      assertButtonStates({
         topBtn: false,
         upBtn: false,
         downBtn: false,
@@ -106,7 +112,7 @@ describe("ElementWrapper", () => {
 
       expect(elementTypes).to.deep.equal(["paragraph", "paragraph", "element"]);
 
-      await assertButtonStates({
+      assertButtonStates({
         topBtn: false,
         upBtn: false,
         downBtn: true,
@@ -124,7 +130,7 @@ describe("ElementWrapper", () => {
 
       expect(elementTypes).to.deep.equal(["paragraph", "element", "paragraph"]);
 
-      await assertButtonStates({
+      assertButtonStates({
         topBtn: false,
         upBtn: false,
         downBtn: false,
@@ -143,7 +149,7 @@ describe("ElementWrapper", () => {
 
       expect(elementTypes).to.deep.equal(["element", "paragraph", "paragraph"]);
 
-      await assertButtonStates({
+      assertButtonStates({
         topBtn: true,
         upBtn: true,
         downBtn: false,

--- a/src/plugin/helpers/__tests__/prosemirror.spec.ts
+++ b/src/plugin/helpers/__tests__/prosemirror.spec.ts
@@ -15,9 +15,12 @@ describe("prosemirror utilities", () => {
   describe("getValidInsertionRange", () => {
     it("gets a valid insertion range", () => {
       const range = getValidElementInsertionRange(document, defaultPredicate);
+
+      // Remove one to account for the fact that the tag exists inside the node,
+      // and the position should be outside the node.
       expect(range).toEqual({
         from: document.tag.a - 1,
-        to: document.tag.d + d.nodeSize,
+        to: document.tag.d + d.nodeSize - 1,
       });
     });
 

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -128,14 +128,6 @@ const moveNode = (consumerPredicate: Predicate) => (
     tr.insert(insertPos, node.cut(0));
   }
 
-  // const mappedPos = tr.mapping.mapResult(pos).pos;
-  // merge the surrounding blocks if possible
-  // this is only useful if we have root `textElement` nodes like in composer
-  // as the time of this commit
-  // if (canJoin(tr.doc, mappedPos)) {
-  //   tr.join(mappedPos);
-  // }
-
   dispatch(tr);
   return true;
 };

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -297,10 +297,9 @@ const createUpdateDecorations = () => (state: EditorState): DecorationSet => {
   } = pluginState;
 
   state.doc.descendants((node, pos) => {
-    if (
-      node.attrs.addUpdateDecoration &&
-      (pos <= from || pos + node.nodeSize >= to)
-    ) {
+    const nodeIsOutsideValidInsertionRange =
+      pos <= from || pos + node.nodeSize >= to;
+    if (node.attrs.addUpdateDecoration && nodeIsOutsideValidInsertionRange) {
       decorations.push(
         Decoration.node(
           pos,

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -187,7 +187,7 @@ export const getValidElementInsertionRange = (
 
   const from = validNodes[0].pos;
   const toNode = validNodes[validNodes.length - 1];
-  const to = toNode.pos + toNode.node.nodeSize + 1;
+  const to = toNode.pos + toNode.node.nodeSize;
 
   return { from, to };
 };


### PR DESCRIPTION
## What does this change?

At the moment, we add a decoration for every parent element node each time the document changes, to force our element NodeViews to rerender.  Adding decorations is the approach recommended by the library author [(here)](https://discuss.prosemirror.net/t/force-nodes-of-specific-type-to-re-render/2480/10).

Normally, NodeViews would only rerender when their content, internal selection or decorations had changed — but we need to respond to all document changes, regardless of whether they touch the relevant node, to update the element movement UI, the buttons of which are disabled when movement is not possible.

However, forcing rerenders for each element on each change isn't ideal, because in documents with large numbers of elements, ProseMirror has to manage large numbers of decorations, and subsequently call `update` for large numbers of nodes. This has a measurable effect on performance (see below.)

This PR uses the recent work optimising command validity detection in #443 to optimise decoration rendering, using the valid ranges to render decorations just for elements that fall outside valid element insertion ranges.

Both adding and removing decorations force a re-render: elements that fall outside the valid insertion range receive a decoration and rerender, and elements moving inside that range lose their decoration, which also forces a rerender.

We recently had a large article, id 673f39b58f083ae557dd22af, which was slow to load and edit in production. The table below gives the profiler script time for 30 keystrokes with the article above loaded in the demo page, with the `enableExpensiveFeatures` flag disabled. Tested on Chrome 131.0.6778.205 on a 14-inch Macbook Pro, M1 Max, 2021:

|Iteration|fdb8213c6eec6f9ba068c22bf9ff9e1f76c42595|2f045d0aa1ca1be2643aeb043854ca504a6e84cc
--|--|--
1|399|463
2|400|495
3|403|482
Average|401|479

About 1.2x faster.

## How to test

- The automated tests should pass. Our integration tests for element movement should test the relevant cases. I've added an additional check for the button states, to make sure they're enabled/disabled as necessary.
- Have a play with the element movement buttons. Do they become enabled/disabled as expected?

## How can we measure success?

Improved performance in large documents with many elements.