### PR TITLE
fix: Preserve whitespace in rich text nodes on parse

### DIFF
--- a/demo/helpers.ts
+++ b/demo/helpers.ts
@@ -1,3 +1,4 @@
+import type { DOMParser, DOMSerializer, Node } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
 import { Plugin } from "prosemirror-state";
 import type { DemoSetMedia } from "../src/elements/demo-image/DemoImageElement";
@@ -217,4 +218,17 @@ export const getImageFromMediaPayload = (
     height: +mainAsset.fields.height,
     mediaId: mediaPayload.mediaId,
   };
+};
+
+export const docToHtml = (serializer: DOMSerializer, doc: Node) => {
+  const dom = serializer.serializeFragment(doc.content);
+  const e = document.createElement("div");
+  e.appendChild(dom);
+  return e.innerHTML;
+};
+
+export const htmlToDoc = (parser: DOMParser, html: string) => {
+  const dom = document.createElement("div");
+  dom.innerHTML = html;
+  return parser.parse(dom, { preserveWhitespace: true });
 };

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -32,11 +32,7 @@ import { richlinkElement } from "../src/elements/rich-link/RichlinkForm";
 import { createStandardElement } from "../src/elements/standard/StandardForm";
 import { tableElement } from "../src/elements/table/TableForm";
 import { createTweetElement } from "../src/elements/tweet/TweetForm";
-import {
-  createParsers,
-  docToHtml,
-  htmlToDoc,
-} from "../src/plugin/helpers/prosemirror";
+import { createParsers } from "../src/plugin/helpers/prosemirror";
 import {
   testDecorationPlugin,
   testInnerEditorEventPropagationPlugin,
@@ -45,7 +41,9 @@ import {
 import { CollabServer, EditorConnection } from "./collab/CollabServer";
 import { createSelectionCollabPlugin } from "./collab/SelectionPlugin";
 import {
+  docToHtml,
   getImageFromMediaPayload,
+  htmlToDoc,
   onCropCartoon,
   onCropImage,
   onDemoCropImage,

--- a/src/plugin/__tests__/element.spec.ts
+++ b/src/plugin/__tests__/element.spec.ts
@@ -949,6 +949,21 @@ describe("buildElementPlugin", () => {
           expect(node?.textContent).toBe("");
         });
 
+        it("should retain whitespace in rich text", () => {
+          const { getNodeFromElementData, view } = createEditorWithElements({
+            testElement,
+          });
+
+          const fieldText = "<p>   </p>";
+
+          const node = getNodeFromElementData(
+            { elementName: "testElement", values: { field1: fieldText } },
+            view.state.schema
+          );
+
+          expect(node?.textContent).toBe("   ");
+        });
+
         it("should retain HTML chars in plain text", () => {
           const { getNodeFromElementData, view } = createEditorWithElements({
             testElement,

--- a/src/plugin/__tests__/nodeSpec.spec.ts
+++ b/src/plugin/__tests__/nodeSpec.spec.ts
@@ -147,7 +147,7 @@ describe("nodeSpec generation", () => {
         expect(field1NodeSpec).toHaveProperty("content", "text*");
         expect(field1NodeSpec?.parseDOM?.[0]).toMatchObject({
           tag: "div",
-          preserveWhitespace: false,
+          preserveWhitespace: true,
         });
       });
     });

--- a/src/plugin/__tests__/nodeSpec.spec.ts
+++ b/src/plugin/__tests__/nodeSpec.spec.ts
@@ -147,7 +147,7 @@ describe("nodeSpec generation", () => {
         expect(field1NodeSpec).toHaveProperty("content", "text*");
         expect(field1NodeSpec?.parseDOM?.[0]).toMatchObject({
           tag: "div",
-          preserveWhitespace: true,
+          preserveWhitespace: "full",
         });
       });
     });

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -324,19 +324,6 @@ const createParsers = <S extends Schema>(schema: S) => {
   return { parser, serializer };
 };
 
-const docToHtml = (serializer: DOMSerializer, doc: Node) => {
-  const dom = serializer.serializeFragment(doc.content);
-  const e = document.createElement("div");
-  e.appendChild(dom);
-  return e.innerHTML;
-};
-
-const htmlToDoc = (parser: DOMParser, html: string) => {
-  const dom = document.createElement("div");
-  dom.innerHTML = html;
-  return parser.parse(dom, { preserveWhitespace: "full" });
-};
-
 // Select all text within a node, as opposed to AllSelection
 const selectAllText = (
   state: EditorState,
@@ -386,7 +373,5 @@ export {
   defaultPredicate,
   createUpdateDecorations,
   createParsers,
-  docToHtml,
-  htmlToDoc,
   selectAllText,
 };

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -334,7 +334,7 @@ const docToHtml = (serializer: DOMSerializer, doc: Node) => {
 const htmlToDoc = (parser: DOMParser, html: string) => {
   const dom = document.createElement("div");
   dom.innerHTML = html;
-  return parser.parse(dom);
+  return parser.parse(dom, { preserveWhitespace: true });
 };
 
 // Select all text within a node, as opposed to AllSelection

--- a/src/plugin/helpers/prosemirror.ts
+++ b/src/plugin/helpers/prosemirror.ts
@@ -334,7 +334,7 @@ const docToHtml = (serializer: DOMSerializer, doc: Node) => {
 const htmlToDoc = (parser: DOMParser, html: string) => {
   const dom = document.createElement("div");
   dom.innerHTML = html;
-  return parser.parse(dom, { preserveWhitespace: true });
+  return parser.parse(dom, { preserveWhitespace: "full" });
 };
 
 // Select all text within a node, as opposed to AllSelection

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -520,7 +520,7 @@ const createContentNodeFromRichText = <S extends Schema>(
   element.innerHTML = fieldValue;
   return parser.parse(element, {
     topNode,
-    preserveWhitespace: false,
+    preserveWhitespace: true,
   });
 };
 

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -112,7 +112,7 @@ export const getNodeSpecForField = (
             {
               tag: "div",
               getAttrs: createGetAttrsForTextNode(nodeName),
-              preserveWhitespace: field.isCode ? "full" : true,
+              preserveWhitespace: "full",
             },
           ],
           code: field.isCode,
@@ -518,9 +518,10 @@ const createContentNodeFromRichText = <S extends Schema>(
   const parser = DOMParser.fromSchema(schema);
   const element = document.createElement("div");
   element.innerHTML = fieldValue;
+
   return parser.parse(element, {
     topNode,
-    preserveWhitespace: true,
+    preserveWhitespace: "full",
   });
 };
 

--- a/src/plugin/nodeSpec.ts
+++ b/src/plugin/nodeSpec.ts
@@ -112,7 +112,7 @@ export const getNodeSpecForField = (
             {
               tag: "div",
               getAttrs: createGetAttrsForTextNode(nodeName),
-              preserveWhitespace: field.isCode ? "full" : false,
+              preserveWhitespace: field.isCode ? "full" : true,
             },
           ],
           code: field.isCode,


### PR DESCRIPTION
_co-authored-with: @SHession_

## What does this change?

At the moment, we're dropping whitespace when we parse elements per HTML's rules ([handy MDN docs.](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace)) This puts us in a situation where we can persist whitespace into elements fields, but cannot remove it — because it's not present to remove.

This PR passes `preserveWhitespace: true` to the ProseMirror methods responsible for parsing element data into ProseMirror nodes, which does what it says on the tin. It was previously set to `false` as what I suspect was an unintended default in the PR that changed it (https://github.com/guardian/prosemirror-elements/pull/129).

## How to test

- The new unit test should pass.
- Open a document in the sandbox, add an element, and add whitespace. Refresh the page. The whitespace should remain:

![pm-after](https://github.com/user-attachments/assets/f78967b9-be6c-42df-a576-cf12a9594022)