### PR TITLE
Fix exports for projects consuming this package as an ES module

### DIFF
--- a/.changeset/ninety-monkeys-fly.md
+++ b/.changeset/ninety-monkeys-fly.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-elements": patch
+---
+
+Fixes exports for projects consuming this package as an ES module

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "repository": {
     "url": "git+https://github.com/guardian/prosemirror-elements.git"
   },
-  "module": "dist/esm/index.js",
+  "exports": {
+		"require": "./dist/cjs/index.js",
+		"import": "./dist/esm/index.js"
+	},
   "types": "dist/declaration/index.d.ts",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Adjusts exports in package.json. The `module` property specified here does not seem to be part of the official Node.js spec. I've noticed that when using vitest, this has led to custom elements not being correctly set up and tests failing—possibly because it tries to import the CommonJS paths provided as if they were ESM. It is possible that in the future, if our projects use a different bundling system, this could cause similar errors in the actual apps at runtime.

The `main` property is left as is, in case this package is consumed by tooling that doesn't use the `exports` property.

See "conditional exports" in https://nodejs.org/docs/latest/api/packages.html for more info.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

I have tested this locally by manually editing `node_modules/@guardian/prosemirror-elements/package.json` with matching changes in a downstream project (Composer). We could test further by doing a "prerelease" but I think this is low risk enough that we could merge, and then revert the changes if problems are found.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
ES module compatibility!

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
There's an unlikely, but non-zero possibility that this will interact strangely with bundlers used in downstream projects.
