### PR TITLE
nested elements can supply own plugins

### DIFF
--- a/.changeset/perky-coins-kiss.md
+++ b/.changeset/perky-coins-kiss.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-elements": minor
+---
+
+NestedElementFieldView constructor accepts optional list of plugins

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export type { FieldValidator, ValidationError } from "./plugin/elementSpec";
+export type { ExternalElementData } from "./plugin/helpers/element";
 export type { FieldNameToValueMap } from "./plugin/helpers/fieldView";
 export type {
   FieldDescriptions,
@@ -10,21 +11,28 @@ export type { CustomField, Field } from "./plugin/types/Element";
 export type { Options } from "./plugin/fieldViews/DropdownFieldView";
 export type { FieldView } from "./plugin/fieldViews/FieldView";
 export { createTextField } from "./plugin/fieldViews/TextFieldView";
-export { createRichTextField } from "./plugin/fieldViews/RichTextFieldView";
+export type { TextFieldView } from "./plugin/fieldViews/TextFieldView";
+export {
+  createRichTextField,
+  createFlatRichTextField,
+} from "./plugin/fieldViews/RichTextFieldView";
+export type { RichTextFieldView } from "./plugin/fieldViews/RichTextFieldView";
 export {
   createNestedElementField,
   isNestedElementField,
 } from "./plugin/fieldViews/NestedElementFieldView";
+export type { NestedElementFieldView } from "./plugin/fieldViews/NestedElementFieldView";
 export { createCheckBoxField } from "./plugin/fieldViews/CheckboxFieldView";
+export type { CheckboxFieldView } from "./plugin/fieldViews/CheckboxFieldView";
 export {
   createCustomDropdownField,
   createCustomField,
 } from "./plugin/fieldViews/CustomFieldView";
-export { createFlatRichTextField } from "./plugin/fieldViews/RichTextFieldView";
 export {
   createRepeaterField,
   isRepeaterField,
 } from "./plugin/fieldViews/RepeaterFieldView";
+export type { RepeaterFieldView } from "./plugin/fieldViews/RepeaterFieldView";
 
 export {
   htmlMaxLength,
@@ -35,7 +43,7 @@ export {
 } from "./plugin/helpers/validation";
 export { undefinedDropdownValue } from "./plugin/helpers/constants";
 
-export { createStore } from "./renderers/react/store";
+export { createStore, Store } from "./renderers/react/store";
 export { TelemetryContext } from "./renderers/react/TelemetryContext";
 export { useCustomFieldState } from "./renderers/react/useCustomFieldViewState";
 export { createReactElementSpec } from "./renderers/react/createReactElementSpec";

--- a/src/plugin/fieldViews/NestedElementFieldView.ts
+++ b/src/plugin/fieldViews/NestedElementFieldView.ts
@@ -1,5 +1,5 @@
 import type { AttributeSpec, Node } from "prosemirror-model";
-import type { PluginKey } from "prosemirror-state";
+import type { Plugin, PluginKey } from "prosemirror-state";
 import type {
   DecorationSource,
   EditorProps,
@@ -23,6 +23,7 @@ type NestedElementOptions = {
   isResizeable?: boolean;
   allowedPlugins?: PluginKey[];
   minRows?: number;
+  ownPlugins?: Plugin[];
 };
 
 export interface NestedElementFieldDescription
@@ -109,8 +110,10 @@ export class NestedElementFieldView extends ProseMirrorFieldView {
     // The initial decorations for the FieldView.
     decorations: DecorationSource,
     { placeholder, isResizeable, minRows }: NestedElementFieldDescription,
-    // Specify plugins of which the field should have its own copy
-    allowedPlugins: PluginKey[] = []
+    // Specify plugins of the outer editor of which the field should have its own copy
+    allowedPlugins: PluginKey[] = [],
+    // Specify plugins which the field should have (in addition to the allowedPlugins)
+    ownPlugins: Plugin[] = []
   ) {
     super(
       node,
@@ -118,12 +121,15 @@ export class NestedElementFieldView extends ProseMirrorFieldView {
       getPos,
       offset,
       decorations,
-      outerView.state.plugins.filter(
-        (plugin) =>
-          !plugin.spec.key ||
-          pluginKey === plugin.spec.key ||
-          allowedPlugins.includes(plugin.spec.key)
-      ),
+      [
+        ...outerView.state.plugins.filter(
+          (plugin) =>
+            !plugin.spec.key ||
+            pluginKey === plugin.spec.key ||
+            allowedPlugins.includes(plugin.spec.key)
+        ),
+        ...ownPlugins,
+      ],
       placeholder,
       isResizeable
     );

--- a/src/plugin/fieldViews/NestedElementFieldView.ts
+++ b/src/plugin/fieldViews/NestedElementFieldView.ts
@@ -22,8 +22,8 @@ type NestedElementOptions = {
   placeholder?: PlaceholderOption;
   isResizeable?: boolean;
   allowedPlugins?: PluginKey[];
-  minRows?: number;
   ownPlugins?: Plugin[];
+  minRows?: number;
 };
 
 export interface NestedElementFieldDescription
@@ -37,6 +37,7 @@ export interface NestedElementFieldDescription
   // include its key in the output data created by `getElementDataFromNode`.
   absentOnEmpty?: boolean;
   allowedPlugins?: PluginKey[];
+  ownPlugins?: Plugin[];
   minRows?: number;
 }
 
@@ -66,6 +67,7 @@ export const createNestedElementField = ({
   placeholder,
   isResizeable,
   allowedPlugins = [],
+  ownPlugins = [],
   minRows = 4,
 }: NestedElementOptions): NestedElementFieldDescription => {
   return {
@@ -78,6 +80,7 @@ export const createNestedElementField = ({
     placeholder,
     isResizeable,
     allowedPlugins,
+    ownPlugins,
     minRows,
   };
 };

--- a/src/plugin/helpers/fieldView.ts
+++ b/src/plugin/helpers/fieldView.ts
@@ -111,7 +111,8 @@ export const getElementFieldViewFromType = (
         offset,
         innerDecos,
         field,
-        field.allowedPlugins
+        field.allowedPlugins,
+        field.ownPlugins
       );
     case "richText":
       return new RichTextFieldView(


### PR DESCRIPTION
## What does this change?

Updated the constructor for the `NestedElementFieldView` to take an optional `Plugin` array. This will allow the Field to have plugins in addition to those inherited from the outer editor (the view which the`NestedElementFieldView` is in).

The main motivation for this change is to unblock migration work on Composer - when defining elementsSpecs in our library, we do not have access to the `pluginKey` of the plugins defined in Composer so cannot include them in `allowedPlugins`, but there may be other application where a `NestedElementFieldView` may need plugins with the rest of the document may not need.

Also exports some extra types  currently imported in the Composer Source code from the dist folder.

## How to test

TBC

## How can we measure success?

Provides a more flexible constructor `NestedElementFieldView` 


## Have we considered potential risks?

This should be safe as only providing an extra option.