### PR TITLE
Remove unused and broken ESM support

### DIFF
--- a/.changeset/shy-icons-relax.md
+++ b/.changeset/shy-icons-relax.md
@@ -1,0 +1,5 @@
+---
+"@guardian/prosemirror-elements": patch
+---
+
+Remove ESM support (that did not actually work)

--- a/package.json
+++ b/package.json
@@ -1,14 +1,9 @@
 {
   "name": "@guardian/prosemirror-elements",
   "version": "9.10.2",
-  "type": "module",
   "main": "dist/cjs/index.js",
   "repository": {
     "url": "git+https://github.com/guardian/prosemirror-elements.git"
-  },
-  "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
   },
   "types": "dist/declaration/index.d.ts",
   "publishConfig": {
@@ -17,7 +12,7 @@
   "license": "MIT",
   "scripts": {
     "start": "webpack serve",
-    "build": "yarn tsc --build ./tsconfig-cjs.json && yarn tsc --build ./tsconfig-esm.json",
+    "build": "yarn tsc --build ./tsconfig-cjs.json",
     "test:integration": "cypress open --e2e --browser chrome",
     "test:unit": "jest --runInBand",
     "ci:build": "yarn lint && yarn test:unit && yarn build",

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -5,16 +5,12 @@
     "target": "es6",
     "lib": ["dom", "ESNext"],
     "types": ["jest"],
-    "sourceMap": true,
-    "declaration": true,
     "strict": true,
     "jsx": "react-jsx",
     "jsxImportSource": "@emotion/react",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "rootDir": "./src",
-    "outDir": "dist/esm",
-    "declarationDir": "dist/declaration"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "cypress", "cypress.config.ts"]

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,8 +1,11 @@
 {
-  "extends": "./tsconfig-esm.json",
+  "extends": "./tsconfig-base.json",
   "compilerOptions": {
     "module": "commonjs",
     "target": "es5",
-    "outDir": "./dist/cjs"
+    "outDir": "./dist/cjs",
+    "sourceMap": true,
+    "declaration": true,
+    "declarationDir": "dist/declaration"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig-esm.json",
+  "extends": "./tsconfig-base.json",
   "compilerOptions": {
     "rootDir": ".",
   },


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Follow up to #481, which did not have the benefits I was hoping for! It seems that the ESM build is not valid, because it does not include full file paths (i.e. ending with `.js`) in imports. As the ESM build is not currently used, and is also broken, I think the simplest thing to do is to remove it and also the `"type": "module"` from the package.json (which I think I must have done at some point when previously debugging vitest-related problems).

We could revisit ESM support later if we think the tooling around it is mature enough to justify this. I think it would also make sense to move completely from CJS to ESM if this were the case—as there is only one downstream project using this I don't think there is much justification for supporting both. 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

I think this might be difficult to test locally. `npm link` would get tricky quickly due to different versions of Node being involved, and the docs for changesets warns that using it for [prereleases is "very complicated"](https://github.com/changesets/changesets/blob/main/docs/prereleases.md). So my suggestion is that we merge and release this, test with Composer, and then fix forward if issues are found.

edit—Alternatives I have tried are `npm install --no-save ../../prosemirror-elements`, `npm link ../../prosemirror-elements` and `npm install ../../prosemirror-elements` (the latter creates a `file:` reference in the `package.json`) and all of these seem to have issues with Jest or Webpack.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Shipping this package in a state less likely to confuse people

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

There's an unlikely, but non-zero possibility that this will break something in Composer.