### PR TITLE
Add option to insert content to a new node during creation

### DIFF
--- a/src/plugin/fieldViews/RepeaterFieldView.ts
+++ b/src/plugin/fieldViews/RepeaterFieldView.ts
@@ -93,9 +93,16 @@ export class RepeaterFieldView extends FieldView<unknown> {
 
   /**
    * Add a new child from this repeater at the given index.
+   * You can pre-populate this with
    * If list is empty, you will need to pass -1.
    */
-  public addChildAfter(index: number) {
+  public addChildAfter(
+    index: number,
+    {
+      textContent,
+      nodeContent,
+    }: { textContent?: string; nodeContent?: Node } = {}
+  ) {
     if (index < -1 || index > this.node.childCount - 1) {
       console.error(
         `Cannot add at index ${index}: index out of range. Minimum -1, Maximum ${
@@ -108,9 +115,14 @@ export class RepeaterFieldView extends FieldView<unknown> {
     const repeaterChildNodeName = getRepeaterChildNameFromParent(
       this.node.type.name
     );
+    const maybeNode =
+      nodeContent ??
+      (textContent ? this.outerView.state.schema.text(textContent) : undefined);
+
     const newNode = this.node.type.schema.nodes[
       repeaterChildNodeName
-    ].createAndFill({ [RepeaterFieldMapIDKey]: getRepeaterID() });
+    ].createAndFill({ [RepeaterFieldMapIDKey]: getRepeaterID() }, maybeNode);
+
     if (!newNode) {
       console.warn(
         `[prosemirror-elements]: Could not create new repeater node of type ${this.fieldName}: createAndFill did not return a node`
@@ -137,8 +149,10 @@ export class RepeaterFieldView extends FieldView<unknown> {
     this.outerView.dispatch(tr);
   }
 
-  public addChildAtEnd() {
-    this.addChildAfter(this.node.childCount - 1);
+  public addChildAtEnd(
+    maybeContent: { textContent?: string; nodeContent?: Node } = {}
+  ) {
+    this.addChildAfter(this.node.childCount - 1, maybeContent);
   }
 
   /**


### PR DESCRIPTION
## What does this change?

Provides a new optional argument to `RepeaterFieldView.addChildAfter()` and `RepeaterFieldView.addChildAtEnd()`.

The old behaviour is kept; that is, if you call `field.view.addChildAfter(index)` a blank field will still be inserted.  However, you can now call `field.view.addChildAfter(index, { nodeContent: someNode })` and have that field inserted with the given node.
As a convenience, you can also call `field.addChildAfter(index, {textContent: someTextString})` and have a node automatically created for you.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests. 

This repository follows the Editorial Tools accessibility guidelines: https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md
-->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
- [ ] [Interactive elements show a focus ring when focused by keyboard](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-the-focus-ring)
- [ ] [Semantic elements have been used where possible](https://github.com/guardian/accessibility/blob/main/editorial-tools-guidelines.md#appendix-semantic-html)
